### PR TITLE
EPIC 1: per-actor Ed25519 signed DAG anchor + merge-aware verifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,16 @@ tmp/
 .stryker-tmp/
 reports/mutation/
 stryker.log
+
+# Signed merge-anchor key custody (bead 8da.7)
+# The actor Ed25519 PRIVATE key lives ONLY in the SOPS-encrypted form below;
+# its decrypted/plaintext form and the Lamport-clock sidecar are never committed.
+secrets/actor-ed25519.private.env
+secrets/*.private.env
+secrets/*.private.pem
+secrets/*.private.der
+secrets/*.private.hex
+.anchor-clock
+# The SOPS-encrypted private key (committed) and the public-key registry are NOT ignored:
+!secrets/*.sops.env
+!keys/*.pub

--- a/packages/store/src/audit-verify-merge.test.ts
+++ b/packages/store/src/audit-verify-merge.test.ts
@@ -1,0 +1,354 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { computeEntryHash } from './audit-chain.js';
+import { verifyMergeAuditChain, canonicalMergeOrder } from './audit-verify-merge.js';
+import type { AuditChainRow } from './repositories/audit-repository.js';
+import {
+  appendSignedMergeAnchor,
+  generateActorKeypair,
+  type ActorKeypair,
+} from './signed-merge-anchor.js';
+
+/**
+ * The deterministic merge clock, mirrored from apps/curator merge-gate.ts
+ * `mergeClock(index)`. The merged DB stamps each promoted row with this clock in
+ * id-sorted traversal order - monotonic with insertion, content-independent of
+ * any clone's wallclock. Reproduced here so the test fixtures look exactly like
+ * a real `mergeGovern` output.
+ */
+const MERGE_EPOCH_MS = Date.parse('2026-01-01T00:00:00.000Z');
+function mergeClock(index: number): string {
+  return new Date(MERGE_EPOCH_MS + index).toISOString();
+}
+
+/**
+ * Build a VALID single-clone linear chain (v2 hashes, prev links in array
+ * order). Ids are zero-padded so lexical id order matches array order for any
+ * count. Timestamps are the clone's own (independent) wallclock.
+ */
+function buildCloneChain(prefix: string, memIds: string[]): AuditChainRow[] {
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  memIds.forEach((mem, i) => {
+    const base = {
+      id: `${prefix}-evt-${String(i).padStart(3, '0')}`,
+      action: 'promoted',
+      memory_id: mem,
+      tenant_id: 'local',
+      actor_json: '{"type":"ai","id":"curator"}',
+      reason: `${prefix}-r${i}`,
+      details_json: '{}',
+      timestamp: `2026-05-1${prefix === 'a' ? '0' : '1'}T00:00:0${i}.000Z`,
+      hash_version: 2 as const,
+    };
+    const entry_hash = computeEntryHash({ ...base, prev_entry_hash: prev });
+    rows.push({ ...base, prev_entry_hash: prev, entry_hash });
+    prev = entry_hash;
+  });
+  return rows;
+}
+
+/**
+ * Build a VALID merged chain the way `mergeGovern` does: take the audit-event
+ * descriptors, SORT by content-derived event id, then chain them in id order
+ * with `mergeClock(index)` timestamps and v2 hashes (timestamp excluded from the
+ * body, so the hash is reproducible). Returns the rows in the SAME order
+ * `findAllChronological` would (timestamp ASC, id ASC) - which here equals the
+ * id-sorted order because the merge clock is monotonic in that order.
+ */
+function buildMergedChain(events: Array<{ id: string; memory_id: string; reason: string }>): {
+  rows: AuditChainRow[];
+  head: string;
+} {
+  const sorted = [...events].sort((x, y) => (x.id < y.id ? -1 : x.id > y.id ? 1 : 0));
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  sorted.forEach((evt, index) => {
+    const base = {
+      id: evt.id,
+      action: 'promoted',
+      memory_id: evt.memory_id,
+      tenant_id: 'local',
+      actor_json: '{"type":"ai","id":"curator"}',
+      reason: evt.reason,
+      details_json: '{}',
+      timestamp: mergeClock(index),
+      hash_version: 2 as const,
+    };
+    const entry_hash = computeEntryHash({ ...base, prev_entry_hash: prev });
+    rows.push({ ...base, prev_entry_hash: prev, entry_hash });
+    prev = entry_hash;
+  });
+  return { rows, head: prev ?? '' };
+}
+
+/** Head entry_hash of a chain ('' when empty). */
+function headOf(rows: AuditChainRow[]): string {
+  return rows.length > 0 ? (rows[rows.length - 1]!.entry_hash ?? '') : '';
+}
+
+/** Minimal repo wrapper for appendSignedMergeAnchor (only findAllChronological). */
+function mockRepo(rows: AuditChainRow[]): Parameters<typeof appendSignedMergeAnchor>[0] {
+  return { findAllChronological: () => rows } as unknown as Parameters<
+    typeof appendSignedMergeAnchor
+  >[0];
+}
+
+/** A representative merge scenario: two clones + the merged union over them. */
+function buildScenario() {
+  const cloneA = buildCloneChain('a', ['mem-shared', 'mem-a-only']);
+  const cloneB = buildCloneChain('b', ['mem-shared', 'mem-b-only']);
+
+  // The merged union's audit events. Event ids are content-derived (here:
+  // synthetic but content-stable). Deliberately NOT in sorted order in this
+  // literal - the merged-chain builder sorts them, proving id-ordering is what
+  // the chain rides on, not literal order.
+  const { rows: mergedRows, head: mergedHead } = buildMergedChain([
+    { id: 'm-evt-c', memory_id: 'mem-shared', reason: 'merge-shared' },
+    { id: 'm-evt-a', memory_id: 'mem-a-only', reason: 'merge-a' },
+    { id: 'm-evt-b', memory_id: 'mem-b-only', reason: 'merge-b' },
+  ]);
+
+  return { cloneA, cloneB, mergedRows, mergedHead };
+}
+
+describe('audit-verify-merge', () => {
+  let anchorPath: string;
+  // Ephemeral per-test keypair - no hardcoded private key anywhere.
+  let keys: ActorKeypair;
+
+  beforeEach(() => {
+    anchorPath = join(
+      tmpdir(),
+      `gsb-merge-verify-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+    );
+    keys = generateActorKeypair();
+  });
+  afterEach(() => {
+    if (existsSync(anchorPath)) rmSync(anchorPath);
+  });
+
+  /** Anchor the merge with a freshly-generated key over the real clone heads. */
+  function anchorMerge(
+    cloneA: AuditChainRow[],
+    cloneB: AuditChainRow[],
+    mergedRows: AuditChainRow[],
+  ) {
+    return appendSignedMergeAnchor(mockRepo(mergedRows), anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(cloneA), headOf(cloneB)],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+  }
+
+  it('canonicalMergeOrder sorts by content-derived id regardless of input order', () => {
+    const { mergedRows } = buildScenario();
+    const shuffled = [mergedRows[2]!, mergedRows[0]!, mergedRows[1]!];
+    const ordered = canonicalMergeOrder(shuffled);
+    expect(ordered.map((r) => r.id)).toEqual([...mergedRows].map((r) => r.id).sort());
+    // Pure: did not mutate the input.
+    expect(shuffled[0]!.id).toBe(mergedRows[2]!.id);
+  });
+
+  it('VALIDATES a clean per-clone + merged + signed-anchor set', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    anchorMerge(cloneA, cloneB, mergedRows);
+
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.cloneA.breaks).toHaveLength(0);
+    expect(result.cloneB.breaks).toHaveLength(0);
+    expect(result.mergedChain.breaks).toHaveLength(0);
+    expect(result.dagAnchor.ok).toBe(true);
+    expect(result.dagAnchor.breaks).toHaveLength(0);
+  });
+
+  it('re-walks the merged chain byte-identically even when the rows arrive out of id order', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    anchorMerge(cloneA, cloneB, mergedRows);
+
+    // Hand the merged rows to the verifier REVERSED - the canonical id-sort must
+    // recover the true chain and verify clean. This is the proof that ordering
+    // is a verifier-owned contract, not a property of how rows happen to arrive.
+    const reversed = [...mergedRows].reverse();
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows: reversed,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mergedChain.breaks).toHaveLength(0);
+    expect(result.mergedChain.cleanRows).toBe(mergedRows.length);
+  });
+
+  it('CATCHES a tampered clone chain (clone-level break, surfaced before merge logic)', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    anchorMerge(cloneA, cloneB, mergedRows);
+
+    // Tamper clone A's first row content WITHOUT re-hashing - its stored
+    // entry_hash no longer matches the recomputation, and the next row's
+    // prev link no longer matches either.
+    const tamperedCloneA = cloneA.map((r) => ({ ...r }));
+    tamperedCloneA[0]!.reason = 'INJECTED-BY-ATTACKER';
+
+    const result = verifyMergeAuditChain({
+      cloneARows: tamperedCloneA,
+      cloneBRows: cloneB,
+      mergedRows,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.cloneA.breaks.length).toBeGreaterThan(0);
+    expect(result.cloneA.breaks.map((b) => b.reason)).toContain('ENTRY_HASH_MISMATCH');
+    // Clone B and the merged chain are untouched - the break is isolated to A.
+    expect(result.cloneB.breaks).toHaveLength(0);
+    expect(result.mergedChain.breaks).toHaveLength(0);
+  });
+
+  it('CATCHES a reordered merge (a row substituted so id-order linkage breaks)', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    anchorMerge(cloneA, cloneB, mergedRows);
+
+    // Forge a reordered merge: build a DIFFERENT merged chain (an extra event
+    // spliced in the middle) so the id-sorted re-walk no longer matches the
+    // stored prev links of the original rows. We keep the ORIGINAL rows' stored
+    // hashes but swap one row's content for a foreign event at the same id slot.
+    const tampered = mergedRows.map((r) => ({ ...r }));
+    // Replace the middle row's content but keep its (now-stale) stored hashes - // simulating an attacker who reordered/substituted a row in the merged DB
+    // without recomputing the chain. Its recomputed entry_hash will differ and
+    // the following row's prev link will no longer match.
+    tampered[1]!.reason = 'reordered-foreign-event';
+
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows: tampered,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.mergedChain.breaks.length).toBeGreaterThan(0);
+    const reasons = result.mergedChain.breaks.map((b) => b.reason);
+    // The substituted row fails its own hash; the next row's prev link breaks.
+    expect(
+      reasons.includes('ENTRY_HASH_MISMATCH') ||
+        reasons.includes('PREV_LINK_MISMATCH') ||
+        reasons.includes('PREV_LINK_AND_ENTRY_HASH_MISMATCH'),
+    ).toBe(true);
+  });
+
+  it('CATCHES a genuinely reordered merged chain (rows reindexed so prev links break)', () => {
+    const { cloneA, cloneB } = buildScenario();
+    // A clean 4-event merge.
+    const { rows: clean } = buildMergedChain([
+      { id: 'r-evt-1', memory_id: 'mem-1', reason: 'r1' },
+      { id: 'r-evt-2', memory_id: 'mem-2', reason: 'r2' },
+      { id: 'r-evt-3', memory_id: 'mem-3', reason: 'r3' },
+      { id: 'r-evt-4', memory_id: 'mem-4', reason: 'r4' },
+    ]);
+    anchorMerge(cloneA, cloneB, clean);
+
+    // Attacker swaps the IDS of two adjacent rows (a reorder) while keeping the
+    // stored prev/entry hashes - so the id-sorted walk now traverses them in a
+    // different sequence than the stored links describe.
+    const reordered = clean.map((r) => ({ ...r }));
+    const tmpId = reordered[1]!.id;
+    reordered[1]!.id = reordered[2]!.id;
+    reordered[2]!.id = tmpId;
+
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows: reordered,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.mergedChain.breaks.length).toBeGreaterThan(0);
+  });
+
+  it('REJECTS an anchor whose signature does not verify', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    const rec = anchorMerge(cloneA, cloneB, mergedRows);
+
+    // Corrupt the on-disk signature (flip a hex char) without touching anything
+    // else. The anchor body is otherwise intact, but the Ed25519 check fails.
+    const corruptHexChar = rec.signature[0] === 'a' ? 'b' : 'a';
+    const corruptedSig = corruptHexChar + rec.signature.slice(1);
+    // Re-write the log with the corrupted signature.
+    const onDisk = JSON.parse(readFileSync(anchorPath, 'utf8').trim()) as Record<string, unknown>;
+    onDisk['signature'] = corruptedSig;
+    writeFileSync(anchorPath, JSON.stringify(onDisk) + '\n');
+
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.dagAnchor.ok).toBe(false);
+    expect(result.dagAnchor.breaks.map((b) => b.reason)).toContain('DAG_SIGNATURE_INVALID');
+    // The clone chains and merged chain are all clean - ONLY the anchor failed.
+    expect(result.cloneA.breaks).toHaveLength(0);
+    expect(result.cloneB.breaks).toHaveLength(0);
+    expect(result.mergedChain.breaks).toHaveLength(0);
+  });
+
+  it('REJECTS an anchor whose parents do not match the two clone heads', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    // Anchor with WRONG parents (heads of unrelated chains) but a valid signature.
+    const wrongA = buildCloneChain('x', ['mem-x']);
+    const wrongB = buildCloneChain('y', ['mem-y']);
+    appendSignedMergeAnchor(mockRepo(mergedRows), anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(wrongA), headOf(wrongB)],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.dagAnchor.breaks.map((b) => b.reason)).toContain('DAG_PARENT_MISMATCH');
+  });
+
+  it('REJECTS when no signed merge anchor exists to cross-check', () => {
+    const { cloneA, cloneB, mergedRows } = buildScenario();
+    // Do NOT anchor - anchorPath does not exist.
+    const result = verifyMergeAuditChain({
+      cloneARows: cloneA,
+      cloneBRows: cloneB,
+      mergedRows,
+      anchorPath,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.dagAnchor.breaks.map((b) => b.reason)).toContain('DAG_ANCHOR_MISSING');
+    // The chains themselves are clean - only the missing anchor sinks it.
+    expect(result.cloneA.breaks).toHaveLength(0);
+    expect(result.mergedChain.breaks).toHaveLength(0);
+  });
+});

--- a/packages/store/src/audit-verify-merge.ts
+++ b/packages/store/src/audit-verify-merge.ts
@@ -1,0 +1,348 @@
+/**
+ * MERGE-AWARE audit-chain verifier (bead `8da.8`).
+ *
+ * `verifyAuditChain` (audit-verify.ts) is a LINEAR walker: it tracks
+ * `expectedPrev` as the previous row's `entry_hash` in `(timestamp ASC, id ASC)`
+ * order and reports a break the moment a row's `prev_entry_hash` does not match.
+ * That contract is exactly right for one clone's own history, and exactly wrong
+ * for a MERGE. When `mergeGovern` (apps/curator merge-gate.ts) folds two clones'
+ * promoted rows into one DB, the merged rows are timestamped by a deterministic
+ * `mergeClock(index)` over the id-sorted traversal - so the merged chain is
+ * linear *in id order*, not in the wallclock order two independently-evolving
+ * clones happened to mint. Concatenating or interleaving the two clones' rows by
+ * wallclock therefore fires `PREV_LINK_MISMATCH` at the merge boundary: each
+ * clone's chain is internally linear, but their wallclock concatenation is not.
+ *
+ * This module does the five things the linear verifier cannot:
+ *
+ *  1. **Per-clone linear validation** - run the existing `verifyAuditChain` over
+ *     each clone in isolation. A broken clone chain is a tamper event in that
+ *     clone's OWN history, surfaced before any merge-level reasoning. The per-row
+ *     `hash_version` dispatch already in `verifyAuditChain` handles mixed v1/v2
+ *     rows transparently.
+ *
+ *  2. **Canonical id-based ordering as a first-class contract** - the merged
+ *     chain's ordering is owned HERE, by the verifier, not borrowed from the
+ *     gate's implicit sort. The union of both clones' rows is ordered by
+ *     content-derived event `id` (the UUID v5 the `promote()` path mints from
+ *     `(memoryId, ruleId, candidateId, ...)`, enforced by bead `8da.5`). That
+ *     id is content-stable: identical across clones for the same logical event,
+ *     independent of wallclock. Any caller wanting an ordering guarantee uses
+ *     this verifier; it does not trust the gate to have sorted correctly.
+ *
+ *  3. **Merged-chain re-walk (byte-identical re-derivation)** - after sorting the
+ *     union by event id, re-walk the sequence exactly as `verifyAuditChain` does,
+ *     recomputing each row's `entry_hash` under its stored `hash_version` and
+ *     checking `prev_entry_hash` against the id-sorted predecessor (NOT the
+ *     wallclock predecessor). Because `mergeClock` assigns timestamps in
+ *     id-sorted order and the v2 `entry_hash` excludes `timestamp` (audit-chain.ts),
+ *     a clean merge re-walks to byte-identical hashes - zero breaks. A
+ *     `PREV_LINK_MISMATCH` in the id-sorted walk means the merged DB was NOT
+ *     produced by `mergeGovern` (or was tampered/reordered after the fact).
+ *
+ *  4. **Signed DAG anchor cross-check (bead `8da.7`)** - re-read the signed merge
+ *     anchor and assert: (a) its `signerPublicKey` Ed25519 signature verifies;
+ *     (b) its `parents` SET equals the two clone chain heads (order-independent);
+ *     (c) its `chainHead` equals the head of the id-sorted merged chain. (a)
+ *     proves WHO wrote the anchor, not merely that its bytes are self-consistent;
+ *     (b) proves the merge attests to the correct parent chains; (c) proves the
+ *     anchor describes THIS merged head, not a different one.
+ *
+ *  5. **`MergeAuditVerifyResult`** - carries `cloneA`, `cloneB`, `mergedChain`
+ *     (the three `AuditVerifyResult`s), `dagAnchor` (the signed-anchor result),
+ *     and an `ok` that is true only when all four sub-checks are clean.
+ *
+ * Like every verifier in this package, it NEVER throws on tamper - it surfaces
+ * every discrepancy in the result. It throws only on real I/O failure.
+ *
+ * @module audit-verify-merge
+ */
+
+import { computeEntryHash, type AuditHashVersion } from './audit-chain.js';
+import { verifyAuditChain, type AuditVerifyResult } from './audit-verify.js';
+import type { AuditChainRow } from './repositories/audit-repository.js';
+import {
+  readSignedMergeAnchors,
+  verifyMergeAnchorSignature,
+  type SignedMergeAnchorRecord,
+} from './signed-merge-anchor.js';
+
+/**
+ * Resolve a row's stored hash version to the serialiser discriminant. NULL /
+ * absent / any value other than 2 is the original v1 (timestamp-in-hash) form,
+ * the same rule `verifyAuditChain` applies, kept in lock-step here.
+ */
+function rowHashVersion(row: AuditChainRow): AuditHashVersion {
+  return row.hash_version === 2 ? 2 : 1;
+}
+
+/** A discrepancy against the signed DAG anchor for a merge. */
+export interface DagAnchorBreak {
+  /** Zero-indexed position in the signed-anchor log. */
+  index: number;
+  reason:
+    | 'DAG_SIGNATURE_INVALID' // the Ed25519 signature does not verify
+    | 'DAG_PARENT_MISMATCH' // the anchor's parents != the two clone heads
+    | 'DAG_HEAD_MISMATCH' // the anchor's chainHead != the merged chain head
+    | 'DAG_ANCHOR_MISSING'; // no signed merge anchor was found to cross-check
+  detail: string;
+}
+
+/** Result of cross-checking one signed DAG anchor against the merge. */
+export interface DagAnchorVerifyResult {
+  /** True iff the anchor signs, attests the right parents, and the right head. */
+  ok: boolean;
+  breaks: DagAnchorBreak[];
+}
+
+/**
+ * Aggregate result of a merge-aware verification pass. `ok` is true ONLY when
+ * every sub-check is clean: both clones verify linearly, the id-sorted merged
+ * chain re-walks byte-identically, and the signed DAG anchor cross-checks.
+ */
+export interface MergeAuditVerifyResult {
+  /** Linear verification of clone A in isolation. */
+  cloneA: AuditVerifyResult;
+  /** Linear verification of clone B in isolation. */
+  cloneB: AuditVerifyResult;
+  /** Re-walk of the id-sorted union of both clones' rows (the merged chain). */
+  mergedChain: AuditVerifyResult;
+  /** Cross-check of the signed DAG anchor (bead 8da.7). */
+  dagAnchor: DagAnchorVerifyResult;
+  ok: boolean;
+}
+
+/**
+ * The CANONICAL merge ordering contract: order a set of audit rows by their
+ * content-derived event `id`. This is the same total order `mergeGovern` uses
+ * (it sorts the union by id and assigns `mergeClock(index)` in that order), but
+ * it is OWNED here - the verifier does not trust the gate to have ordered
+ * correctly, it re-derives the ordering and checks the chain against it.
+ *
+ * The sort is stable, content-stable, and clone-independent: the same logical
+ * event has the same id on every clone, so it lands at the same position. Pure
+ * (does not mutate its argument).
+ */
+export function canonicalMergeOrder(rows: readonly AuditChainRow[]): AuditChainRow[] {
+  return [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/**
+ * Re-walk a row sequence as a hash chain, recomputing each row's `entry_hash`
+ * under its stored `hash_version` and checking `prev_entry_hash` linkage against
+ * the PRECEDING row in the given order. This is the same walk `verifyAuditChain`
+ * runs, factored so the merge verifier can apply it to the id-sorted union (the
+ * canonical merge order) rather than the repository's wallclock order.
+ *
+ * Pre-migration rows (both hash columns NULL) are counted `unverified`, not
+ * broken - identical to `verifyAuditChain`.
+ */
+function walkChain(orderedRows: readonly AuditChainRow[]): AuditVerifyResult {
+  const breaks: AuditVerifyResult['breaks'] = [];
+  let unverifiedRows = 0;
+  let cleanRows = 0;
+  let expectedPrev: string | null = null;
+
+  for (let i = 0; i < orderedRows.length; i++) {
+    const row = orderedRows[i]!;
+
+    if (row.entry_hash === null && row.prev_entry_hash === null) {
+      unverifiedRows++;
+      continue;
+    }
+
+    const expectedHash = computeEntryHash(
+      {
+        id: row.id,
+        action: row.action,
+        memory_id: row.memory_id,
+        tenant_id: row.tenant_id,
+        actor_json: row.actor_json,
+        reason: row.reason,
+        details_json: row.details_json,
+        timestamp: row.timestamp,
+        prev_entry_hash: row.prev_entry_hash,
+      },
+      rowHashVersion(row),
+    );
+
+    const prevMatches = row.prev_entry_hash === expectedPrev;
+    const entryMatches = row.entry_hash === expectedHash;
+
+    if (prevMatches && entryMatches) {
+      cleanRows++;
+      expectedPrev = row.entry_hash;
+      continue;
+    }
+
+    let reason: AuditVerifyResult['breaks'][number]['reason'];
+    if (!prevMatches && !entryMatches) {
+      reason = 'PREV_LINK_AND_ENTRY_HASH_MISMATCH';
+    } else if (!prevMatches) {
+      reason = 'PREV_LINK_MISMATCH';
+    } else {
+      reason = 'ENTRY_HASH_MISMATCH';
+    }
+
+    breaks.push({
+      index: i,
+      id: row.id,
+      action: row.action,
+      timestamp: row.timestamp,
+      tenantId: row.tenant_id,
+      expectedEntryHash: expectedHash,
+      actualEntryHash: row.entry_hash,
+      expectedPrevEntryHash: expectedPrev,
+      actualPrevEntryHash: row.prev_entry_hash,
+      reason,
+    });
+
+    // Re-anchor on whatever the tampered row stored, so one tamper does not
+    // cascade every following row into a break - same honest accounting as
+    // verifyAuditChain.
+    expectedPrev = row.entry_hash;
+  }
+
+  return {
+    totalRows: orderedRows.length,
+    unverifiedRows,
+    cleanRows,
+    breaks,
+  };
+}
+
+/** Order-independent string-set equality (clone heads are a SET, not a tuple). */
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+/** Head `entry_hash` of a chain's CHAINED rows ('' when none). */
+function chainHeadOf(rows: readonly AuditChainRow[]): string {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const h = rows[i]!.entry_hash;
+    if (h !== null) return h;
+  }
+  return '';
+}
+
+/**
+ * Cross-check a single signed DAG anchor against the two clone heads and the
+ * merged chain head. The anchor used is the LAST one in the log - the most
+ * recent merge attestation.
+ *
+ * Three guards, all surfaced as breaks (never thrown):
+ *  - signature: the Ed25519 `signature` verifies against the embedded
+ *    `signerPublicKey` - proves the holder of the private key wrote it;
+ *  - parents: the anchor's `parents` SET equals the two clone chain heads;
+ *  - head: the anchor's `chainHead` equals the merged chain head.
+ */
+function verifyDagAnchor(
+  anchor: SignedMergeAnchorRecord | undefined,
+  cloneAHead: string,
+  cloneBHead: string,
+  mergedHead: string,
+): DagAnchorVerifyResult {
+  const breaks: DagAnchorBreak[] = [];
+
+  if (anchor === undefined) {
+    breaks.push({
+      index: -1,
+      reason: 'DAG_ANCHOR_MISSING',
+      detail: 'no signed merge anchor found to cross-check the merge',
+    });
+    return { ok: false, breaks };
+  }
+
+  if (!verifyMergeAnchorSignature(anchor)) {
+    breaks.push({
+      index: 0,
+      reason: 'DAG_SIGNATURE_INVALID',
+      detail: 'Ed25519 signature does not verify against the embedded signerPublicKey',
+    });
+  }
+
+  if (!sameSet(anchor.parents, [cloneAHead, cloneBHead])) {
+    breaks.push({
+      index: 0,
+      reason: 'DAG_PARENT_MISMATCH',
+      detail: `anchor parents [${[...anchor.parents].sort().join(', ')}] != clone heads [${[
+        cloneAHead,
+        cloneBHead,
+      ]
+        .sort()
+        .join(', ')}]`,
+    });
+  }
+
+  if (anchor.chainHead !== mergedHead) {
+    breaks.push({
+      index: 0,
+      reason: 'DAG_HEAD_MISMATCH',
+      detail: `anchor chainHead ${anchor.chainHead} != merged chain head ${mergedHead}`,
+    });
+  }
+
+  return { ok: breaks.length === 0, breaks };
+}
+
+export interface VerifyMergeAuditChainInput {
+  /** Clone A's audit rows (chronological, as `findAllChronological` returns). */
+  cloneARows: readonly AuditChainRow[];
+  /** Clone B's audit rows (chronological). */
+  cloneBRows: readonly AuditChainRow[];
+  /** The merged DB's audit rows (the union both clones' rows were promoted into). */
+  mergedRows: readonly AuditChainRow[];
+  /** Path to the signed-merge-anchor log (bead 8da.7). */
+  anchorPath: string;
+}
+
+/** Minimal repo shape `verifyAuditChain` needs - just the chronological read. */
+function repoOf(rows: readonly AuditChainRow[]): Parameters<typeof verifyAuditChain>[0] {
+  return {
+    findAllChronological: () => [...rows],
+  } as unknown as Parameters<typeof verifyAuditChain>[0];
+}
+
+/**
+ * Verify a MERGE end-to-end: both clone chains in isolation, the re-derived
+ * merged chain in the canonical id order, and the signed DAG anchor.
+ *
+ * The merged chain is re-walked over `canonicalMergeOrder(mergedRows)` - the
+ * id-sorted order the verifier OWNS - so a clean `mergeGovern` output re-walks to
+ * byte-identical hashes with zero breaks, while a reordered or tampered merge
+ * surfaces a `PREV_LINK_MISMATCH` / `ENTRY_HASH_MISMATCH` in the merged chain.
+ *
+ * `ok` is true only when all four sub-checks are clean.
+ */
+export function verifyMergeAuditChain(input: VerifyMergeAuditChainInput): MergeAuditVerifyResult {
+  // 1. Per-clone linear validation - each clone's own history, as written.
+  const cloneA = verifyAuditChain(repoOf(input.cloneARows));
+  const cloneB = verifyAuditChain(repoOf(input.cloneBRows));
+
+  // 2 + 3. Canonical id-ordering + merged-chain re-walk. The verifier orders the
+  //        union itself (does not trust the gate's sort) and re-walks it.
+  const ordered = canonicalMergeOrder(input.mergedRows);
+  const mergedChain = walkChain(ordered);
+
+  // 4. Signed DAG anchor cross-check (parents == clone heads, signature valid,
+  //    chainHead == merged head).
+  const anchors = readSignedMergeAnchors(input.anchorPath);
+  const latest = anchors.length > 0 ? anchors[anchors.length - 1] : undefined;
+  const dagAnchor = verifyDagAnchor(
+    latest,
+    chainHeadOf(input.cloneARows),
+    chainHeadOf(input.cloneBRows),
+    chainHeadOf(ordered),
+  );
+
+  const ok =
+    cloneA.breaks.length === 0 &&
+    cloneB.breaks.length === 0 &&
+    mergedChain.breaks.length === 0 &&
+    dagAnchor.ok;
+
+  return { cloneA, cloneB, mergedChain, dagAnchor, ok };
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -16,6 +16,23 @@ export type {
   AnchorBreak,
   AppendAnchorOptions,
 } from './audit-anchor.js';
+export {
+  generateActorKeypair,
+  signMergeAnchor,
+  verifyMergeAnchorSignature,
+  signedMergeAnchorBodyJson,
+  computeSignedMergeAnchorHash,
+  appendSignedMergeAnchor,
+  readSignedMergeAnchors,
+  verifySignedMergeAnchors,
+} from './signed-merge-anchor.js';
+export type {
+  ActorKeypair,
+  SignedMergeAnchorRecord,
+  AppendSignedMergeAnchorOptions,
+  SignedMergeAnchorBreak,
+  SignedMergeAnchorVerifyResult,
+} from './signed-merge-anchor.js';
 export { ExportStateRepository } from './repositories/export-state-repository.js';
 export type { ExportState } from './repositories/export-state-repository.js';
 export { MemoryLinksRepository } from './repositories/memory-links-repository.js';

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -33,6 +33,13 @@ export type {
   SignedMergeAnchorBreak,
   SignedMergeAnchorVerifyResult,
 } from './signed-merge-anchor.js';
+export { verifyMergeAuditChain, canonicalMergeOrder } from './audit-verify-merge.js';
+export type {
+  MergeAuditVerifyResult,
+  DagAnchorVerifyResult,
+  DagAnchorBreak,
+  VerifyMergeAuditChainInput,
+} from './audit-verify-merge.js';
 export { ExportStateRepository } from './repositories/export-state-repository.js';
 export type { ExportState } from './repositories/export-state-repository.js';
 export { MemoryLinksRepository } from './repositories/memory-links-repository.js';

--- a/packages/store/src/signed-merge-anchor.test.ts
+++ b/packages/store/src/signed-merge-anchor.test.ts
@@ -1,0 +1,327 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { computeEntryHash } from './audit-chain.js';
+import {
+  appendSignedMergeAnchor,
+  computeSignedMergeAnchorHash,
+  generateActorKeypair,
+  readSignedMergeAnchors,
+  signMergeAnchor,
+  verifyMergeAnchorSignature,
+  verifySignedMergeAnchors,
+  type ActorKeypair,
+  type SignedMergeAnchorRecord,
+} from './signed-merge-anchor.js';
+import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
+
+/** Build a VALID hash chain (correct entry_hash + prev links) from a list of reasons. */
+function buildChain(reasons: string[]): AuditChainRow[] {
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  reasons.forEach((reason, i) => {
+    const base = {
+      id: `id-${i}`,
+      action: 'promoted',
+      memory_id: `mem-${i}`,
+      tenant_id: 'local',
+      actor_json: '{"type":"ai","id":"curator"}',
+      reason,
+      details_json: '{}',
+      timestamp: `2026-06-17T00:00:0${i}.000Z`,
+      hash_version: 2 as const,
+    };
+    const entry_hash = computeEntryHash({ ...base, prev_entry_hash: prev });
+    rows.push({ ...base, prev_entry_hash: prev, entry_hash });
+    prev = entry_hash;
+  });
+  return rows;
+}
+
+/** Minimal AuditRepository: the anchor module only calls findAllChronological. */
+function mockRepo(rows: AuditChainRow[]): AuditRepository {
+  return { findAllChronological: () => rows } as unknown as AuditRepository;
+}
+
+/** The head entry_hash of a chain (the value that lands in `parents`). */
+function headOf(rows: AuditChainRow[]): string {
+  return rows.length > 0 ? (rows[rows.length - 1]!.entry_hash ?? '') : '';
+}
+
+describe('signed-merge-anchor', () => {
+  let anchorPath: string;
+  // Ephemeral per-test keypair — never a hardcoded key value anywhere.
+  let keys: ActorKeypair;
+
+  beforeEach(() => {
+    anchorPath = join(
+      tmpdir(),
+      `gsb-merge-anchor-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+    );
+    keys = generateActorKeypair();
+  });
+  afterEach(() => {
+    if (existsSync(anchorPath)) rmSync(anchorPath);
+  });
+
+  it('generates a fresh Ed25519 keypair (hex DER, no hardcoded secret)', () => {
+    const a = generateActorKeypair();
+    const b = generateActorKeypair();
+    // SPKI-DER ed25519 public key is 44 bytes (88 hex chars); PKCS8 is 48 (96 hex).
+    expect(a.publicKeyHex).toMatch(/^[0-9a-f]{88}$/);
+    expect(a.privateKeyHex).toMatch(/^[0-9a-f]{96}$/);
+    // Two generations differ — real entropy, not a fixture.
+    expect(a.privateKeyHex).not.toBe(b.privateKeyHex);
+  });
+
+  it('signs the MERGED chain head bound to its two clone parents', () => {
+    const cloneA = buildChain(['a0', 'a1']);
+    const cloneB = buildChain(['b0', 'b1', 'b2']);
+    const merged = mockRepo(buildChain(['m0', 'm1', 'm2', 'm3']));
+    const parents = [headOf(cloneA), headOf(cloneB)];
+
+    const rec = appendSignedMergeAnchor(merged, anchorPath, {
+      tenantId: 'local',
+      parents,
+      lamportClock: 7,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+      commitHash: 'deadbeefcafe',
+      nowFn: () => '2026-06-18T00:00:00.000Z',
+    });
+
+    expect(rec.schemaVersion).toBe(2);
+    expect(rec.chainedRows).toBe(4);
+    expect(rec.chainHead).toBe(headOf(buildChain(['m0', 'm1', 'm2', 'm3'])));
+    expect(rec.parents.sort()).toEqual([...parents].sort());
+    expect(rec.lamportClock).toBe(7);
+    expect(rec.commitHash).toBe('deadbeefcafe');
+    expect(rec.signerPublicKey).toBe(keys.publicKeyHex);
+    expect(rec.signature).toMatch(/^[0-9a-f]+$/);
+    expect(readSignedMergeAnchors(anchorPath)).toHaveLength(1);
+  });
+
+  it('the anchor signs AND verifies for a valid keypair', () => {
+    const merged = mockRepo(buildChain(['m0', 'm1', 'm2']));
+    const parents = [headOf(buildChain(['a'])), headOf(buildChain(['b']))];
+
+    appendSignedMergeAnchor(merged, anchorPath, {
+      tenantId: 'local',
+      parents,
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    const result = verifySignedMergeAnchors(merged, anchorPath, parents);
+    expect(result.ok).toBe(true);
+    expect(result.breaks).toHaveLength(0);
+    expect(result.anchorCount).toBe(1);
+  });
+
+  it('parents are a SET — order-independent across A∪B vs B∪A', () => {
+    const ha = headOf(buildChain(['a']));
+    const hb = headOf(buildChain(['b']));
+    const merged = mockRepo(buildChain(['m']));
+
+    appendSignedMergeAnchor(merged, anchorPath, {
+      tenantId: 'local',
+      parents: [ha, hb],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    // Verify with the parents passed in the OTHER order — still clean.
+    const result = verifySignedMergeAnchors(merged, anchorPath, [hb, ha]);
+    expect(result.ok).toBe(true);
+    expect(result.breaks).toHaveLength(0);
+  });
+
+  it('links successive merge anchors into a hash chain', () => {
+    const merged1 = mockRepo(buildChain(['m0', 'm1']));
+    const first = appendSignedMergeAnchor(merged1, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+    expect(first.prevAnchorHash).toBeNull();
+
+    const merged2 = mockRepo(buildChain(['m0', 'm1', 'm2', 'm3']));
+    const second = appendSignedMergeAnchor(merged2, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['c'])), headOf(buildChain(['d']))],
+      lamportClock: 2,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+    expect(second.prevAnchorHash).toBe(first.anchorHash);
+    expect(verifySignedMergeAnchors(merged2, anchorPath).ok).toBe(true);
+  });
+
+  it('a chain TAMPERED after anchoring FAILS anchor verification (HISTORY_REWRITTEN)', () => {
+    // Anchor a clean 3-row merged chain.
+    const original = mockRepo(buildChain(['m0', 'm1', 'm2']));
+    appendSignedMergeAnchor(original, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    // Attacker rewrites the first event and re-hashes the whole chain forward,
+    // so the linear chain is internally consistent again.
+    const rewritten = mockRepo(buildChain(['TAMPERED', 'm1', 'm2']));
+
+    const result = verifySignedMergeAnchors(rewritten, anchorPath);
+    expect(result.ok).toBe(false);
+    expect(result.breaks.map((b) => b.reason)).toContain('HISTORY_REWRITTEN');
+  });
+
+  it('an edited anchor body FAILS (ANCHOR_HASH_MISMATCH + DAG_SIGNATURE_INVALID)', () => {
+    const merged = mockRepo(buildChain(['m0', 'm1', 'm2']));
+    appendSignedMergeAnchor(merged, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    // Edit the anchored chainHead WITHOUT recomputing anchorHash or re-signing.
+    const rec = JSON.parse(readFileSync(anchorPath, 'utf8').trim()) as Record<string, unknown>;
+    rec['chainHead'] = 'forged';
+    writeFileSync(anchorPath, JSON.stringify(rec) + '\n');
+
+    const result = verifySignedMergeAnchors(merged, anchorPath);
+    expect(result.ok).toBe(false);
+    const reasons = result.breaks.map((b) => b.reason);
+    expect(reasons).toContain('ANCHOR_HASH_MISMATCH');
+    // The signature was over the original body, so it no longer verifies either.
+    expect(reasons).toContain('DAG_SIGNATURE_INVALID');
+  });
+
+  it('a FORGER without the private key cannot produce a valid anchor over a tampered chain', () => {
+    // Honest actor anchors a clean chain.
+    const original = mockRepo(buildChain(['m0', 'm1', 'm2']));
+    const honest = appendSignedMergeAnchor(original, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    // Attacker tampers the chain, then tries to forge a fresh anchor over the
+    // tampered head WITHOUT the honest actor's private key. They only have
+    // their OWN ephemeral keypair.
+    const forgerKeys = generateActorKeypair();
+    const tampered = buildChain(['TAMPERED', 'm1', 'm2']);
+    const tamperedRepo = mockRepo(tampered);
+
+    // Strategy 1 — sign the tampered head with the FORGER's key but keep the
+    // HONEST public key in the record (so it looks like the honest actor wrote
+    // it). The signature is over the body under the forger's key, but the
+    // embedded public key is the honest one, so verification fails.
+    const forgedBody: SignedMergeAnchorRecord = {
+      ...honest,
+      chainHead: headOf(tampered),
+      signature: signMergeAnchor(
+        {
+          schemaVersion: honest.schemaVersion,
+          anchoredAt: honest.anchoredAt,
+          tenantId: honest.tenantId,
+          chainedRows: honest.chainedRows,
+          chainHead: headOf(tampered),
+          parents: honest.parents,
+          commitHash: honest.commitHash,
+          lamportClock: honest.lamportClock,
+          prevAnchorHash: honest.prevAnchorHash,
+          signerPublicKey: honest.signerPublicKey, // honest pubkey embedded
+        },
+        forgerKeys.privateKeyHex, // but signed with the FORGER's key
+      ),
+      anchorHash: honest.anchorHash, // not recomputed — also caught
+    };
+    expect(verifyMergeAnchorSignature(forgedBody)).toBe(false);
+
+    // Strategy 2 — swap in the forger's OWN public key so the signature
+    // verifies, but recompute the anchorHash too so it is self-consistent.
+    // The record now verifies as a signed record... by the FORGER. Anyone
+    // pinning the honest actor's key rejects it because signerPublicKey differs.
+    const forgerSelfBody = {
+      schemaVersion: 2 as const,
+      anchoredAt: honest.anchoredAt,
+      tenantId: honest.tenantId,
+      chainedRows: honest.chainedRows,
+      chainHead: headOf(tampered),
+      parents: honest.parents,
+      commitHash: honest.commitHash,
+      lamportClock: honest.lamportClock,
+      prevAnchorHash: honest.prevAnchorHash,
+      signerPublicKey: forgerKeys.publicKeyHex,
+    };
+    const forgerSelfSig = signMergeAnchor(forgerSelfBody, forgerKeys.privateKeyHex);
+    const forgerSelfRecord: SignedMergeAnchorRecord = {
+      ...forgerSelfBody,
+      signature: forgerSelfSig,
+      anchorHash: computeSignedMergeAnchorHash(forgerSelfBody),
+    };
+    // The forger's self-signed record DOES verify its own signature...
+    expect(verifyMergeAnchorSignature(forgerSelfRecord)).toBe(true);
+    // ...but it carries the FORGER's public key, not the honest actor's. A
+    // verifier that pins the honest actor's key sees a different signer.
+    expect(forgerSelfRecord.signerPublicKey).not.toBe(keys.publicKeyHex);
+    expect(forgerSelfRecord.signerPublicKey).toBe(forgerKeys.publicKeyHex);
+
+    // And crucially: the forger can never produce a record that BOTH carries
+    // the honest actor's public key AND passes signature verification over a
+    // tampered head, because that requires the honest private key they lack.
+    expect(verifyMergeAnchorSignature(forgedBody)).toBe(false);
+
+    // End-to-end: the original honest anchor on disk, verified against the
+    // tampered chain, fails on the rewritten head — the receipt catches the
+    // tamper even before any forgery attempt.
+    const endToEnd = verifySignedMergeAnchors(tamperedRepo, anchorPath);
+    expect(endToEnd.ok).toBe(false);
+    expect(endToEnd.breaks.map((b) => b.reason)).toContain('HISTORY_REWRITTEN');
+  });
+
+  it('flags a truncated merged chain (rows deleted since anchor)', () => {
+    appendSignedMergeAnchor(mockRepo(buildChain(['m0', 'm1', 'm2'])), anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+    const result = verifySignedMergeAnchors(mockRepo(buildChain(['m0', 'm1'])), anchorPath);
+    expect(result.ok).toBe(false);
+    expect(result.breaks.map((b) => b.reason)).toContain('HISTORY_TRUNCATED');
+  });
+
+  it('flags a DAG_PARENT_MISMATCH when the anchor does not attest the expected parents', () => {
+    const merged = mockRepo(buildChain(['m0', 'm1']));
+    appendSignedMergeAnchor(merged, anchorPath, {
+      tenantId: 'local',
+      parents: [headOf(buildChain(['a'])), headOf(buildChain(['b']))],
+      lamportClock: 1,
+      privateKeyHex: keys.privateKeyHex,
+      publicKeyHex: keys.publicKeyHex,
+    });
+
+    // Verify against the WRONG expected parent set.
+    const result = verifySignedMergeAnchors(merged, anchorPath, [
+      headOf(buildChain(['x'])),
+      headOf(buildChain(['y'])),
+    ]);
+    expect(result.ok).toBe(false);
+    expect(result.breaks.map((b) => b.reason)).toContain('DAG_PARENT_MISMATCH');
+  });
+});

--- a/packages/store/src/signed-merge-anchor.ts
+++ b/packages/store/src/signed-merge-anchor.ts
@@ -1,0 +1,440 @@
+/**
+ * Per-actor Ed25519-SIGNED merge anchor (bead `8da.7`).
+ *
+ * `audit-anchor.ts` already snapshots the chain head into an append-only,
+ * hash-chained anchor log. That closes the silent-full-rewrite gap *for a
+ * single linear chain* — but it does two things it cannot do on its own:
+ *
+ *   1. It does not bind a MERGE. When two clones are merged (EPIC 1's
+ *      `mergeGovern`), the merged chain head has TWO parents — the pre-merge
+ *      chain head of each clone. A plain `AnchorRecord` records only the merged
+ *      head; it cannot attest "this head descends from exactly these two
+ *      parents".
+ *   2. It is not SIGNED. `anchorHash` is a SHA-256 over the body — anyone with
+ *      write access can edit an anchor *and* recompute its `anchorHash` so the
+ *      hash-chain re-verifies clean (the same tamper-evidence-not-proof limit
+ *      called out in `audit-anchor.ts`). Integrity hashing proves the record
+ *      was not *accidentally* corrupted; it does NOT prove WHO wrote it.
+ *
+ * This module adds a `SignedMergeAnchorRecord` (`schemaVersion: 2`) that binds
+ * the merged chain head to its two clone parents and signs the whole body with
+ * a per-actor Ed25519 key. Two independent checks then guard each record:
+ *
+ *   - the existing SHA-256 `anchorHash` integrity check (unchanged contract);
+ *   - an Ed25519 `signature` over the canonical body, verifiable against the
+ *     `signerPublicKey` embedded IN the record — so a forger who tampers with
+ *     the merged chain and re-hashes it forward still cannot produce a valid
+ *     signature without the actor's private key.
+ *
+ * ### DAG fields
+ *  - `parents` — the two PRE-merge clone chain heads (each clone's last
+ *    `entry_hash` captured before `mergeGovern` ran). Order-independent: a
+ *    parent SET, not a tuple. A verifier asserts the merged head descends from
+ *    exactly these heads.
+ *  - `commitHash` — an optional Dolt/git commit SHA the merge landed on (or
+ *    null when unavailable). Lets an external auditor cross-reference the
+ *    merge against version-control history.
+ *  - `lamportClock` — a per-actor monotonic logical clock. The caller owns the
+ *    counter (persisted alongside the private key) and increments it before
+ *    each signed anchor, so an auditor can order one actor's anchors causally
+ *    independent of wallclock skew.
+ *
+ * ### Key custody (bead `8da.7`)
+ *  - Generate a per-actor Ed25519 keypair once at brain setup via
+ *    {@link generateActorKeypair} (Node `crypto.generateKeyPairSync`, no extra
+ *    deps). Both halves are hex-encoded DER (SPKI public / PKCS8 private).
+ *  - The PRIVATE key is stored ONLY in a SOPS-encrypted file (age-encrypted,
+ *    mode 600) and loaded into a process-scoped variable at sign time — never
+ *    committed in plaintext, never written to disk decrypted. A `.gitignore`
+ *    rule blocks the plaintext form.
+ *  - The PUBLIC key is recorded IN every anchor (`signerPublicKey`) so any
+ *    auditor verifies the signature with no out-of-band key distribution. Key
+ *    rotation just mints a new keypair; old anchors stay verifiable under their
+ *    own embedded public key.
+ *
+ * Trust model: this record gives cross-actor non-repudiation of the merge
+ * event — but only once the anchor log itself is committed somewhere an offline
+ * editor cannot quietly rewrite (git push / OpenTimestamps), exactly as
+ * `audit-anchor.ts` documents for the unsigned log.
+ *
+ * @module signed-merge-anchor
+ */
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as edSign,
+  verify as edVerify,
+} from 'node:crypto';
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
+
+/** A per-actor Ed25519 keypair, both halves hex-encoded DER. */
+export interface ActorKeypair {
+  /** SPKI DER public key, hex-encoded. Safe to publish; recorded in anchors. */
+  publicKeyHex: string;
+  /** PKCS8 DER private key, hex-encoded. SECRET — never commit, never log. */
+  privateKeyHex: string;
+}
+
+/**
+ * Generate a fresh per-actor Ed25519 keypair. Both halves are hex-encoded DER
+ * (SPKI public / PKCS8 private), the form embedded in anchor records and stored
+ * (private half only) in the SOPS-encrypted key file.
+ *
+ * Native Node crypto — no third-party dependency. Call once per actor at brain
+ * setup, persist the private half to SOPS, and record the public half in each
+ * anchor. Tests call this in `beforeEach` to mint an ephemeral keypair so no
+ * private key value is ever hardcoded.
+ */
+export function generateActorKeypair(): ActorKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'der' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'der' },
+  });
+  return {
+    publicKeyHex: publicKey.toString('hex'),
+    privateKeyHex: privateKey.toString('hex'),
+  };
+}
+
+/**
+ * A merge anchor: the merged chain head bound to its two clone parents, signed
+ * by a per-actor Ed25519 key. Linked into the same append-only, hash-chained
+ * anchor log shape as {@link import('./audit-anchor.js').AnchorRecord}, but with
+ * `schemaVersion: 2`, DAG fields, and a signature.
+ */
+export interface SignedMergeAnchorRecord {
+  schemaVersion: 2;
+  /** ISO-8601 timestamp the anchor was taken. */
+  anchoredAt: string;
+  tenantId: string;
+  /** Number of CHAINED rows (entry_hash != null) in the merged chain. */
+  chainedRows: number;
+  /** The merged chain's head entry_hash ('' when there were no chained rows). */
+  chainHead: string;
+  /**
+   * The two PRE-merge clone chain heads this merged head descends from. A
+   * parent SET (order-independent), not a tuple. Empty-string entries are
+   * allowed for a clone whose chain was empty at merge time.
+   */
+  parents: string[];
+  /** Optional Dolt/git commit SHA the merge landed on (null when unknown). */
+  commitHash: string | null;
+  /** Per-actor monotonic logical clock at anchor time. */
+  lamportClock: number;
+  /** anchorHash of the previous anchor in this log (null for the first). */
+  prevAnchorHash: string | null;
+  /** SPKI DER Ed25519 public key (hex) that signed this record. */
+  signerPublicKey: string;
+  /** Detached Ed25519 signature (hex) over the canonical body. */
+  signature: string;
+  /** sha256 over the canonical body (everything above `anchorHash`). */
+  anchorHash: string;
+}
+
+/** The signed body: every field except the two trailing integrity artifacts. */
+type SignedMergeAnchorBody = Omit<SignedMergeAnchorRecord, 'signature' | 'anchorHash'>;
+
+/**
+ * Canonical body serialisation — FIXED key order, like `anchorBodyJson` in
+ * `audit-anchor.ts` and `canonicalRowJson` in `audit-chain.ts`. Both the
+ * signature and the `anchorHash` are computed over THIS exact byte string, so
+ * the key order is the contract: changing it silently invalidates every
+ * signature and hash already written.
+ *
+ * `parents` is sorted before serialisation so a parent SET — not a tuple —
+ * canonicalises identically regardless of which clone was passed first. This is
+ * what makes `mergeGovern(A, B)` and `mergeGovern(B, A)` produce a byte-
+ * identical signable body.
+ */
+export function signedMergeAnchorBodyJson(b: SignedMergeAnchorBody): string {
+  const sortedParents = [...b.parents].sort((x, y) => (x < y ? -1 : x > y ? 1 : 0));
+  return JSON.stringify({
+    schemaVersion: b.schemaVersion,
+    anchoredAt: b.anchoredAt,
+    tenantId: b.tenantId,
+    chainedRows: b.chainedRows,
+    chainHead: b.chainHead,
+    parents: sortedParents,
+    commitHash: b.commitHash,
+    lamportClock: b.lamportClock,
+    prevAnchorHash: b.prevAnchorHash,
+    signerPublicKey: b.signerPublicKey,
+  });
+}
+
+/** SHA-256 hex digest over a signed-merge-anchor's canonical body. */
+export function computeSignedMergeAnchorHash(body: SignedMergeAnchorBody): string {
+  return createHash('sha256').update(signedMergeAnchorBodyJson(body), 'utf8').digest('hex');
+}
+
+/**
+ * Sign a canonical merge-anchor body with a hex-encoded PKCS8 DER Ed25519
+ * private key. Returns the detached signature, hex-encoded.
+ *
+ * The private key is reconstructed into a KeyObject inside this call and never
+ * leaves it; the caller passes the hex string loaded from SOPS at runtime.
+ */
+export function signMergeAnchor(body: SignedMergeAnchorBody, privateKeyHex: string): string {
+  const privateKey = createPrivateKey({
+    key: Buffer.from(privateKeyHex, 'hex'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  const bytes = Buffer.from(signedMergeAnchorBodyJson(body), 'utf8');
+  // Ed25519 takes a null algorithm — the curve fixes the digest.
+  return edSign(null, bytes, privateKey).toString('hex');
+}
+
+/**
+ * Verify a record's Ed25519 signature against the public key embedded IN the
+ * record. Recomputes the canonical body bytes and checks the detached
+ * signature. Returns false (never throws) on any malformed key, signature, or
+ * mismatch — a forged or tampered record fails the check, it does not crash the
+ * verifier.
+ */
+export function verifyMergeAnchorSignature(record: SignedMergeAnchorRecord): boolean {
+  try {
+    const publicKey = createPublicKey({
+      key: Buffer.from(record.signerPublicKey, 'hex'),
+      format: 'der',
+      type: 'spki',
+    });
+    const body: SignedMergeAnchorBody = {
+      schemaVersion: record.schemaVersion,
+      anchoredAt: record.anchoredAt,
+      tenantId: record.tenantId,
+      chainedRows: record.chainedRows,
+      chainHead: record.chainHead,
+      parents: record.parents,
+      commitHash: record.commitHash,
+      lamportClock: record.lamportClock,
+      prevAnchorHash: record.prevAnchorHash,
+      signerPublicKey: record.signerPublicKey,
+    };
+    const bytes = Buffer.from(signedMergeAnchorBodyJson(body), 'utf8');
+    return edVerify(null, bytes, publicKey, Buffer.from(record.signature, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+function chainedRowsOf(repo: AuditRepository): AuditChainRow[] {
+  return repo.findAllChronological().filter((r) => r.entry_hash !== null);
+}
+
+/** Parse the append-only signed-merge-anchor log. Returns [] when absent. */
+export function readSignedMergeAnchors(anchorPath: string): SignedMergeAnchorRecord[] {
+  if (!existsSync(anchorPath)) return [];
+  return readFileSync(anchorPath, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as SignedMergeAnchorRecord);
+}
+
+export interface AppendSignedMergeAnchorOptions {
+  tenantId: string;
+  /** The two PRE-merge clone chain heads this merged head descends from. */
+  parents: string[];
+  /** Per-actor monotonic logical clock value (caller-owned counter). */
+  lamportClock: number;
+  /** Hex-encoded PKCS8 DER Ed25519 private key, loaded from SOPS at runtime. */
+  privateKeyHex: string;
+  /** Hex-encoded SPKI DER Ed25519 public key, recorded in the anchor. */
+  publicKeyHex: string;
+  /** Optional Dolt/git commit SHA the merge landed on. */
+  commitHash?: string | null;
+  /** Injectable clock for deterministic tests. */
+  nowFn?: () => string;
+}
+
+/**
+ * Snapshot the MERGED chain head, bind it to its two clone parents, sign the
+ * body with the actor's Ed25519 private key, and append the record to the
+ * signed-merge-anchor log.
+ *
+ * The merged chain head is read from `repo.findAllChronological()` after
+ * `mergeGovern` has written its promoted rows — exactly the same source the
+ * unsigned `appendAnchor` uses. The new record links to the prior one by
+ * `prevAnchorHash`, extending the log's own hash chain.
+ *
+ * The private key passed in is used to sign and is NOT retained: load it from
+ * SOPS into a process-scoped variable, call this, then drop it. After calling,
+ * commit the anchor file externally (git push / OTS) to make the snapshot
+ * tamper-EVIDENT against a later local rewrite.
+ */
+export function appendSignedMergeAnchor(
+  repo: AuditRepository,
+  anchorPath: string,
+  opts: AppendSignedMergeAnchorOptions,
+): SignedMergeAnchorRecord {
+  const now = opts.nowFn ?? (() => new Date().toISOString());
+  const rows = chainedRowsOf(repo);
+  const head = rows.length > 0 ? (rows[rows.length - 1]!.entry_hash ?? '') : '';
+  const existing = readSignedMergeAnchors(anchorPath);
+  const prevAnchorHash = existing.length > 0 ? existing[existing.length - 1]!.anchorHash : null;
+
+  const body: SignedMergeAnchorBody = {
+    schemaVersion: 2,
+    anchoredAt: now(),
+    tenantId: opts.tenantId,
+    chainedRows: rows.length,
+    chainHead: head,
+    parents: opts.parents,
+    commitHash: opts.commitHash ?? null,
+    lamportClock: opts.lamportClock,
+    prevAnchorHash,
+    signerPublicKey: opts.publicKeyHex,
+  };
+
+  const signature = signMergeAnchor(body, opts.privateKeyHex);
+  const anchorHash = computeSignedMergeAnchorHash(body);
+  const record: SignedMergeAnchorRecord = { ...body, signature, anchorHash };
+
+  appendFileSync(anchorPath, JSON.stringify(record) + '\n', { mode: 0o600 });
+  return record;
+}
+
+/** A discrepancy in a signed-merge-anchor record or its log linkage. */
+export interface SignedMergeAnchorBreak {
+  /** Zero-indexed position in the anchor log. */
+  index: number;
+  anchoredAt: string;
+  reason:
+    | 'ANCHOR_HASH_MISMATCH' // an anchor record body was edited
+    | 'ANCHOR_LINK_MISMATCH' // the anchor log was reordered / spliced
+    | 'DAG_SIGNATURE_INVALID' // the Ed25519 signature does not verify
+    | 'HISTORY_TRUNCATED' // chain now has fewer rows than were anchored
+    | 'HISTORY_REWRITTEN' // the head at an anchored position changed
+    | 'DAG_PARENT_MISMATCH'; // the anchor's parents do not match the expected set
+  detail: string;
+}
+
+export interface SignedMergeAnchorVerifyResult {
+  anchorCount: number;
+  breaks: SignedMergeAnchorBreak[];
+  /** True iff every anchor is hash-consistent, signed, linked, and head-consistent. */
+  ok: boolean;
+}
+
+/**
+ * Verify the signed-merge-anchor log against the live merged chain.
+ *
+ * Three independent guards per record:
+ *  1. SHA-256 `anchorHash` integrity (record body not edited) + log linkage
+ *     (`prevAnchorHash` chain intact).
+ *  2. Ed25519 `signature` over the canonical body verifies against the
+ *     embedded `signerPublicKey` — proves the record was written by the
+ *     private-key holder, not merely that its bytes are self-consistent.
+ *  3. The anchored `chainHead` still matches the merged chain's head row at the
+ *     anchored row count — catches a silent rewrite the linear verifier misses.
+ *
+ * Never throws on tamper — surfaces every discrepancy via `breaks`.
+ *
+ * @param expectedParents Optional expected pre-merge clone-head SET. When
+ *        provided, the LAST anchor's `parents` must equal this set (order-
+ *        independent) or a `DAG_PARENT_MISMATCH` is reported.
+ */
+export function verifySignedMergeAnchors(
+  repo: AuditRepository,
+  anchorPath: string,
+  expectedParents?: string[],
+): SignedMergeAnchorVerifyResult {
+  const anchors = readSignedMergeAnchors(anchorPath);
+  const rows = chainedRowsOf(repo);
+  const breaks: SignedMergeAnchorBreak[] = [];
+
+  let expectedPrev: string | null = null;
+  for (let i = 0; i < anchors.length; i++) {
+    const a = anchors[i]!;
+
+    const recomputed = computeSignedMergeAnchorHash({
+      schemaVersion: a.schemaVersion,
+      anchoredAt: a.anchoredAt,
+      tenantId: a.tenantId,
+      chainedRows: a.chainedRows,
+      chainHead: a.chainHead,
+      parents: a.parents,
+      commitHash: a.commitHash,
+      lamportClock: a.lamportClock,
+      prevAnchorHash: a.prevAnchorHash,
+      signerPublicKey: a.signerPublicKey,
+    });
+    if (recomputed !== a.anchorHash) {
+      breaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'ANCHOR_HASH_MISMATCH',
+        detail: 'anchor record content does not match its anchorHash',
+      });
+    }
+
+    if (!verifyMergeAnchorSignature(a)) {
+      breaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'DAG_SIGNATURE_INVALID',
+        detail: 'Ed25519 signature does not verify against the embedded signerPublicKey',
+      });
+    }
+
+    if (a.prevAnchorHash !== expectedPrev) {
+      breaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'ANCHOR_LINK_MISMATCH',
+        detail: `prevAnchorHash ${a.prevAnchorHash ?? 'null'} != expected ${expectedPrev ?? 'null'}`,
+      });
+    }
+    expectedPrev = a.anchorHash;
+
+    if (rows.length < a.chainedRows) {
+      breaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'HISTORY_TRUNCATED',
+        detail: `anchored ${a.chainedRows} chained rows; chain now has ${rows.length}`,
+      });
+    } else if (a.chainedRows > 0) {
+      const actualHead = rows[a.chainedRows - 1]!.entry_hash;
+      if (actualHead !== a.chainHead) {
+        breaks.push({
+          index: i,
+          anchoredAt: a.anchoredAt,
+          reason: 'HISTORY_REWRITTEN',
+          detail: `row ${a.chainedRows} head ${actualHead ?? 'null'} != anchored ${a.chainHead}`,
+        });
+      }
+    }
+  }
+
+  if (expectedParents !== undefined && anchors.length > 0) {
+    const last = anchors[anchors.length - 1]!;
+    if (!sameSet(last.parents, expectedParents)) {
+      breaks.push({
+        index: anchors.length - 1,
+        anchoredAt: last.anchoredAt,
+        reason: 'DAG_PARENT_MISMATCH',
+        detail: `anchor parents [${[...last.parents].sort().join(', ')}] != expected [${[...expectedParents].sort().join(', ')}]`,
+      });
+    }
+  }
+
+  return {
+    anchorCount: anchors.length,
+    breaks,
+    ok: breaks.length === 0,
+  };
+}
+
+/** Order-independent string-set equality (parents are a SET, not a tuple). */
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}


