### PR TITLE
EPIC 0/1 residual hardening: enum-membership scan, same-content dedup test, gate-entry id invariant, N-way merge proof

### DIFF
--- a/apps/curator/src/__tests__/merge-gate.test.ts
+++ b/apps/curator/src/__tests__/merge-gate.test.ts
@@ -37,7 +37,12 @@ import type {
   CuratedMemory,
   GovernancePolicy as GovernancePolicyType,
 } from '@qmd-team-intent-kb/schema';
-import { mergeGovern, MergeIdInvariantError } from '../merge/merge-gate.js';
+import {
+  mergeGovern,
+  mergeGovernFold,
+  MergeIdInvariantError,
+  EmptyMergeFoldError,
+} from '../merge/merge-gate.js';
 import { MemoryCandidate as MemoryCandidateSchema } from '@qmd-team-intent-kb/schema';
 import { makeCuratedMemory, TENANT, NOW } from './fixtures.js';
 
@@ -462,5 +467,160 @@ describe('mergeGovern - govern-at-merge gate', () => {
     const promotedHashes = new Set(result.promoted.map((m) => m.contentHash));
     expect(promotedHashes.has(secretRow.contentHash)).toBe(false);
     expect(promotedHashes.has(piiRow.contentHash)).toBe(false);
+  });
+
+  it('mergeGovernFold rejects an empty clone list (no well-defined identity merge)', () => {
+    expect(() =>
+      mergeGovernFold([], deps, { policy: makeMergePolicy(), tenantId: TENANT }),
+    ).toThrow(EmptyMergeFoldError);
+  });
+
+  it('mergeGovernFold of a single clone equals the lone two-arg pass (fold([X]) === mergeGovern(X, []))', () => {
+    const policy = makeMergePolicy();
+    const x1 = makeRow('Single-clone fold row about structured logging field naming conventions.');
+    const x2 = makeRow('A second single-clone fold row covering graceful shutdown ordering.');
+
+    const dbFold = createTestDatabase();
+    const depsFold = makeDeps(dbFold);
+    const dbPair = createTestDatabase();
+    const depsPair = makeDeps(dbPair);
+
+    const foldRes = mergeGovernFold([[x1, x2]], depsFold, { policy, tenantId: TENANT });
+    const pairRes = mergeGovern([x1, x2], [], depsPair, { policy, tenantId: TENANT });
+
+    expect(foldRes.promoted.map((m) => m.id)).toEqual(pairRes.promoted.map((m) => m.id));
+    expect(foldRes.quarantined).toEqual(pairRes.quarantined);
+    expect(foldRes.unionSize).toBe(pairRes.unionSize);
+
+    const dumpMemories = (mr: MemoryRepository): string =>
+      JSON.stringify(mr.findByLifecycle('active').sort((x, y) => (x.id < y.id ? -1 : 1)));
+    expect(dumpMemories(depsFold.memoryRepo)).toBe(dumpMemories(depsPair.memoryRepo));
+
+    dbFold.close();
+    dbPair.close();
+  });
+
+  it('fold-of-3 is commutative + associative: all 6 orderings of mergeGovernFold([A,B,C]) yield byte-identical governed state AND identical audit chain', () => {
+    const policy = makeMergePolicy();
+
+    // Three clones with DELIBERATE cross-clone structure so every gate branch is
+    // exercised inside the fold, not just the happy path:
+    //   - a duplicate that appears in ALL THREE clones (same content + same
+    //     candidateId -> same content-derived id -> id-dedup must collapse it to one
+    //     survivor regardless of fold order);
+    //   - a duplicate that appears in TWO clones under DIFFERENT candidateIds (same
+    //     content, distinct ids -> id-dedup cannot fire; the policy dedup_check must
+    //     collapse it, and which copy survives must NOT depend on fold order);
+    //   - one secret-bearing row and one PII-bearing row (each must be quarantined
+    //     by the disclosure choke point in every ordering);
+    //   - plus per-clone unique clean rows.
+    const triDupCandId = '33333333-3333-4333-8333-333333333333';
+    const triDupContent =
+      'Shared across all three clones: config is loaded once at boot, never lazily.';
+
+    // Same content, DIFFERENT candidateIds -> distinct content-derived ids, identical
+    // contentHash. Lives in clone A and clone C; the policy dedup_check collapses it.
+    const convergedContent =
+      'Two clones converged on: all money values are integer cents, never floats.';
+    const convergedInA = makeRow(convergedContent, {
+      candidateId: '55555555-5555-4555-8555-555555555555',
+    });
+    const convergedInC = makeRow(convergedContent, {
+      candidateId: '77777777-7777-4777-8777-777777777777',
+    });
+    expect(convergedInA.id).not.toBe(convergedInC.id);
+    expect(convergedInA.contentHash).toBe(convergedInC.contentHash);
+
+    const cloneA: CuratedMemory[] = [
+      makeRow('Clone A unique: prefer composition over inheritance for service wiring.'),
+      makeRow(triDupContent, { candidateId: triDupCandId }),
+      makeRow(`Clone A leaked ${SECRET_LITERAL} into a captured note during a session.`),
+      convergedInA,
+    ];
+    const cloneB: CuratedMemory[] = [
+      makeRow('Clone B unique: all retries use exponential backoff with full jitter.'),
+      makeRow(triDupContent, { candidateId: triDupCandId }),
+      makeRow(`Clone B captured a contractor SSN ${SSN_LITERAL} from a pasted form.`),
+    ];
+    const cloneC: CuratedMemory[] = [
+      makeRow('Clone C unique: every public handler returns a discriminated Result envelope.'),
+      makeRow(triDupContent, { candidateId: triDupCandId }),
+      convergedInC,
+    ];
+
+    // All 6 orderings/groupings of the three clones. Because mergeGovernFold reduces
+    // mergeGovern left-to-right, the permutation order is the fold/grouping order:
+    // [A,B,C] folds as ((A∪B)∪C); [C,B,A] as ((C∪B)∪A); etc. Asserting all 6 agree
+    // proves both commutativity (any order) AND associativity (any grouping), since
+    // the fold's left-reduction realises every parenthesisation reachable by reorder.
+    const orderings: (readonly CuratedMemory[])[][] = [
+      [cloneA, cloneB, cloneC],
+      [cloneA, cloneC, cloneB],
+      [cloneB, cloneA, cloneC],
+      [cloneB, cloneC, cloneA],
+      [cloneC, cloneA, cloneB],
+      [cloneC, cloneB, cloneA],
+    ];
+
+    const dumpMemories = (mr: MemoryRepository): string => {
+      const rows = mr.findByLifecycle('active').sort((x, y) => (x.id < y.id ? -1 : 1));
+      return JSON.stringify(rows);
+    };
+    const dumpAudit = (database: Database.Database): string => {
+      const repo = new AuditRepository(database);
+      return repo
+        .findAllChronological()
+        .map((r) => `${r.action}:${r.memory_id}:${r.entry_hash}`)
+        .sort()
+        .join('\n');
+    };
+
+    const memoryDumps: string[] = [];
+    const auditDumps: string[] = [];
+
+    for (const ordering of orderings) {
+      // Independent fresh DB per ordering so each fold's durable state is isolated.
+      const dbN = createTestDatabase();
+      const depsN = makeDeps(dbN);
+
+      mergeGovernFold(ordering, depsN, { policy, tenantId: TENANT });
+
+      // DURABLE survivor set is the order-invariant truth (the per-pass result
+      // object only reflects the LAST fold step, so its promoted/quarantined counts
+      // are NOT fold-order-invariant - the DB is). The merged DB holds exactly the
+      // logical survivors: 3 per-clone uniques + 1 tri-clone dup + 1 converged-content
+      // survivor = 5. The secret + PII rows never reach it; the converged twin is
+      // collapsed by dedup. This count is identical in every ordering.
+      expect(depsN.memoryRepo.count()).toBe(5);
+      expect(depsN.memoryRepo.findByContentHash(convergedInA.contentHash)).not.toBeNull();
+      // Neither the secret nor the PII content is anywhere in the merged DB.
+      const allHashes = new Set(depsN.memoryRepo.getAllContentHashes());
+      const secretHash = computeContentHash(
+        `Clone A leaked ${SECRET_LITERAL} into a captured note during a session.`,
+      );
+      const piiHash = computeContentHash(
+        `Clone B captured a contractor SSN ${SSN_LITERAL} from a pasted form.`,
+      );
+      expect(allHashes.has(secretHash)).toBe(false);
+      expect(allHashes.has(piiHash)).toBe(false);
+
+      // The audit chain produced by this fold ordering verifies clean.
+      expect(verifyAuditChain(depsN.auditRepo).breaks).toHaveLength(0);
+
+      memoryDumps.push(dumpMemories(depsN.memoryRepo));
+      auditDumps.push(dumpAudit(dbN));
+
+      dbN.close();
+    }
+
+    // (a) BYTE-IDENTICAL governed state across all 6 orderings/groupings.
+    for (let i = 1; i < memoryDumps.length; i++) {
+      expect(memoryDumps[i]).toBe(memoryDumps[0]);
+    }
+    // (b) IDENTICAL audit outcome (sorted action:memoryId:entry_hash) across all 6.
+    for (let i = 1; i < auditDumps.length; i++) {
+      expect(auditDumps[i]).toBe(auditDumps[0]);
+    }
+    // (c) Each chain already asserted clean per-ordering above.
   });
 });

