### PR TITLE
test(uuid): cross-repo namespace drift guard (8da.10)

### DIFF
--- a/packages/common/src/__tests__/uuid-v5.test.ts
+++ b/packages/common/src/__tests__/uuid-v5.test.ts
@@ -87,6 +87,20 @@ describe('deriveCandidateId', () => {
     expect(a).toMatch(UUID_RE);
   });
 
+  it("matches ICO's locked golden vector (cross-repo drift guard, bead 8da.10)", () => {
+    // The SAME (workspaceId, relPath, bodySha256) triple ICO pins in its own
+    // packages/kernel/src/uuid.test.ts must derive the SAME id here. ICO uses
+    // SHA_A = '0123456789abcdef' repeated 4x (64 hex chars). If either repo's
+    // namespace or NUL-delimited name composition drifts, this assertion fails:
+    // the cross-repo dedup key and the audit-chain candidateId link would
+    // otherwise diverge silently. This is the INTKB half of the drift guard;
+    // ICO pins the same vector independently, so a drift in either repo is caught.
+    const SHA_A = '0123456789abcdef'.repeat(4);
+    expect(deriveCandidateId('my-workspace', 'wiki/concepts/foo.md', SHA_A)).toBe(
+      'e0e430cb-ede6-53ae-8bd0-1edc3b945c6f',
+    );
+  });
+
   it('uses a NUL-delimited name tuple byte-identical to ICO buildCandidate', () => {
     // ICO composes `${workspaceId}\x00${relPath}\x00${bodySha256}`.
     const nul = String.fromCharCode(0);


### PR DESCRIPTION
Closes the 8da.10 drift-guard gap. ICO pins the content-derived UUID golden vector (e0e430cb...) for a known (workspaceId, relPath, bodySha256) triple in packages/kernel/src/uuid.test.ts. INTKB derived the same value but only tested internal consistency, never the cross-repo anchor - so an INTKB-side namespace or name-composition drift would pass its own tests. This adds the SAME golden-vector assertion on the INTKB side, so a drift in EITHER repo fails its own test. Verified locally: the assertion passes (no current drift); 16/16 common tests green. Refs intent-solutions-io/governed-second-brain#1, bead compile-then-govern-8da.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case for UUID derivation functionality to ensure deterministic behavior and maintain cross-system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->