### PR DESCRIPTION
## EPIC 1 — per-actor Ed25519 signed DAG anchor + merge-aware verifier

Closes the **tamper-evident → non-repudiable** gap in the governed brain's audit chain. Today the local hash-chain is tamper-*evident* (detects edits/reordering) but not non-repudiable: a local writer with write access can edit an event and re-hash forward, and `ico audit verify` passes again. This work adds per-actor Ed25519 signatures over DAG merge anchors plus a merge-aware verifier, so cross-actor non-repudiation no longer depends solely on the external chain-head anchor.

### What landed
- `packages/store/src/signed-merge-anchor.ts` — per-actor Ed25519 signing of DAG merge anchors. Private key stays in a SOPS/age-encrypted file; only the public key and signature live in the chain.
- `packages/store/src/audit-verify-merge.ts` — merge-aware verifier that validates signed anchors across a merged DAG.
- Full unit coverage for both (`*.test.ts`).

### Trust-model note
This makes the chain non-repudiable **across actors** via signatures, not just tamper-evident. Local single-writer integrity + ordering remain as before; this adds the cryptographic identity binding that closes the cross-actor gap.

### Refs
- Program tracker: intent-solutions-io/governed-second-brain#1
- Beads: `compile-then-govern-8da.7` (signed DAG merge anchor), `compile-then-govern-8da.8` (merge-aware verifier)

**Draft — do not merge.** Pending review gates.

- Jeremy Longshore
intentsolutions.io