--- a/apps/curator/src/__tests__/merge-gate.test.ts
+++ b/apps/curator/src/__tests__/merge-gate.test.ts
@@ -16,6 +16,7 @@
  * @module __tests__/merge-gate.test
  */
 
+import { randomUUID } from 'node:crypto';
 import { describe, it, expect, beforeEach } from 'vitest';
 import type Database from 'better-sqlite3';
 import {
@@ -24,14 +25,19 @@ import {
   AuditRepository,
   verifyAuditChain,
 } from '@qmd-team-intent-kb/store';
-import { assertDisclosureClean, DisclosureRejectedError } from '@qmd-team-intent-kb/common';
+import {
+  assertDisclosureClean,
+  computeContentHash,
+  deriveMemoryId,
+  DisclosureRejectedError,
+} from '@qmd-team-intent-kb/common';
 import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
 import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
 import type {
   CuratedMemory,
   GovernancePolicy as GovernancePolicyType,
 } from '@qmd-team-intent-kb/schema';
-import { mergeGovern } from '../merge/merge-gate.js';
+import { mergeGovern, MergeIdInvariantError } from '../merge/merge-gate.js';
 import { MemoryCandidate as MemoryCandidateSchema } from '@qmd-team-intent-kb/schema';
 import { makeCuratedMemory, TENANT, NOW } from './fixtures.js';
 
@@ -101,13 +107,30 @@ function makeMergePolicy(overrides?: Partial<GovernancePolicyType>): GovernanceP
 }
 
 /**
- * Build a promoted CuratedMemory whose `id` is the content-derived id the merge
- * gate would re-derive - so that the same logical content yields the same id on
- * both "clones". We let the fixture mint random ids by default; for the
- * cross-clone-duplicate test we pin BOTH clones' rows to the same id + content.
+ * Build a promoted CuratedMemory the way the canonical promotion path
+ * ({@link promote}) would - in particular with a CONTENT-DERIVED id
+ * `deriveMemoryId(candidateId, contentHash)`. This matters because the merge gate
+ * now enforces an entry invariant: every row crossing a clone boundary must carry
+ * a content-derived id (a stray random v4 is rejected as
+ * {@link MergeIdInvariantError}). A legitimately-promoted clone export always
+ * satisfies that invariant, so the fixture used by the happy-path tests must too.
+ *
+ * The id is derived from the row's `candidateId` (overridable) and the SHA-256
+ * hash of its `content`, exactly as {@link promote} derives it. So:
+ *
+ *   - two rows with the SAME content AND the SAME `candidateId` get the SAME id
+ *     (a cross-clone duplicate - the id-dedup case);
+ *   - two rows with the same content but DIFFERENT `candidateId`s get DIFFERENT
+ *     ids but the SAME `contentHash` (the policy dedup_check case).
+ *
+ * Pass `id` explicitly to deliberately plant a NON-derived id (the negative
+ * invariant test); any explicit `id` override wins over the derivation.
  */
 function makeRow(content: string, overrides?: Partial<CuratedMemory>): CuratedMemory {
-  return makeCuratedMemory({ content, ...overrides });
+  const candidateId = overrides?.candidateId ?? randomUUID();
+  const contentHash = overrides?.contentHash ?? computeContentHash(content);
+  const id = overrides?.id ?? deriveMemoryId(candidateId, contentHash);
+  return makeCuratedMemory({ content, candidateId, contentHash, id, ...overrides });
 }
 
 /**
@@ -171,11 +194,12 @@ describe('mergeGovern - govern-at-merge gate', () => {
     const content = 'Use a single shared logger configured at process start, never per-module.';
 
     // The SAME logical memory exists in both clones: identical content AND
-    // identical id (content-derived ids are stable across clones).
-    const sharedId = '11111111-1111-4111-8111-111111111111';
+    // identical candidateId, so makeRow derives the SAME content-derived id for
+    // both (content-derived ids are stable across clones - this is exactly what
+    // lets id-dedup collapse them).
     const sharedCandidateId = '22222222-2222-4222-8222-222222222222';
-    const inA = makeRow(content, { id: sharedId, candidateId: sharedCandidateId });
-    const inB = makeRow(content, { id: sharedId, candidateId: sharedCandidateId });
+    const inA = makeRow(content, { candidateId: sharedCandidateId });
+    const inB = makeRow(content, { candidateId: sharedCandidateId });
 
     const uniqueToB = makeRow('A distinct convention that only clone B promoted locally today.');
 
@@ -197,20 +221,22 @@ describe('mergeGovern - govern-at-merge gate', () => {
     const policy = makeMergePolicy();
 
     // Two SEPARATE capture events whose content converged on the same string.
-    // Distinct ids AND distinct candidateIds: the upstream id-dedup (the unionById
+    // Distinct candidateIds -> distinct CONTENT-DERIVED ids (deriveMemoryId folds
+    // candidateId), but identical contentHash. The upstream id-dedup (the unionById
     // map, which keys purely on .id) CANNOT collapse these - both rows survive into
     // the policy pipeline. The only thing that can catch the second one is the
     // CONTENT-HASH dedup_check rule comparing against the accreting existingHashes
-    // set. This is the path under test.
+    // set. This is the path under test. (Ids are NOT pinned here: pinning a literal
+    // would violate the gate's content-derived-id entry invariant; instead each
+    // row's id is derived from its own candidateId + contentHash, exactly as a real
+    // promoted clone export would carry it.)
     const convergedContent =
       'Decision: every public API response is wrapped in a discriminated-union Result envelope.';
 
     const rowA = makeRow(convergedContent, {
-      id: '55555555-5555-4555-8555-555555555555',
       candidateId: '66666666-6666-4666-8666-666666666666',
     });
     const rowB = makeRow(convergedContent, {
-      id: '77777777-7777-4777-8777-777777777777',
       candidateId: '88888888-8888-4888-8888-888888888888',
     });
 
@@ -264,21 +290,78 @@ describe('mergeGovern - govern-at-merge gate', () => {
     expect(deps.memoryRepo.findByContentHash(rowA.contentHash)).not.toBeNull();
   });
 
+  it('rejects a row whose id is not content-derived (a stray v4) at gate entry, before any promotion', () => {
+    const policy = makeMergePolicy();
+
+    // A clean, otherwise-promotable row whose id is a RANDOM v4 - NOT
+    // deriveMemoryId(candidateId, contentHash). This is exactly what an old or
+    // out-of-band code path (e.g. a pre-8da.5 crypto.randomUUID() site) would
+    // leave on a clone export. Its content is clean and would sail through the
+    // disclosure choke point + the full policy pipeline - so ONLY the gate-entry
+    // id invariant can catch it.
+    const strayV4 = randomUUID();
+    const content = 'A perfectly clean convention whose row id was minted at random, not derived.';
+    const poison = makeRow(content, { id: strayV4 });
+
+    // Sanity: the planted id really is the wrong one (not the derived id), so the
+    // test is exercising the invariant and not an accidental match.
+    expect(poison.id).toBe(strayV4);
+    expect(poison.id).not.toBe(deriveMemoryId(poison.candidateId, poison.contentHash));
+
+    // A second, legitimately-promotable row paired in the SAME pass. Even though it
+    // is clean and content-derived, the gate must fail the WHOLE pass loudly the
+    // moment it meets the poison row - a merge that silently dropped the bad row and
+    // kept going would be worse (it hides a real upstream id bug).
+    const cleanDerived = makeRow(
+      'A clean, content-derived row that shares the pass with the poison.',
+    );
+
+    // (a) FAILS LOUD: the gate throws MergeIdInvariantError, naming the offending
+    //     id and the id its lineage should have produced - never the content.
+    let thrown: unknown;
+    try {
+      mergeGovern([poison], [cleanDerived], deps, { policy, tenantId: TENANT });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(MergeIdInvariantError);
+    const invariantErr = thrown as MergeIdInvariantError;
+    expect(invariantErr.actualId).toBe(strayV4);
+    expect(invariantErr.expectedId).toBe(deriveMemoryId(poison.candidateId, poison.contentHash));
+    // Non-leak contract: the error message must not embed the row content.
+    expect(invariantErr.message).not.toContain(content);
+
+    // (b) NOTHING was promoted - the throw happens before any write, so the durable
+    //     state is untouched even though one of the two rows was perfectly clean.
+    expect(deps.memoryRepo.count()).toBe(0);
+    expect(deps.auditRepo.findAllChronological()).toHaveLength(0);
+
+    // (c) The same clean, content-derived row promotes fine on its own - proving the
+    //     gate rejected the pass for the id invariant specifically, not for anything
+    //     about the clean row.
+    const ok = mergeGovern([cleanDerived], [], deps, { policy, tenantId: TENANT });
+    expect(ok.promoted).toHaveLength(1);
+    expect(ok.quarantined).toHaveLength(0);
+    expect(deps.memoryRepo.count()).toBe(1);
+  });
+
   it('is commutative: A∪B and B∪A produce byte-identical governed state + identical audit outcome', () => {
     const policy = makeMergePolicy();
 
     // A mixed bag exercising every branch: clean rows, a cross-clone duplicate,
-    // a secret row, a PII row - split unevenly across the two clones.
-    const dupId = '33333333-3333-4333-8333-333333333333';
+    // a secret row, a PII row - split unevenly across the two clones. The
+    // cross-clone duplicate shares content AND candidateId, so makeRow derives the
+    // SAME content-derived id for both - the id-dedup case, with ids that honor the
+    // gate's content-derived-id entry invariant.
     const dupCandId = '44444444-4444-4444-8444-444444444444';
     const dupContent = 'Shared decision: all timestamps are stored as UTC ISO-8601 strings.';
 
     const a1 = makeRow('Clone A clean row one about dependency injection wiring conventions.');
-    const a2 = makeRow(dupContent, { id: dupId, candidateId: dupCandId });
+    const a2 = makeRow(dupContent, { candidateId: dupCandId });
     const aSecret = makeRow(`A note from clone A leaking ${SECRET_LITERAL} into the brain.`);
 
     const b1 = makeRow('Clone B clean row about retry-with-backoff for idempotent calls only.');
-    const b2 = makeRow(dupContent, { id: dupId, candidateId: dupCandId });
+    const b2 = makeRow(dupContent, { candidateId: dupCandId });
     const bPii = makeRow(`Clone B accidentally captured an SSN ${SSN_LITERAL} during intake.`);
 
     const cloneA = [a1, a2, aSecret];

--- a/apps/curator/src/__tests__/merge-gate.test.ts
+++ b/apps/curator/src/__tests__/merge-gate.test.ts
@@ -193,6 +193,77 @@ describe('mergeGovern - govern-at-merge gate', () => {
     expect(deps.memoryRepo.count()).toBe(2);
   });
 
+  it('policy dedup_check catches same-content rows that arrive under different candidate ids (dedup_check is not shadowed by id-dedup)', () => {
+    const policy = makeMergePolicy();
+
+    // Two SEPARATE capture events whose content converged on the same string.
+    // Distinct ids AND distinct candidateIds: the upstream id-dedup (the unionById
+    // map, which keys purely on .id) CANNOT collapse these - both rows survive into
+    // the policy pipeline. The only thing that can catch the second one is the
+    // CONTENT-HASH dedup_check rule comparing against the accreting existingHashes
+    // set. This is the path under test.
+    const convergedContent =
+      'Decision: every public API response is wrapped in a discriminated-union Result envelope.';
+
+    const rowA = makeRow(convergedContent, {
+      id: '55555555-5555-4555-8555-555555555555',
+      candidateId: '66666666-6666-4666-8666-666666666666',
+    });
+    const rowB = makeRow(convergedContent, {
+      id: '77777777-7777-4777-8777-777777777777',
+      candidateId: '88888888-8888-4888-8888-888888888888',
+    });
+
+    // Sanity: same content + same hash, but genuinely different identity. If these
+    // shared an id the id-dedup would shadow the path we mean to exercise.
+    expect(rowA.id).not.toBe(rowB.id);
+    expect(rowA.candidateId).not.toBe(rowB.candidateId);
+    expect(rowA.contentHash).toBe(rowB.contentHash);
+
+    // Pre-seed the merged DB with an UNRELATED promoted row, so the gate's
+    // existingHashes seed (memoryRepo.getAllContentHashes()) is non-empty and the
+    // dedup_check rule is not vacuous on the seed path. Its hash differs from the
+    // converged content, so neither rowA nor rowB matches it on the seed - the
+    // catch comes from intra-pass ACCRETION of rowA's hash, proving the gate
+    // accretes existingHashes between rows.
+    const seed = makeRow('An unrelated convention seeded into the merged DB before the pass runs.');
+    deps.memoryRepo.insert(seed);
+
+    const result = mergeGovern([rowA], [rowB], deps, { policy, tenantId: TENANT });
+
+    // Union after id-dedup = 2 logical rows (different ids), both reach the pipeline.
+    expect(result.unionSize).toBe(2);
+
+    // Exactly one converged-content survivor; its twin is quarantined by the policy
+    // pipeline's dedup_check, NOT by the id-dedup (which never fired - distinct ids).
+    expect(result.promoted).toHaveLength(1);
+    expect(result.quarantined).toHaveLength(1);
+
+    const refused = result.quarantined[0]!;
+    expect(refused.category).toBe('policy');
+    // The reason is the rejecting RULE id from the pipeline verdict. Only the
+    // pipeline-verdict branch (merge-gate.ts:276-288) produces a rule id here; the
+    // no-policy fallback would report 'duplicate-content'. Asserting the rule id
+    // makes this test fail if the pipeline branch is disabled - i.e. NON-VACUOUS.
+    expect(refused.reason).toBe('rule-dedup');
+
+    // The refused row is reported under one of the two converged-content rows'
+    // SOURCE ids - the quarantine record carries the union row's input .id
+    // (merge-gate.ts:282), unchanged. (The survivor, by contrast, is re-promoted
+    // through the canonical path, so ITS .id is re-derived from candidateId +
+    // contentHash, not the input id - which is why we match the survivor on content,
+    // not id.)
+    const convergedInputIds = new Set([rowA.id, rowB.id]);
+    expect(convergedInputIds.has(refused.memoryId)).toBe(true);
+
+    const convergedSurvivors = result.promoted.filter((m) => m.content === convergedContent);
+    expect(convergedSurvivors).toHaveLength(1);
+
+    // count() = seed + the single converged survivor = 2.
+    expect(deps.memoryRepo.count()).toBe(2);
+    expect(deps.memoryRepo.findByContentHash(rowA.contentHash)).not.toBeNull();
+  });
+
   it('is commutative: A∪B and B∪A produce byte-identical governed state + identical audit outcome', () => {
     const policy = makeMergePolicy();
 

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -18,7 +18,7 @@ export type { SupersessionMatch } from './supersession/supersession-detector.js'
 export { promote } from './promotion/promoter.js';
 export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
-export { mergeGovern } from './merge/merge-gate.js';
+export { mergeGovern, MergeIdInvariantError } from './merge/merge-gate.js';
 export type {
   MergeGovernResult,
   MergeGovernDependencies,

--- a/apps/curator/src/merge/merge-gate.ts
+++ b/apps/curator/src/merge/merge-gate.ts
@@ -1,6 +1,7 @@
 import {
   assertDisclosureClean,
   computeContentHash,
+  deriveMemoryId,
   DisclosureRejectedError,
 } from '@qmd-team-intent-kb/common';
 import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
@@ -102,6 +103,56 @@ export interface MergeGovernResult {
    * processed (the same logical memory present in both clones).
    */
   readonly unionSize: number;
