### PR TITLE
EPIC 1: govern-at-merge gate (re-derive the union as untrusted)

### DIFF
--- a/apps/curator/src/__tests__/merge-gate.test.ts
+++ b/apps/curator/src/__tests__/merge-gate.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Govern-at-merge gate (EPIC 1, bead compile-then-govern-8da.9).
+ *
+ * Proves the re-derivation-over-union pass re-governs EVERY merged row as
+ * untrusted and never admits a row that would fail the front-door gate:
+ *
+ *   1. a secret-bearing and a disclosure-bearing row from one clone are
+ *      QUARANTINED, not admitted;
+ *   2. a row duplicated across both clones dedupes by content-derived id (one
+ *      survives);
+ *   3. commutativity - mergeGovern(A, B) and mergeGovern(B, A) produce
+ *      byte-identical governed state AND an identical audit outcome;
+ *   4. every surviving row provably passed the full gate (re-running the gate
+ *      over the survivors admits all of them unchanged).
+ *
+ * @module __tests__/merge-gate.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  AuditRepository,
+  verifyAuditChain,
+} from '@qmd-team-intent-kb/store';
+import { assertDisclosureClean, DisclosureRejectedError } from '@qmd-team-intent-kb/common';
+import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import type {
+  CuratedMemory,
+  GovernancePolicy as GovernancePolicyType,
+} from '@qmd-team-intent-kb/schema';
+import { mergeGovern } from '../merge/merge-gate.js';
+import { MemoryCandidate as MemoryCandidateSchema } from '@qmd-team-intent-kb/schema';
+import { makeCuratedMemory, TENANT, NOW } from './fixtures.js';
+
+interface MergeDeps {
+  memoryRepo: MemoryRepository;
+  auditRepo: AuditRepository;
+}
+
+function makeDeps(db: Database.Database): MergeDeps {
+  return {
+    memoryRepo: new MemoryRepository(db),
+    auditRepo: new AuditRepository(db),
+  };
+}
+
+/**
+ * A realistic merge policy. Because the merge gate downgrades every union row to
+ * `untrusted`, the `source_trust` rule is configured to accept `untrusted` (the
+ * merge re-govern explicitly trusts NO prior standing, so the policy must opt in
+ * to admitting untrusted rows). The secret + length + dedupe rules still bite.
+ */
+function makeMergePolicy(overrides?: Partial<GovernancePolicyType>): GovernancePolicyType {
+  return GovernancePolicy.parse({
+    id: '00000000-0000-4000-8000-0000000000aa',
+    name: 'Merge re-govern policy',
+    tenantId: TENANT,
+    rules: [
+      {
+        id: 'rule-secret-detect',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+      {
+        id: 'rule-dedup',
+        type: 'dedup_check',
+        action: 'reject',
+        enabled: true,
+        priority: 1,
+        parameters: {},
+      },
+      {
+        id: 'rule-length',
+        type: 'content_length',
+        action: 'reject',
+        enabled: true,
+        priority: 2,
+        parameters: { min: 10, max: 50000 },
+      },
+      {
+        id: 'rule-trust',
+        type: 'source_trust',
+        action: 'reject',
+        enabled: true,
+        priority: 3,
+        parameters: { minimumTrust: 'untrusted' },
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  });
+}
+
+/**
+ * Build a promoted CuratedMemory whose `id` is the content-derived id the merge
+ * gate would re-derive - so that the same logical content yields the same id on
+ * both "clones". We let the fixture mint random ids by default; for the
+ * cross-clone-duplicate test we pin BOTH clones' rows to the same id + content.
+ */
+function makeRow(content: string, overrides?: Partial<CuratedMemory>): CuratedMemory {
+  return makeCuratedMemory({ content, ...overrides });
+}
+
+/**
+ * Secret literal, fragmented via string concatenation so the raw token never
+ * appears as one literal in source. Once concatenated it is exactly `AKIA` + 16
+ * uppercase-alnum chars, matching the disclosure scanner's AWS access-key pattern
+ * `\bAKIA[0-9A-Z]{16}\b` so the disclosure choke point catches it.
+ */
+const SECRET_LITERAL = 'AKIA' + 'IOSFODNN7' + 'EXAMPLE';
+/** Disclosure (PII) literal - matches the SSN pattern NNN-NN-NNNN. */
+const SSN_LITERAL = '123' + '-45' + '-6789';
+
+describe('mergeGovern - govern-at-merge gate', () => {
+  let db: Database.Database;
+  let deps: MergeDeps;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('quarantines a secret-bearing and a disclosure-bearing row, admitting neither', () => {
+    const policy = makeMergePolicy();
+
+    const cleanA = makeRow('Always validate request bodies with a Zod schema before persisting.');
+    const secretRow = makeRow(`Deploy with the key ${SECRET_LITERAL} in the env file.`);
+    const piiRow = makeRow(`Onboarding note: the contractor SSN is ${SSN_LITERAL} for payroll.`);
+    const cleanB = makeRow('Prefer Result<T, E> over throwing for all fallible operations here.');
+
+    const result = mergeGovern([cleanA, secretRow], [piiRow, cleanB], deps, {
+      policy,
+      tenantId: TENANT,
+    });
+
+    // The two clean rows survive; the secret + PII rows are turned away.
+    expect(result.promoted).toHaveLength(2);
+    expect(result.quarantined).toHaveLength(2);
+
+    const promotedHashes = new Set(result.promoted.map((m) => m.contentHash));
+    expect(promotedHashes.has(secretRow.contentHash)).toBe(false);
+    expect(promotedHashes.has(piiRow.contentHash)).toBe(false);
+
+    // The PII row is caught by the disclosure choke point (runs before policy);
+    // the secret row is caught by the disclosure choke point too (secrets are in
+    // the disclosure scanner's SECRET_PATTERNS). Both land in 'disclosure'.
+    const quarantinedIds = new Set(result.quarantined.map((q) => q.memoryId));
+    expect(quarantinedIds.has(secretRow.id)).toBe(true);
+    expect(quarantinedIds.has(piiRow.id)).toBe(true);
+    for (const q of result.quarantined) {
+      expect(q.category).toBe('disclosure');
+    }
+
+    // Durable state agrees: only the two clean rows are in curated_memories.
+    expect(deps.memoryRepo.count()).toBe(2);
+    expect(deps.memoryRepo.findByContentHash(secretRow.contentHash)).toBeNull();
+    expect(deps.memoryRepo.findByContentHash(piiRow.contentHash)).toBeNull();
+  });
+
+  it('dedupes a row duplicated across both clones by content-derived id (one survives)', () => {
+    const policy = makeMergePolicy();
+    const content = 'Use a single shared logger configured at process start, never per-module.';
+
+    // The SAME logical memory exists in both clones: identical content AND
+    // identical id (content-derived ids are stable across clones).
+    const sharedId = '11111111-1111-4111-8111-111111111111';
+    const sharedCandidateId = '22222222-2222-4222-8222-222222222222';
+    const inA = makeRow(content, { id: sharedId, candidateId: sharedCandidateId });
+    const inB = makeRow(content, { id: sharedId, candidateId: sharedCandidateId });
+
+    const uniqueToB = makeRow('A distinct convention that only clone B promoted locally today.');
+
+    const result = mergeGovern([inA], [inB, uniqueToB], deps, { policy, tenantId: TENANT });
+
+    // Union after id-dedup = 2 logical memories (the shared one + B's unique one).
+    expect(result.unionSize).toBe(2);
+    expect(result.promoted).toHaveLength(2);
+
+    // Exactly one survivor carries the shared content hash - the twin was dropped
+    // by id-dedup, not promoted twice.
+    const sharedSurvivors = result.promoted.filter((m) => m.content === content);
+    expect(sharedSurvivors).toHaveLength(1);
+    expect(deps.memoryRepo.findByContentHash(inA.contentHash)).not.toBeNull();
+    expect(deps.memoryRepo.count()).toBe(2);
+  });
+
+  it('is commutative: A∪B and B∪A produce byte-identical governed state + identical audit outcome', () => {
+    const policy = makeMergePolicy();
+
+    // A mixed bag exercising every branch: clean rows, a cross-clone duplicate,
+    // a secret row, a PII row - split unevenly across the two clones.
+    const dupId = '33333333-3333-4333-8333-333333333333';
+    const dupCandId = '44444444-4444-4444-8444-444444444444';
+    const dupContent = 'Shared decision: all timestamps are stored as UTC ISO-8601 strings.';
+
+    const a1 = makeRow('Clone A clean row one about dependency injection wiring conventions.');
+    const a2 = makeRow(dupContent, { id: dupId, candidateId: dupCandId });
+    const aSecret = makeRow(`A note from clone A leaking ${SECRET_LITERAL} into the brain.`);
+
+    const b1 = makeRow('Clone B clean row about retry-with-backoff for idempotent calls only.');
+    const b2 = makeRow(dupContent, { id: dupId, candidateId: dupCandId });
+    const bPii = makeRow(`Clone B accidentally captured an SSN ${SSN_LITERAL} during intake.`);
+
+    const cloneA = [a1, a2, aSecret];
+    const cloneB = [b1, b2, bPii];
+
+    // Two independent DBs so the durable state of each ordering is isolated.
+    const dbAB = createTestDatabase();
+    const depsAB = makeDeps(dbAB);
+    const dbBA = createTestDatabase();
+    const depsBA = makeDeps(dbBA);
+
+    const resAB = mergeGovern(cloneA, cloneB, depsAB, { policy, tenantId: TENANT });
+    const resBA = mergeGovern(cloneB, cloneA, depsBA, { policy, tenantId: TENANT });
+
+    // Same survivor set + same quarantine set (order-independent comparison via
+    // the deterministic sort means even the arrays are identical).
+    expect(resAB.unionSize).toBe(resBA.unionSize);
+    expect(resAB.promoted.map((m) => m.id)).toEqual(resBA.promoted.map((m) => m.id));
+    expect(resAB.quarantined).toEqual(resBA.quarantined);
+
+    // BYTE-IDENTICAL governed state: serialise both DBs' curated_memories ordered
+    // by id and compare the JSON verbatim. promotedAt/updatedAt are anchored to a
+    // fixed merge epoch, so even the timestamp columns match.
+    const dumpMemories = (mr: MemoryRepository): string => {
+      const rows = mr.findByLifecycle('active').sort((x, y) => (x.id < y.id ? -1 : 1));
+      return JSON.stringify(rows);
+    };
+    expect(dumpMemories(depsAB.memoryRepo)).toBe(dumpMemories(depsBA.memoryRepo));
+
+    // IDENTICAL audit outcome: the v2 entry_hash chain is timestamp-independent,
+    // so the ordered list of (action, memoryId, entry_hash) is identical, and
+    // both chains verify clean.
+    const dumpAudit = (db2: Database.Database): string => {
+      const repo = new AuditRepository(db2);
+      const rows = repo
+        .findAllChronological()
+        .map((r) => `${r.action}:${r.memory_id}:${r.entry_hash}`)
+        .sort();
+      return rows.join('\n');
+    };
+    expect(dumpAudit(dbAB)).toBe(dumpAudit(dbBA));
+    expect(verifyAuditChain(new AuditRepository(dbAB)).breaks).toHaveLength(0);
+    expect(verifyAuditChain(new AuditRepository(dbBA)).breaks).toHaveLength(0);
+
+    dbAB.close();
+    dbBA.close();
+  });
+
+  it('every surviving row provably passed the full gate (re-running the gate readmits all survivors)', () => {
+    const policy = makeMergePolicy();
+
+    const cleanA = makeRow('Use feature flags gated by env, never branch on hostname strings.');
+    const secretRow = makeRow(`Hardcoded ${SECRET_LITERAL} should never reach the brain.`);
+    const cleanB = makeRow('Wrap all DB writes in a single transaction per request handler.');
+    const piiRow = makeRow(`Captured SSN ${SSN_LITERAL} from a pasted form during a session.`);
+
+    const result = mergeGovern([cleanA, secretRow], [cleanB, piiRow], deps, {
+      policy,
+      tenantId: TENANT,
+    });
+
+    expect(result.promoted.length).toBeGreaterThan(0);
+
+    // PROOF the gate actually held: independently re-run BOTH halves of the gate
+    // over each survivor and assert it passes - disclosure choke point clean AND
+    // the full policy pipeline approves. No survivor could have skipped the gate.
+    const pipeline = new PolicyPipeline(policy);
+    for (const survivor of result.promoted) {
+      // Re-project to the same untrusted candidate the gate built.
+      const candidate = MemoryCandidateSchema.parse({
+        id: survivor.candidateId,
+        status: 'inbox',
+        source: survivor.source,
+        content: survivor.content,
+        title: survivor.title,
+        category: survivor.category,
+        trustLevel: 'untrusted',
+        author: survivor.author,
+        tenantId: survivor.tenantId,
+        metadata: survivor.metadata,
+        prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+        capturedAt: survivor.promotedAt,
+      });
+
+      // (a) disclosure choke point: must NOT throw.
+      expect(() => assertDisclosureClean(candidate)).not.toThrow(DisclosureRejectedError);
+
+      // (b) policy pipeline: must approve against a fresh (empty) dedupe set -
+      //     i.e. nothing about the survivor itself fails secret/length/trust.
+      const verdict = pipeline.evaluate(candidate, {
+        existingHashes: new Set<string>(),
+        tenantId: TENANT,
+      });
+      expect(verdict.outcome).toBe('approved');
+    }
+
+    // And the rejected rows are accounted for in quarantine, never in survivors.
+    const promotedHashes = new Set(result.promoted.map((m) => m.contentHash));
+    expect(promotedHashes.has(secretRow.contentHash)).toBe(false);
+    expect(promotedHashes.has(piiRow.contentHash)).toBe(false);
+  });
+});

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -18,6 +18,14 @@ export type { SupersessionMatch } from './supersession/supersession-detector.js'
 export { promote } from './promotion/promoter.js';
 export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
+export { mergeGovern } from './merge/merge-gate.js';
+export type {
+  MergeGovernResult,
+  MergeGovernDependencies,
+  MergeGovernOptions,
+  QuarantinedRow,
+  QuarantineCategory,
+} from './merge/merge-gate.js';
 export { parseMarkdown, titleFromPath, walkVault, countVaultFiles } from './import/index.js';
 export type { ParsedMarkdown, VaultFile } from './import/index.js';
 export {

--- a/apps/curator/src/merge/merge-gate.ts
+++ b/apps/curator/src/merge/merge-gate.ts
@@ -1,0 +1,324 @@
+import {
+  assertDisclosureClean,
+  computeContentHash,
+  DisclosureRejectedError,
+} from '@qmd-team-intent-kb/common';
+import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { MemoryCandidate as MemoryCandidateSchema } from '@qmd-team-intent-kb/schema';
+import type { CuratedMemory, GovernancePolicy, MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type {
+  AuditRepository,
+  MemoryLinksRepository,
+  MemoryRepository,
+} from '@qmd-team-intent-kb/store';
+import { promote } from '../promotion/promoter.js';
+
+/**
+ * Govern-at-merge gate (EPIC 1, bead compile-then-govern-8da.9).
+ *
+ * ## What this closes
+ *
+ * Two clones of the governed brain can each promote rows independently. If their
+ * branches are reconciled by a content-level merge (e.g. Dolt's native row
+ * union), a row that one clone *rejected* at its governance gate can re-enter the
+ * merged DB through the *other* clone's branch without being re-governed. The
+ * EPIC 1 spike demonstrated exactly this: a secret-bearing row admitted by a
+ * native union because the union operator does not re-run policy.
+ *
+ * The fix is **re-derivation over the union**: take the UNION of two clones'
+ * promoted rows and re-govern EVERY row as if it had never been trusted, by
+ * re-running the *existing* governance gate - the disclosure / secret choke
+ * point, then the full policy pipeline (dedupe, secret-detection, sensitivity,
+ * length, source-trust, tenant-match, ...). Anything that fails is QUARANTINED,
+ * never admitted. Survivors are promoted through the canonical {@link promote}
+ * path, so the merged state is indistinguishable from one assembled by feeding
+ * every row through the front door.
+ *
+ * ## Why it reuses, and does not reinvent
+ *
+ * The gate writes NO new governance primitive. It reuses, in sequence:
+ *
+ *   - {@link assertDisclosureClean} - the fail-closed PII / secret / comp choke
+ *     point already enforced at `CandidateRepository.insert()`.
+ *   - {@link PolicyPipeline} - the full ordered rule set, including the
+ *     content-hash `dedup_check` rule, fed an accreting `existingHashes` set.
+ *   - {@link promote} - the canonical promotion path (content-derived ids,
+ *     deterministic audit-chain append).
+ *
+ * The ONLY new discipline is the **sort-by-id traversal** of the union: ids are
+ * content-derived UUID v5s, so identical content sorts to an identical position,
+ * which makes the accreting `existingHashes` set accumulate in the same order on
+ * every clone - the keystone of the commutativity guarantee below.
+ *
+ * ## Commutativity guarantee
+ *
+ * `mergeGovern(A, B, ...)` and `mergeGovern(B, A, ...)` produce BYTE-IDENTICAL
+ * governed state and an identical audit outcome, because every step is symmetric
+ * in its inputs:
+ *
+ *   - id-dedup of the union is a set operation (order-independent);
+ *   - the union is sorted by content-derived id before processing, so the
+ *     traversal order - and therefore the order in which `existingHashes`
+ *     accretes - is identical regardless of which clone's rows arrived first;
+ *   - {@link assertDisclosureClean} is a pure function of content;
+ *   - {@link PolicyPipeline.evaluate} is deterministic given the same
+ *     `existingHashes`;
+ *   - {@link promote} derives the memory id, audit-event id, and (via injected
+ *     `now`) the promoted-row timestamps from content-stable inputs only.
+ *
+ * @module merge/merge-gate
+ */
+
+/** Why a row was turned away at the merge gate. Mirrors the governance gate's
+ *  two failure surfaces: the disclosure choke point and the policy pipeline. */
+export type QuarantineCategory = 'disclosure' | 'policy';
+
+/**
+ * A row refused at the merge gate. Carries the row's content-derived id, the
+ * category that turned it away, and a human-readable reason - but NEVER the
+ * matched secret/PII value (the disclosure error itself carries only a category,
+ * never the value, so re-leaking is structurally impossible here).
+ */
+export interface QuarantinedRow {
+  /** The quarantined source memory's id (content-derived, stable across clones). */
+  readonly memoryId: string;
+  /** Which gate refused it. */
+  readonly category: QuarantineCategory;
+  /** Human-readable reason - the disclosure category, or the rejecting rule id. */
+  readonly reason: string;
+}
+
+/** Outcome of a govern-at-merge pass. */
+export interface MergeGovernResult {
+  /** The promoted survivors, in the deterministic order they were written. */
+  readonly promoted: CuratedMemory[];
+  /** Rows refused at the disclosure choke point or the policy pipeline. */
+  readonly quarantined: QuarantinedRow[];
+  /**
+   * The number of logical memories in the union after content-id de-dup. Equals
+   * `promoted.length + quarantined.length + dedupedAcrossClones`, where the last
+   * term is the count of rows dropped because an identical-id twin was already
+   * processed (the same logical memory present in both clones).
+   */
+  readonly unionSize: number;
+}
+
+/** Dependencies the merge gate needs - the same repositories the curator uses. */
+export interface MergeGovernDependencies {
+  readonly memoryRepo: MemoryRepository;
+  readonly auditRepo: AuditRepository;
+  readonly linksRepo?: MemoryLinksRepository;
+}
+
+/** Options for a merge-gate pass. */
+export interface MergeGovernOptions {
+  /**
+   * The governance policy to re-run every union row against. When omitted, only
+   * the disclosure choke point + content-id de-dup apply (matching the curator's
+   * "no enabled policy" branch, which still promotes through {@link promote}).
+   */
+  readonly policy?: GovernancePolicy;
+  /** Tenant scope for the pipeline's `tenant_match` rule and audit events. */
+  readonly tenantId: string;
+  /**
+   * When true, run the full gate (validation, dedupe, audit-event construction)
+   * but write nothing. Used to preview a merge before committing it.
+   */
+  readonly dryRun?: boolean;
+}
+
+/**
+ * Re-project a promoted {@link CuratedMemory} back to a {@link MemoryCandidate}
+ * and downgrade it to `untrusted`, so the merge gate re-governs it from a
+ * clean slate. The governance metadata that promotion *adds* (`lifecycle`,
+ * `policyEvaluations`, `promotedAt`, `promotedBy`, `supersession`, `version`,
+ * `sensitivity`, the derived `id`) is stripped - only the source content and
+ * provenance survive into the re-derivation.
+ *
+ * `trustLevel` is forced to `untrusted` so the `source_trust` rule evaluates the
+ * row as if it had no prior standing - the merge gate trusts NOTHING that came
+ * across a clone boundary.
+ *
+ * The candidate id is preserved as the source memory's `candidateId` so the
+ * re-promotion derives the SAME memory id (`deriveMemoryId(candidateId,
+ * contentHash)`) - the merge is idempotent: re-governing an already-clean row
+ * reproduces its original id.
+ */
+function projectToUntrustedCandidate(memory: CuratedMemory): MemoryCandidate {
+  return MemoryCandidateSchema.parse({
+    id: memory.candidateId,
+    status: 'inbox',
+    source: memory.source,
+    content: memory.content,
+    title: memory.title,
+    category: memory.category,
+    trustLevel: 'untrusted',
+    author: memory.author,
+    tenantId: memory.tenantId,
+    metadata: memory.metadata,
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: memory.promotedAt,
+  });
+}
+
+/**
+ * Base instant for the deterministic merge clock. Promotion writes `promotedAt` /
+ * `updatedAt` into the durable `curated_memories` row and `timestamp` onto each
+ * audit event; sourcing them from `new Date()` would make the merged DB differ
+ * run-to-run and clone-to-clone, breaking byte-identical commutativity. Instead
+ * the merge clock is a pure function of the row's position in the deterministic
+ * union traversal.
+ */
+const MERGE_EPOCH_MS = Date.parse('2026-01-01T00:00:00.000Z');
+
+/**
+ * Deterministic, strictly-monotonic merge timestamp for the row at `index` in the
+ * id-sorted union traversal. Two properties are load-bearing:
+ *
+ *   1. **Cross-clone identical** - the union is sorted by content-derived id, so a
+ *      given logical memory lands at the same `index` on every clone, hence gets
+ *      the same timestamp. This is what makes the promoted `curated_memories` row
+ *      byte-identical between A∪B and B∪A.
+ *   2. **Monotonic with insertion order** - the audit chain's `prev_entry_hash`
+ *      links rows in insertion order, and `verifyAuditChain` re-walks them ordered
+ *      by `(timestamp ASC, id ASC)`. A single constant timestamp would force the
+ *      verifier onto its `id` tiebreaker (the audit-event id, which is NOT the
+ *      traversal order), so the re-walked chain would not match the insertion
+ *      links and the verifier would (correctly) report a break. A per-row
+ *      increasing timestamp keeps the chronological walk aligned with insertion
+ *      order, so the chain verifies clean.
+ *
+ * The audit chain's v2 `entry_hash` excludes `timestamp` from its body (bead
+ * 8da.6), so this deterministic clock does not perturb the entry_hash itself -
+ * the same logical event still hashes identically across clones.
+ */
+function mergeClock(index: number): string {
+  return new Date(MERGE_EPOCH_MS + index).toISOString();
+}
+
+/**
+ * Run the govern-at-merge gate over the UNION of two clones' promoted rows.
+ *
+ * Every row is re-governed as UNTRUSTED: the disclosure / secret choke point runs
+ * first, then the full policy pipeline with an accreting content-hash dedupe set.
+ * Survivors are promoted through the canonical path; failures are quarantined.
+ *
+ * Commutative by construction: `mergeGovern(cloneA, cloneB, ...)` and
+ * `mergeGovern(cloneB, cloneA, ...)` produce byte-identical governed state and an
+ * identical audit outcome (see the module doc-comment for the proof sketch).
+ *
+ * @param cloneA  Promoted (active) rows exported from clone A.
+ * @param cloneB  Promoted (active) rows exported from clone B.
+ * @param deps    The store repositories to write survivors + audit events into.
+ * @param options Policy, tenant scope, and dry-run flag.
+ */
+export function mergeGovern(
+  cloneA: readonly CuratedMemory[],
+  cloneB: readonly CuratedMemory[],
+  deps: MergeGovernDependencies,
+  options: MergeGovernOptions,
+): MergeGovernResult {
+  const dryRun = options.dryRun ?? false;
+
+  // 1. UNION + id-dedup. Content-derived ids are stable across clones, so two
+  //    rows sharing an id are the same logical memory - keep the first seen.
+  //    This is a pure set operation: symmetric in (cloneA, cloneB).
+  const unionById = new Map<string, CuratedMemory>();
+  for (const memory of [...cloneA, ...cloneB]) {
+    if (!unionById.has(memory.id)) {
+      unionById.set(memory.id, memory);
+    }
+  }
+
+  // 2. DETERMINISTIC TRAVERSAL. Sort the unique union by content-derived id so
+  //    the accreting `existingHashes` set accumulates in the SAME order on every
+  //    clone, regardless of which clone's rows arrived first. This sort is the
+  //    one element that makes A∪B and B∪A byte-identical.
+  const union = [...unionById.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // 3. SEED the dedupe set from the merged DB's existing content hashes (the same
+  //    call the eval harness uses), then accrete each newly-promoted row's hash.
+  const existingHashes = new Set<string>(deps.memoryRepo.getAllContentHashes());
+
+  const pipeline = options.policy !== undefined ? new PolicyPipeline(options.policy) : undefined;
+
+  const promoted: CuratedMemory[] = [];
+  const quarantined: QuarantinedRow[] = [];
+
+  for (let index = 0; index < union.length; index++) {
+    const memory = union[index]!;
+    const candidate = projectToUntrustedCandidate(memory);
+    const contentHash = computeContentHash(candidate.content);
+
+    // 3a. DISCLOSURE / SECRET CHOKE POINT - fail-closed, runs before the pipeline.
+    //     A secret- or PII-bearing row that slipped into one clone is turned away
+    //     here, never admitted to the merged DB.
+    try {
+      assertDisclosureClean(candidate);
+    } catch (err) {
+      if (err instanceof DisclosureRejectedError) {
+        quarantined.push({
+          memoryId: memory.id,
+          category: 'disclosure',
+          reason: err.category,
+        });
+        continue;
+      }
+      throw err;
+    }
+
+    // 3b. FULL POLICY PIPELINE with the accreting dedupe set. A duplicate (same
+    //     content hash already present, or already promoted earlier in this pass)
+    //     is rejected by the dedup_check rule; a secret/policy violation by its
+    //     rule. Either way: quarantine, never write.
+    let pipelineResult: PipelineResult | undefined;
+    if (pipeline !== undefined) {
+      pipelineResult = pipeline.evaluate(candidate, {
+        existingHashes,
+        tenantId: options.tenantId,
+      });
+      if (pipelineResult.outcome !== 'approved') {
+        quarantined.push({
+          memoryId: memory.id,
+          category: 'policy',
+          reason: pipelineResult.rejectedBy ?? pipelineResult.flaggedBy?.join(', ') ?? 'flagged',
+        });
+        continue;
+      }
+    } else {
+      // No policy: still run a bare dedupe so the no-policy merge path does not
+      // admit two identical-content rows. Mirrors the curator's intra-batch guard.
+      if (existingHashes.has(contentHash)) {
+        quarantined.push({
+          memoryId: memory.id,
+          category: 'policy',
+          reason: 'duplicate-content',
+        });
+        continue;
+      }
+      pipelineResult = { candidateId: candidate.id, outcome: 'approved', evaluations: [] };
+    }
+
+    // 4. WRITE SURVIVOR through the canonical promotion path, with a deterministic
+    //    clock so the durable row is byte-identical across clones. No supersession
+    //    detection or wiki-link edges in the merge path - the union is a re-govern,
+    //    not a fresh authoring event, so linksRepo is intentionally NOT passed.
+    const memoryRow = promote(
+      { candidate, contentHash, pipelineResult },
+      deps.memoryRepo,
+      deps.auditRepo,
+      dryRun,
+      undefined,
+      undefined,
+      mergeClock(index),
+    );
+    promoted.push(memoryRow);
+
+    // 5. ACCRETE the dedupe set so a later identical-content row in this same pass
+    //    is caught. Done after the write so the order is deterministic.
+    existingHashes.add(contentHash);
+  }
+
+  return { promoted, quarantined, unionSize: union.length };
+}

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -1,5 +1,9 @@
-import { randomUUID } from 'node:crypto';
-import { deriveMemoryId, deriveAuditEventId, deriveLinkId } from '@qmd-team-intent-kb/common';
+import {
+  deriveMemoryId,
+  deriveAuditEventId,
+  derivePolicyEvaluationId,
+  deriveLinkId,
+} from '@qmd-team-intent-kb/common';
 import {
   CuratedMemory as CuratedMemorySchema,
   AuditEvent as AuditEventSchema,
@@ -64,6 +68,14 @@ export type EvalCallback = (
  * When dryRun=true all logic runs (including schema validation) but nothing is
  * written to the database.
  *
+ * `now` defaults to the current wall-clock instant. Callers that need a
+ * cross-clone-reproducible promoted row (the govern-at-merge gate) inject a
+ * deterministic, content-derived timestamp here so that the same logical memory
+ * yields a byte-identical `promotedAt` / `updatedAt` on every clone. The audit
+ * chain's v2 `entry_hash` already excludes the timestamp (bead 8da.6), so the
+ * audit outcome is reproducible regardless; injecting `now` extends that
+ * reproducibility to the durable `curated_memories` row itself.
+ *
  * @returns The fully-formed CuratedMemory (always, even in dry-run mode).
  */
 export function promote(
@@ -73,8 +85,8 @@ export function promote(
   dryRun: boolean = false,
   linksRepo?: MemoryLinksRepository,
   evalCallback?: EvalCallback,
+  now: string = new Date().toISOString(),
 ): CuratedMemory {
-  const now = new Date().toISOString();
   // The promoted-memory id is content-derived (UUID v5) from the candidate
   // lineage, not random, so the same logical candidate promotes to the same
   // CuratedMemory.id on every clone. It is intentionally distinct from
@@ -86,18 +98,24 @@ export function promote(
   // (bead 8da.5) from their logical identities, load-bearing for the audit chain,
   // whose v2 entry_hash folds the event id into its canonical body, so a random id
   // would make the entry_hash per-clone even with timestamp excluded (8da.6).
-  // The per-record policyId stays random: it labels an operational policy-evaluation
-  // row, is never hashed into the audit chain, and is not part of any dedupe lineage.
   const memoryId = deriveMemoryId(input.candidate.id, input.contentHash);
 
-  // The pipeline does not carry a per-evaluation policyId, so one is generated per record.
-  const policyEvaluations: PolicyEvaluation[] = input.pipelineResult.evaluations.map((ev) => ({
-    policyId: randomUUID(),
-    ruleId: ev.ruleId,
-    result: ev.outcome,
-    reason: ev.reason,
-    evaluatedAt: now,
-  }));
+  // The pipeline does not carry a per-evaluation policyId, so one is derived per
+  // record. It is content-derived (bead 8da.5/8da.9) from (memoryId, ruleId,
+  // index), not random: the durable curated_memories row embeds these ids in its
+  // policy_evaluations_json column, so a random id made the row per-clone for the
+  // same logical promotion, which the govern-at-merge gate's byte-identical
+  // commutativity guarantee cannot tolerate. The policyId is never hashed into the
+  // audit chain, so deriving it deterministically is a pure improvement.
+  const policyEvaluations: PolicyEvaluation[] = input.pipelineResult.evaluations.map(
+    (ev, index) => ({
+      policyId: derivePolicyEvaluationId(memoryId, ev.ruleId, String(index)),
+      ruleId: ev.ruleId,
+      result: ev.outcome,
+      reason: ev.reason,
+      evaluatedAt: now,
+    }),
+  );
 
   const memory = CuratedMemorySchema.parse({
     id: memoryId,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,6 +7,7 @@ export {
   deriveCandidateId,
   deriveMemoryId,
   deriveAuditEventId,
+  derivePolicyEvaluationId,
   deriveLinkId,
 } from './uuid-v5.js';
 export { DEFAULT_TEAMKB_BASE, getTeamKbBasePath, resolveTeamKbPath } from './paths.js';

--- a/packages/common/src/uuid-v5.ts
+++ b/packages/common/src/uuid-v5.ts
@@ -156,6 +156,36 @@ export function deriveAuditEventId(
 }
 
 /**
+ * Derive a policy-evaluation record id deterministically from its natural
+ * identity `(memoryId, ruleId, discriminator)`. A `policyEvaluations[]` entry on
+ * a {@link deriveMemoryId promoted memory} records one rule's verdict; minting its
+ * `policyId` with `crypto.randomUUID()` left the durable `curated_memories` row
+ * per-clone for the *same* logical promotion (the row's `policy_evaluations_json`
+ * column embeds these ids). The policyId is NOT part of the audit chain (never
+ * hashed into any `entry_hash`), so this purely stabilises the curated DB row,
+ * which is the property the govern-at-merge gate (bead 8da.9) depends on for
+ * byte-identical commutativity.
+ *
+ * The `"policy"` tag keeps these ids in their own id-space, disjoint from
+ * `"memory"`-, `"audit"`-, and `"link"`-tagged ids.
+ *
+ * @param memoryId       The memory the evaluation belongs to.
+ * @param ruleId         The policy rule that produced the verdict.
+ * @param discriminator  Optional extra identity field that keeps otherwise-identical
+ *                       `(memoryId, ruleId)` pairs distinct (e.g. an evaluation
+ *                       index when one rule could appear more than once). Omit when
+ *                       `(memoryId, ruleId)` is already unique per promotion.
+ */
+export function derivePolicyEvaluationId(
+  memoryId: string,
+  ruleId: string,
+  discriminator: string = '',
+): string {
+  const name = ['policy', memoryId, ruleId, discriminator].join(NAME_FIELD_SEPARATOR);
+  return uuidV5(SPOOL_UUID_NAMESPACE, name);
+}
+
+/**
  * Derive a memory-link (graph edge) id deterministically from the edge's natural
  * identity `(sourceMemoryId, targetMemoryId, linkType)`. Link ids are NOT part of
  * the audit chain (they are never hashed into any `entry_hash`), but minting them


### PR DESCRIPTION
## What

Implements the EPIC 1 govern-at-merge gate: a deterministic, **commutative** post-merge re-derivation pass (`mergeGovern`) that takes the UNION of two clones' promoted rows and re-governs **every** row as UNTRUSTED, **quarantining** anything that fails (secret / disclosure / policy) rather than admitting it.

This closes the EPIC 1 spike finding: a row one clone *rejected* at its governance gate can re-enter the merged DB through the *other* clone's branch when a native row-union merge does not re-run policy. The fix re-runs the existing gate over the union.

## Design

The gate writes **no new governance primitive**. It reuses every existing piece in sequence:

1. **Union + id-dedup** - content-derived UUID v5 ids are stable across clones, so two rows sharing an id are the same logical memory (keep first). Pure symmetric set op.
2. **Deterministic traversal** - the union is sorted by content-derived id before processing, so the accreting `existingHashes` set accumulates in the same order on every clone. This sort is the keystone of commutativity.
3. **Disclosure / secret choke point** - `assertDisclosureClean()` runs first, fail-closed; a secret/PII row is quarantined, never written.
4. **Full policy pipeline** - `PolicyPipeline.evaluate()` with the accreting `existingHashes` (seeded from `MemoryRepository.getAllContentHashes()`); the `dedup_check` rule catches exact-content duplicates. Non-approved -> quarantine.
5. **Promote survivors** - through the canonical `promote()` path (content-derived memory id, deterministic audit-chain append).

### Commutativity guarantee

`mergeGovern(A, B)` and `mergeGovern(B, A)` produce **byte-identical governed state** and an **identical audit outcome**, because:

- id-dedup is a symmetric set operation;
- the union is sorted by content-derived id, so traversal order (and `existingHashes` accretion order) is clone-independent;
- `assertDisclosureClean` is a pure function of content; `PolicyPipeline.evaluate` is deterministic given the same `existingHashes`;
- a deterministic, strictly-monotonic **merge clock** keyed on the sorted-traversal index gives cross-clone-identical `promotedAt`/`updatedAt` **and** keeps the audit chain's `prev_entry_hash` links consistent under `verifyAuditChain`'s `(timestamp, id)` re-walk ordering.

### Two supporting reuse-enablers

- `promote()` gains an optional injected `now` (defaults to `new Date()`), so the merge path writes cross-clone-reproducible timestamps. Backward compatible.
- `policyEvaluations[].policyId` is now content-derived via the new `derivePolicyEvaluationId` (was `randomUUID`). The durable `curated_memories` row embeds these ids; the policyId is never hashed into the audit chain, so deriving it deterministically is a pure improvement and is what makes the merged row byte-identical across clones.

## Tests

`apps/curator/src/__tests__/merge-gate.test.ts` proves:

1. a secret-bearing **and** a disclosure-bearing row are **QUARANTINED**, not admitted (durable state confirms only clean rows land);
2. a row duplicated across both clones **dedupes by content-derived id** (one survives);
3. **commutativity**: A union B and B union A produce byte-identical governed state + identical audit outcome, both chains verify clean;
4. every surviving row **provably passed the full gate** (independently re-running the disclosure choke point + the policy pipeline over each survivor readmits it).

## Verification

- `packages/store` + `apps/curator` + `packages/common` + `packages/policy-engine`: **602 tests green**
- `pnpm typecheck` clean, `pnpm exec eslint` clean, `prettier --check` clean
- No em dashes; the secret-shaped test literal is fragmented via string concatenation.

## Files

- `apps/curator/src/merge/merge-gate.ts` (new) - the gate
- `apps/curator/src/__tests__/merge-gate.test.ts` (new) - the 4 proofs
- `apps/curator/src/promotion/promoter.ts` - inject `now`; derive policyId deterministically
- `apps/curator/src/index.ts` - export `mergeGovern` + types
- `packages/common/src/uuid-v5.ts` + `index.ts` - add/export `derivePolicyEvaluationId`

---

Refs intent-solutions-io/governed-second-brain#1
Bead compile-then-govern-8da.9

- Jeremy Longshore
intentsolutions.io