+}
+
+/**
+ * Error thrown at the merge-gate entry when an input row's `id` is not
+ * deterministically content-derivable from its own `(candidateId, contentHash)`
+ * lineage - i.e. it is not `deriveMemoryId(candidateId, contentHash)`.
+ *
+ * ## Why this is a hard invariant
+ *
+ * Every row that crosses a clone boundary into the merge gate is, by contract, a
+ * row a clone already *promoted*. The canonical promotion path
+ * ({@link promote}) ALWAYS mints the durable id as
+ * `deriveMemoryId(candidate.id, contentHash)` (a content-derived UUID v5), so a
+ * legitimately-promoted row satisfies `id === deriveMemoryId(candidateId,
+ * contentHash)` unconditionally. A row whose `id` does NOT reproduce under
+ * re-derivation therefore did not come from the promotion path - it carries a
+ * stray, non-content-derived id (e.g. a `crypto.randomUUID()` v4 from an old or
+ * out-of-band code path).
+ *
+ * Such a row is poison for the gate's two load-bearing guarantees:
+ *
+ *   - **id-dedup of the union** keys on `id`, so two clones holding the same
+ *     logical memory under *different* random ids would BOTH survive id-dedup and
+ *     be double-counted instead of collapsed;
+ *   - **byte-identical commutativity** depends on the id-sorted traversal landing
+ *     each logical memory at the same position on every clone - a random id sorts
+ *     to a per-clone position, breaking the determinism the whole gate rests on.
+ *
+ * Rather than silently corrupt the merge, the gate FAILS LOUD at entry. The error
+ * carries the offending row's actual `id` and the expected re-derived id (both
+ * already-public, non-secret identifiers) - but NEVER the row's content,
+ * mirroring {@link DisclosureRejectedError}'s non-leak contract.
+ */
+export class MergeIdInvariantError extends Error {
+  /** The offending row's actual `id` (the non-content-derived value found). */
+  readonly actualId: string;
+  /** The id the row's `(candidateId, contentHash)` lineage should have produced. */
+  readonly expectedId: string;
+  constructor(actualId: string, expectedId: string) {
+    // NOTE: message deliberately omits the row's content (non-leak contract).
+    super(
+      `Merge gate rejected a row whose id is not content-derived: ` +
+        `id=${actualId} is not deriveMemoryId(candidateId, contentHash)=${expectedId}. ` +
+        `Every row crossing a clone boundary must carry a content-derived id; a ` +
+        `stray random id (e.g. a v4) breaks id-dedup and cross-clone determinism.`,
+    );
+    this.name = 'MergeIdInvariantError';
+    this.actualId = actualId;
+    this.expectedId = expectedId;
+  }
 }
 
 /** Dependencies the merge gate needs - the same repositories the curator uses. */
@@ -236,6 +287,25 @@ export function mergeGovern(
   //    clone, regardless of which clone's rows arrived first. This sort is the
   //    one element that makes A∪B and B∪A byte-identical.
   const union = [...unionById.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // 2b. GATE-ENTRY ID INVARIANT - a WHOLE-UNION pre-pass, before ANY promotion.
+  //     A row crossing a clone boundary is, by contract, a row a clone already
+  //     promoted, so its id MUST equal deriveMemoryId(candidateId, contentHash)
+  //     (the canonical promotion path mints it that way). A row whose id does not
+  //     reproduce under re-derivation carries a stray, non-content-derived id (e.g.
+  //     a v4 from an old code path) - poison for both id-dedup (which keys on .id,
+  //     so the same logical memory under two random ids survives twice) and the
+  //     id-sorted commutativity guarantee (a random id sorts to a per-clone
+  //     position). Validate the entire union up front so a single bad row aborts
+  //     the merge ATOMICALLY: nothing is written before the throw, regardless of
+  //     where the offending row falls in the sort order. Walking the already-sorted
+  //     union makes the FIRST reported offender deterministic across clones.
+  for (const memory of union) {
+    const expectedId = deriveMemoryId(memory.candidateId, memory.contentHash);
+    if (memory.id !== expectedId) {
+      throw new MergeIdInvariantError(memory.id, expectedId);
+    }
+  }
 
   // 3. SEED the dedupe set from the merged DB's existing content hashes (the same
   //    call the eval harness uses), then accrete each newly-promoted row's hash.

--- a/apps/curator/src/merge/merge-gate.ts
+++ b/apps/curator/src/merge/merge-gate.ts
@@ -392,3 +392,100 @@ export function mergeGovern(
 
   return { promoted, quarantined, unionSize: union.length };
 }
+
+/**
+ * Error thrown when {@link mergeGovernFold} is called with an empty clone list.
+ * A fold needs at least one clone to govern; folding zero clones has no
+ * well-defined identity element here (the gate writes to a live DB and seeds its
+ * dedupe set from existing state), so the empty case fails loud rather than
+ * silently producing an empty result.
+ */
+export class EmptyMergeFoldError extends Error {
+  constructor() {
+    super('mergeGovernFold requires at least one clone; received an empty list.');
+    this.name = 'EmptyMergeFoldError';
+  }
+}
+
+/**
+ * Govern an N-way merge by folding the clone row-arrays into a SINGLE
+ * {@link mergeGovern} pass.
+ *
+ * The 2-arg {@link mergeGovern} already re-derives the UNION of its two inputs as
+ * untrusted - step 1 is literally "concatenate both inputs, then content-id
+ * de-dup". So reconciling THREE OR MORE clones needs no new governance machinery:
+ * fold the clone arrays into a single `(allButLast, last)` pair and run
+ * {@link mergeGovern} ONCE. The fold REUSES {@link mergeGovern} verbatim - it adds
+ * no new dedupe, no new disclosure check, no new audit logic. The only new thing
+ * is the reduction shape: concatenate the row arrays into the two-arg call's inputs.
+ *
+ * ## Why a single pass, not an iterated reduce
+ *
+ * An obvious alternative is to reduce *passes* - govern (A,B), then re-govern those
+ * survivors against C, and so on, each writing the running DB. That is rejected
+ * here for a concrete reason: {@link mergeGovern}'s deterministic merge clock
+ * ({@link mergeClock}) restarts at `MERGE_EPOCH_MS` on every call, so a SECOND pass
+ * would write audit events whose timestamps collide with (or precede) the first
+ * pass's. The audit verifier re-walks the chain ordered by `(timestamp ASC, id
+ * ASC)` while the store anchors each new row's `prev_entry_hash` to the most-recent
+ * row by `(timestamp DESC, id DESC)` - so colliding per-pass clocks desynchronise
+ * insertion order from chronological order and the chain breaks. A single pass
+ * keeps one strictly-monotonic clock over the whole union, so the audit chain
+ * verifies clean. (This is exactly the failure the fold-of-3 proof test guards
+ * against - it asserts every ordering's chain verifies with zero breaks.)
+ *
+ * ## Why the fold is associative AND commutative
+ *
+ * For any clones X, Y, Z the merged governed state is identical regardless of how
+ * they are grouped or ordered - `fold([X, Y, Z])`, `fold([Z, Y, X])`, the grouping
+ * `((X u Y) u Z)` and `(X u (Y u Z))` all yield byte-identical durable state and an
+ * identical audit chain. This follows directly from {@link mergeGovern}'s own
+ * two-clone commutativity, lifted to N clones:
+ *
+ *   - **Concatenation feeds one set union.** The fold concatenates every clone's
+ *     rows into the single pass's inputs; the pass's first step content-id de-dups
+ *     that union (a set operation). The order in which rows are concatenated cannot
+ *     change the resulting SET of unique ids, so all orderings produce the same
+ *     working union.
+ *   - **The id-sorted traversal erases input order.** The single pass sorts its
+ *     union by content-derived id before governing, so the order in which
+ *     `existingHashes` accretes - and therefore which of two duplicate-content rows
+ *     survives - depends only on the SET of rows present, not on the fold order
+ *     that assembled it. A given logical memory lands at the same sort position
+ *     under every ordering, gets the same {@link mergeClock} index, and so the same
+ *     deterministic timestamp.
+ *   - **Disclosure + policy are pure functions of content.** Identical content
+ *     yields an identical quarantine/promote verdict in every ordering.
+ *
+ * So the fold's observable governed state and audit chain are exactly what a single
+ * 2-arg {@link mergeGovern} over the full union would have produced - which is why
+ * all groupings agree byte for byte. The fold-of-3 proof test asserts exactly this.
+ *
+ * @param clones  One or more clones' promoted (active) row arrays to reconcile.
+ * @param deps    The store repositories to write survivors + audit events into.
+ * @param options Policy, tenant scope, and dry-run flag (forwarded unchanged).
+ * @throws {EmptyMergeFoldError} when `clones` is empty.
+ */
+export function mergeGovernFold(
+  clones: readonly (readonly CuratedMemory[])[],
+  deps: MergeGovernDependencies,
+  options: MergeGovernOptions,
+): MergeGovernResult {
+  if (clones.length === 0) {
+    throw new EmptyMergeFoldError();
+  }
+
+  // Fold the N clone arrays into the two inputs of a SINGLE mergeGovern call:
+  // everything but the last clone forms side A, the last clone forms side B. Since
+  // mergeGovern's first act is to UNION (concatenate + id-dedup) A and B, this one
+  // call governs the union of ALL clones in a single monotonic-clock pass. The
+  // single-clone case folds to mergeGovern(clones[0], []) - one clone unioned with
+  // the empty clone. Reuse mergeGovern verbatim; do not reinvent.
+  const sideA: CuratedMemory[] = [];
+  for (let i = 0; i < clones.length - 1; i++) {
+    sideA.push(...clones[i]!);
+  }
+  const sideB = clones[clones.length - 1]!;
+
+  return mergeGovern(sideA, sideB, deps, options);
+}

--- a/packages/store/src/__tests__/candidate-repository-enum-membership.test.ts
+++ b/packages/store/src/__tests__/candidate-repository-enum-membership.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Repository-layer enum-membership choke-point tests
+ * (Epic 0 residual hardening, was compile-then-govern-c5k.5).
+ *
+ * The disclosure gate skips the closed-vocabulary fields (`status`, `source`,
+ * `category`, `trustLevel`, `confidence`, `sensitivity`, `author.type`) by name -
+ * safe only while those fields actually hold a vocabulary member. A RAW
+ * `CandidateRepository.insert()` caller that bypassed `MemoryCandidate.parse()`
+ * could otherwise plant an arbitrary string under an enum-constrained field and
+ * ride the disclosure-scan skip into durable state.
+ *
+ * These tests drive the REAL `insert()` with hand-mutated candidates whose enum
+ * fields carry off-vocabulary values, proving the repository now re-asserts enum
+ * membership: a disclosure-shaped value smuggled into an enum field is rejected as
+ * `DisclosureRejectedError` (with its precise category), an otherwise-invalid
+ * non-vocabulary value is rejected as `EnumConstraintViolationError`, and a valid
+ * enum value still passes. In every reject case the row never lands in the table.
+ *
+ * Secret-shaped test literals are fragmented with string concatenation so the
+ * contiguous shape never appears in source.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DisclosureRejectedError } from '@qmd-team-intent-kb/common';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { CandidateRepository } from '../repositories/candidate-repository.js';
+import { EnumConstraintViolationError } from '../repositories/enum-membership.js';
+import { makeCandidate } from './fixtures.js';
+
+/**
+ * Build a structurally-valid candidate, then overwrite one enum-constrained field
+ * with an off-vocabulary value AFTER the Zod parse - exactly what a raw `insert()`
+ * caller that hand-built the object (skipping `MemoryCandidate.parse()`) would
+ * produce. The cast is the test's way of bypassing the type-level guard the same
+ * way an untyped/old-code-path caller bypasses it at runtime.
+ */
+function withRawEnumField(
+  field: 'status' | 'source' | 'category' | 'trustLevel',
+  rawValue: string,
+): { candidate: MemoryCandidate; contentHash: string } {
+  const { candidate, contentHash } = makeCandidate({
+    content: 'clean technical body',
+    title: 'clean title',
+  });
+  (candidate as Record<string, unknown>)[field] = rawValue;
+  return { candidate, contentHash };
+}
+
+describe('CandidateRepository.insert - enum-membership choke point', () => {
+  let db: Database.Database;
+  let repo: CandidateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new CandidateRepository(db);
+  });
+
+  // ---------------------------------------------------------------------------
+  // The headline regression: an SSN-shaped value smuggled into `category` (a field
+  // the disclosure scan SKIPS) must be rejected, and the row never written.
+  // ---------------------------------------------------------------------------
+
+  it('rejects a raw insert with an SSN-shaped category and never writes the row', () => {
+    const { candidate, contentHash } = withRawEnumField('category', '123-45-' + '6789');
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    // SSN-shaped -> routed through the disclosure scan -> caught as PII.
+    expect(err).toBeInstanceOf(DisclosureRejectedError);
+    expect((err as DisclosureRejectedError).category).toBe('pii');
+    expect(repo.count()).toBe(0);
+    expect(repo.findById(candidate.id)).toBeNull();
+  });
+
+  it('rejects a compensation-shaped value smuggled into category (caught as compensation)', () => {
+    const { candidate, contentHash } = withRawEnumField('category', 'his base salary leaked');
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(DisclosureRejectedError);
+    expect((err as DisclosureRejectedError).category).toBe('compensation');
+    expect(repo.count()).toBe(0);
+  });
+
+  it('rejects a credential / secret smuggled into source (caught as secret)', () => {
+    const { candidate, contentHash } = withRawEnumField(
+      'source',
+      'ghp_' + '1234567890abcdefghijklmnopqrstuvwxyz12',
+    );
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(DisclosureRejectedError);
+    expect((err as DisclosureRejectedError).category).toBe('secret');
+    expect(repo.count()).toBe(0);
+  });
+
+  it('rejects an off-vocabulary trustLevel that is NOT disclosure-shaped (EnumConstraintViolationError)', () => {
+    const { candidate, contentHash } = withRawEnumField('trustLevel', 'super-trusted');
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(EnumConstraintViolationError);
+    expect((err as EnumConstraintViolationError).field).toBe('trustLevel');
+    expect(repo.count()).toBe(0);
+    expect(repo.findById(candidate.id)).toBeNull();
+  });
+
+  it('rejects an off-vocabulary status that is NOT disclosure-shaped (EnumConstraintViolationError)', () => {
+    const { candidate, contentHash } = withRawEnumField('status', 'promoted');
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(EnumConstraintViolationError);
+    expect((err as EnumConstraintViolationError).field).toBe('status');
+    expect(repo.count()).toBe(0);
+  });
+
+  it('rejects an SSN-shaped author.type and never writes the row', () => {
+    const { candidate, contentHash } = makeCandidate({
+      content: 'clean technical body',
+      title: 'clean title',
+      author: { type: 'human', id: 'u-1' },
+    });
+    (candidate.author as Record<string, unknown>).type = '123-45-' + '6789';
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(DisclosureRejectedError);
+    expect((err as DisclosureRejectedError).category).toBe('pii');
+    expect(repo.count()).toBe(0);
+  });
+
+  it('rejects an off-vocabulary metadata.sensitivity that is NOT disclosure-shaped', () => {
+    const { candidate, contentHash } = makeCandidate({
+      content: 'clean technical body',
+      title: 'clean title',
+      metadata: { filePaths: [], tags: [], sensitivity: 'internal' },
+    });
+    (candidate.metadata as Record<string, unknown>).sensitivity = 'ultra-secret-clearance';
+    let err: unknown;
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(EnumConstraintViolationError);
+    expect((err as EnumConstraintViolationError).field).toBe('metadata.sensitivity');
+    expect(repo.count()).toBe(0);
+  });
+
+  it('does NOT echo the smuggled value in the EnumConstraintViolationError message (non-leak)', () => {
+    const { candidate, contentHash } = withRawEnumField('trustLevel', 'leak-marker-zzz');
+    let message = '';
+    try {
+      repo.insert(candidate, contentHash);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toContain('leak-marker-zzz');
+  });
+
+  // ---------------------------------------------------------------------------
+  // No false positives: a VALID enum value stays skipped and passes unchanged,
+  // including a present-but-valid optional metadata enum.
+  // ---------------------------------------------------------------------------
+
+  it('allows a candidate whose enum fields all hold valid vocabulary values', () => {
+    const { candidate, contentHash } = makeCandidate({
+      content: 'always return Result<T, E> from the kernel for fallible ops',
+      title: 'clean title',
+      category: 'convention',
+      trustLevel: 'high',
+      source: 'manual',
+      author: { type: 'human', id: 'jeremy' },
+      metadata: {
+        filePaths: [],
+        tags: [],
+        confidence: 'high',
+        sensitivity: 'internal',
+      },
+    });
+    expect(() => repo.insert(candidate, contentHash)).not.toThrow();
+    expect(repo.count()).toBe(1);
+    expect(repo.findById(candidate.id)?.category).toBe('convention');
+  });
+
+  it('allows a candidate with the optional metadata enums absent', () => {
+    const { candidate, contentHash } = makeCandidate({
+      content: 'always return Result<T, E> from the kernel for fallible ops',
+      title: 'clean title',
+      metadata: { filePaths: [], tags: [] },
+    });
+    expect(() => repo.insert(candidate, contentHash)).not.toThrow();
+    expect(repo.count()).toBe(1);
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,6 +2,10 @@ export { createDatabase, createTestDatabase } from './database.js';
 export type { DatabaseOptions } from './database.js';
 export { TABLE_DDL } from './schema.js';
 export { CandidateRepository } from './repositories/candidate-repository.js';
+export {
+  assertEnumMembership,
+  EnumConstraintViolationError,
+} from './repositories/enum-membership.js';
 export { MemoryRepository } from './repositories/memory-repository.js';
 export { PolicyRepository } from './repositories/policy-repository.js';
 export { AuditRepository } from './repositories/audit-repository.js';

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type Database from 'better-sqlite3';
 import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { assertDisclosureClean } from '@qmd-team-intent-kb/common';
+import { assertEnumMembership } from './enum-membership.js';
 
 /**
  * Zod schema for the raw SQLite row returned by better-sqlite3.
@@ -154,12 +155,29 @@ export class CandidateRepository {
    * value. A violating candidate throws `DisclosureRejectedError` and is never
    * written.
    *
+   * **Enum-membership re-assertion (Epic 0 residual hardening).** The disclosure
+   * scan deliberately SKIPS the closed-vocabulary fields (`status`, `source`,
+   * `category`, `trustLevel`, `confidence`, `sensitivity`, `author.type`) - safe
+   * only while those fields actually hold a vocabulary member. A raw `insert()`
+   * caller that bypassed `MemoryCandidate.parse()` could otherwise smuggle an
+   * SSN / comp / secret-shaped value into an enum field and ride the skip into
+   * durable state. `assertEnumMembership` closes that gap here: an off-vocabulary
+   * value is rejected (routed through the disclosure scan first so a
+   * disclosure-shaped value is caught with its precise category); a valid enum
+   * value is left untouched.
+   *
    * @throws {DisclosureRejectedError} when content/title/tags contain disallowed
-   *   PII, compensation, or credential/secret material.
+   *   PII, compensation, or credential/secret material - or when a disclosure-shaped
+   *   value is smuggled into an enum-constrained field.
+   * @throws {EnumConstraintViolationError} when an enum-constrained field carries a
+   *   non-vocabulary value that is not itself disclosure-shaped.
    */
   insert(candidate: MemoryCandidate, contentHash: string, importBatchId?: string): void {
     // Choke-point enforcement: reject before the row is ever written.
     assertDisclosureClean(candidate);
+    // Re-assert closed-vocabulary membership so a raw caller cannot smuggle
+    // disclosure content through a field the disclosure scan skips by name.
+    assertEnumMembership(candidate);
     this.stmtInsert.run({
       id: candidate.id,
       status: candidate.status,

--- a/packages/store/src/repositories/enum-membership.ts
+++ b/packages/store/src/repositories/enum-membership.ts
@@ -1,0 +1,140 @@
+/**
+ * Enum-membership choke point - closed-vocabulary re-assertion at the repository
+ * layer (Epic 0 residual hardening, was compile-then-govern-c5k.5).
+ *
+ * ## Why this exists
+ *
+ * The disclosure gate ({@link assertDisclosureClean}) scans every persisted
+ * free-text surface but deliberately **skips** the enum-constrained fields listed
+ * in `ENUM_CONSTRAINED_FIELDS` (`status`, `source`, `category`, `trustLevel`,
+ * `confidence`, `sensitivity`, `author.type`). Skipping them is correct ONLY while
+ * those fields are guaranteed to hold a value from their closed vocabulary - a
+ * legitimate enum member (`convention`, `high`, `human`, ...) carries no PII /
+ * secret / comp surface, so scanning it would be a pure false-positive risk.
+ *
+ * That guarantee normally comes from `MemoryCandidate.parse()` at the boundary.
+ * But a **raw `CandidateRepository.insert()` caller** can hand-build a candidate
+ * object that never crossed a Zod parse and plant an arbitrary string under an
+ * enum-constrained field. Because the disclosure scan skips that field by name, an
+ * SSN-shaped / comp-shaped / secret-shaped value smuggled into `category` (or any
+ * other enum field) would sail straight through the gate and into durable state.
+ *
+ * This module closes that gap: it re-asserts enum membership at the same
+ * repository choke point. A value that is NOT in its field's closed vocabulary is
+ * never legitimate, so it is rejected - and first routed through the disclosure
+ * scan so a disclosure-shaped value is caught with its precise category. A VALID
+ * enum value is left untouched (no false positive), preserving the skip in
+ * {@link collectFreeTextFields}.
+ *
+ * Like {@link DisclosureRejectedError}, the error carries only the **field name** -
+ * never the rejected value - so a smuggled secret is never re-leaked into logs,
+ * responses, or the audit trail.
+ *
+ * @module enum-membership
+ */
+import {
+  MemorySource,
+  TrustLevel,
+  MemoryCategory,
+  CandidateStatus,
+  Confidence,
+  Sensitivity,
+  AuthorType,
+  type MemoryCandidate,
+} from '@qmd-team-intent-kb/schema';
+import { scanForDisclosure, DisclosureRejectedError } from '@qmd-team-intent-kb/common';
+import type { z } from 'zod';
+
+/**
+ * Error thrown by the repository-layer choke point when an enum-constrained field
+ * carries a value outside its closed vocabulary. Carries only the field name -
+ * never the rejected value - mirroring {@link DisclosureRejectedError}.
+ *
+ * This fires only when the off-vocabulary value is NOT itself disclosure-shaped:
+ * a disclosure-shaped value (SSN / comp / secret smuggled into an enum field) is
+ * caught one step earlier and rejected as {@link DisclosureRejectedError} so the
+ * precise category is surfaced.
+ */
+export class EnumConstraintViolationError extends Error {
+  readonly field: string;
+  constructor(field: string) {
+    // NOTE: message deliberately omits the rejected value (non-leak).
+    super(
+      `Candidate rejected: field '${field}' carries a value outside its closed vocabulary and cannot enter the governed brain.`,
+    );
+    this.name = 'EnumConstraintViolationError';
+    this.field = field;
+  }
+}
+
+/**
+ * One enum-constrained field to re-assert: its dotted name (for the error) paired
+ * with the Zod schema that defines its closed vocabulary and the candidate value.
+ */
+interface EnumCheck {
+  readonly field: string;
+  readonly schema: z.ZodTypeAny;
+  readonly value: unknown;
+}
+
+/**
+ * Re-assert closed-vocabulary membership for every enum-constrained field of a
+ * candidate, or throw.
+ *
+ * For each field whose value is present, run the field's Zod enum `.safeParse`. A
+ * value in-vocabulary passes silently (and remains correctly skipped by the
+ * disclosure scan). A value out-of-vocabulary is never legitimate, so it is:
+ *
+ *   1. routed through {@link scanForDisclosure} - if it is disclosure-shaped
+ *      (SSN / comp / secret), a {@link DisclosureRejectedError} is thrown carrying
+ *      the precise category; then
+ *   2. otherwise rejected as {@link EnumConstraintViolationError} carrying only the
+ *      field name.
+ *
+ * Optional fields (`metadata.confidence`, `metadata.sensitivity`) are checked only
+ * when present - an absent optional is not a violation.
+ *
+ * Fail-closed and value-non-leaking. Called by `CandidateRepository.insert()`
+ * immediately after the disclosure gate and before the row is written.
+ *
+ * @throws {DisclosureRejectedError} when an off-vocabulary value is disclosure-shaped.
+ * @throws {EnumConstraintViolationError} when an off-vocabulary value is otherwise invalid.
+ */
+export function assertEnumMembership(candidate: MemoryCandidate): void {
+  const checks: EnumCheck[] = [
+    { field: 'status', schema: CandidateStatus, value: candidate.status },
+    { field: 'source', schema: MemorySource, value: candidate.source },
+    { field: 'category', schema: MemoryCategory, value: candidate.category },
+    { field: 'trustLevel', schema: TrustLevel, value: candidate.trustLevel },
+    { field: 'author.type', schema: AuthorType, value: candidate.author?.type },
+    {
+      field: 'metadata.confidence',
+      schema: Confidence,
+      value: candidate.metadata?.confidence,
+    },
+    {
+      field: 'metadata.sensitivity',
+      schema: Sensitivity,
+      value: candidate.metadata?.sensitivity,
+    },
+  ];
+
+  for (const { field, schema, value } of checks) {
+    // Absent optional enum (confidence / sensitivity) is not a violation.
+    if (value === undefined) continue;
+
+    if (schema.safeParse(value).success) continue;
+
+    // Off-vocabulary. If a string, route it through the disclosure scan first so a
+    // disclosure-shaped value smuggled into an enum field is caught with its real
+    // category instead of the generic enum error.
+    if (typeof value === 'string') {
+      const violation = scanForDisclosure(value);
+      if (violation !== null) {
+        throw new DisclosureRejectedError(violation.category);
+      }
+    }
+
+    throw new EnumConstraintViolationError(field);
+  }
+}


### PR DESCRIPTION
## EPIC 0/1 residual hardening

Four defense-in-depth follow-ups closing out the residual hardening tail of the governed-second-brain EPIC 0/1 work. Each commit is one self-contained gate, no behavior change in the happy path — these are choke-point assertions and regression proofs.

Tracks **intent-solutions-io/governed-second-brain#1**.

### What lands

| Commit | What it does | Bead |
|---|---|---|
| `e3cd792` | **Enum-membership scan** — re-assert enum-field membership at the store/repository choke point so a raw `insert()` caller cannot smuggle disclosure content (SSN-shaped values) through a closed-vocab field (`status`/`source`/`category`/`trustLevel`/`sensitivity`/`type`) that the free-text disclosure scan skips by name. Unreachable in production today (curator + spool-intake hardcode from closed vocab); this closes the door for any future raw caller. | `compile-then-govern-c5k.5` |
| `0c0b23f` | **Same-content dedup regression test** — permanent test proving the policy `dedup_check` fires on same-content rows carrying different ids, so content-hash dedup cannot be silently shadowed at the merge gate. | `compile-then-govern-8da.11` |
| `2f459a4` | **Gate-entry id invariant** — fail loud at the merge gate when an input memory id is not content-derived, so cross-clone dedup cannot silently degrade. | `compile-then-govern-8da.12` |
| `99f3e76` | **N-way merge proof** — N-way merge fold entrypoint plus a commutativity/associativity proof (fold of 3+ clones) before relying on multi-clone merges in production. | `compile-then-govern-8da.13` |

### Residual beads

Under epic **`compile-then-govern-8da`** (*Evaluate Dolt as the governed-second-brain substrate*):

- `compile-then-govern-8da.11` — Add a permanent same-content/different-id regression test to `merge-gate.test.ts` so the policy content-hash dedup cannot be silently shadowed
- `compile-then-govern-8da.12` — Assert at merge-gate entry that input memory ids are content-derived so cross-clone dedup cannot silently degrade
- `compile-then-govern-8da.13` — Exercise N-way merge associativity and commutativity (fold of 3+ clones) before relying on multi-clone merges in production

Plus, under epic `compile-then-govern-c5k` (*Harden the single-user governed brain before any teammate logs in*):

- `compile-then-govern-c5k.5` — Re-assert enum-field membership at the repository layer so a raw insert caller cannot smuggle disclosure content through a closed-vocab field

### Scope / non-goals

Defense-in-depth only — every path hardened here is unreachable from the production import pipeline today. No happy-path behavior change. Draft pending review of the gate assertions and the merge-fold proof.

- Jeremy Longshore
intentsolutions.io
