### PR TITLE
docs(ops): brain API tailnet deploy runbook (650.5 verified live)

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -50,6 +50,7 @@
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
 - `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)
+- `040-OD-OPSM-brain-api-tailnet-deploy.md` — brain API tailnet deploy runbook (systemd --user service, token management, team-mode client, verify, hardening gaps)
 
 ### AA — After Action & Review
 
@@ -71,45 +72,46 @@
 
 ## Chronological Listing
 
-| #   | Code    | File                                | Description                    |
-| --- | ------- | ----------------------------------- | ------------------------------ |
-| 000 | PP-PLAN | mega-blueprint                      | Canonical project blueprint    |
-| 001 | AT-ARCH | repo-blueprint                      | Repository structure           |
-| 002 | AT-ARCH | architecture-overview               | System architecture            |
-| 003 | AT-DSGN | system-thesis                       | Design rationale               |
-| 004 | PP-RMAP | phase-plan                          | Implementation roadmap         |
-| 005 | TQ-TEST | testing-ci-strategy                 | Testing and CI                 |
-| 006 | TQ-SECU | security-governance                 | Security and threats           |
-| 007 | AT-DSGN | data-model-draft                    | Domain model                   |
-| 008 | OD-RELS | release-versioning-policy           | Release policy                 |
-| 009 | DR-GUID | contribution-workflow               | Contributor guide              |
-| 010 | WA-WFLW | internal-claude-operations          | Claude workflows               |
-| 011 | PM-RISK | risk-register                       | Risk tracking                  |
-| 012 | AA-AACR | initial-aar                         | Phase 0 AAR                    |
-| 013 | AA-AACR | phase1-schema                       | Phase 1 AAR                    |
-| 014 | AA-AACR | phase2-runtime                      | Phase 2 AAR                    |
-| 015 | AA-AACR | phase3-adapter                      | Phase 3 AAR                    |
-| 016 | OD-OPSM | branch-protection-checklist         | Branch protection setup        |
-| 017 | AA-AACR | phase4-api                          | Phase 4 AAR                    |
-| 018 | AA-AACR | phase5-curator                      | Phase 5 AAR                    |
-| 019 | AA-AACR | phase6-exporter                     | Phase 6 AAR                    |
-| 020 | OD-RELS | v1-release-checklist                | v1 release checklist           |
-| 021 | AA-AACR | phase7-reporting                    | Phase 7 AAR                    |
-| 022 | AA-AACR | phase8-security                     | Phase 8 AAR                    |
-| 023 | AA-AACR | phase9-release-readiness            | Phase 9 AAR                    |
-| 024 | PP-CLOS | v1-scope-closeout                   | v1 scope closeout              |
-| 025 | AA-AACR | v0.3.0-release-report               | v0.3.0 release report          |
-| 026 | AT-DSGN | repo-resolver-design                | repo-resolver package design   |
-| 027 | OD-OPSM | edge-daemon-runbook                 | edge-daemon operations runbook |
-| 028 | OD-SECU | release-signing                     | Release supply-chain signing   |
-| 029 | OD-RELS | npm-publishing-strategy             | npm publishing strategy        |
-| 030 | DR-GUID | import-conversion-recipes           | Import from various sources    |
-| 031 | AA-AACR | v0.6.0-release-aar                  | v0.6.0 release report          |
-| 034 | AT-NTRP | ecosystem-thesis                    | Compile, Then Govern thesis    |
-| 035 | AT-DECR | post-thesis-build-direction         | Post-thesis council decision   |
-| 036 | AT-THRT | spool-boundary-threat-model         | Spool boundary threat model    |
-| 037 | AT-DSGN | qmd-adapter-source-index-separation | qmd-adapter source/index ADR   |
-| 038 | AT-DECR | retrieval-backend-decision          | Retrieval backend decision     |
-| 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0   | v0.7.0 release report          |
+| #   | Code    | File                                | Description                      |
+| --- | ------- | ----------------------------------- | -------------------------------- |
+| 000 | PP-PLAN | mega-blueprint                      | Canonical project blueprint      |
+| 001 | AT-ARCH | repo-blueprint                      | Repository structure             |
+| 002 | AT-ARCH | architecture-overview               | System architecture              |
+| 003 | AT-DSGN | system-thesis                       | Design rationale                 |
+| 004 | PP-RMAP | phase-plan                          | Implementation roadmap           |
+| 005 | TQ-TEST | testing-ci-strategy                 | Testing and CI                   |
+| 006 | TQ-SECU | security-governance                 | Security and threats             |
+| 007 | AT-DSGN | data-model-draft                    | Domain model                     |
+| 008 | OD-RELS | release-versioning-policy           | Release policy                   |
+| 009 | DR-GUID | contribution-workflow               | Contributor guide                |
+| 010 | WA-WFLW | internal-claude-operations          | Claude workflows                 |
+| 011 | PM-RISK | risk-register                       | Risk tracking                    |
+| 012 | AA-AACR | initial-aar                         | Phase 0 AAR                      |
+| 013 | AA-AACR | phase1-schema                       | Phase 1 AAR                      |
+| 014 | AA-AACR | phase2-runtime                      | Phase 2 AAR                      |
+| 015 | AA-AACR | phase3-adapter                      | Phase 3 AAR                      |
+| 016 | OD-OPSM | branch-protection-checklist         | Branch protection setup          |
+| 017 | AA-AACR | phase4-api                          | Phase 4 AAR                      |
+| 018 | AA-AACR | phase5-curator                      | Phase 5 AAR                      |
+| 019 | AA-AACR | phase6-exporter                     | Phase 6 AAR                      |
+| 020 | OD-RELS | v1-release-checklist                | v1 release checklist             |
+| 021 | AA-AACR | phase7-reporting                    | Phase 7 AAR                      |
+| 022 | AA-AACR | phase8-security                     | Phase 8 AAR                      |
+| 023 | AA-AACR | phase9-release-readiness            | Phase 9 AAR                      |
+| 024 | PP-CLOS | v1-scope-closeout                   | v1 scope closeout                |
+| 025 | AA-AACR | v0.3.0-release-report               | v0.3.0 release report            |
+| 026 | AT-DSGN | repo-resolver-design                | repo-resolver package design     |
+| 027 | OD-OPSM | edge-daemon-runbook                 | edge-daemon operations runbook   |
+| 028 | OD-SECU | release-signing                     | Release supply-chain signing     |
+| 029 | OD-RELS | npm-publishing-strategy             | npm publishing strategy          |
+| 030 | DR-GUID | import-conversion-recipes           | Import from various sources      |
+| 031 | AA-AACR | v0.6.0-release-aar                  | v0.6.0 release report            |
+| 034 | AT-NTRP | ecosystem-thesis                    | Compile, Then Govern thesis      |
+| 035 | AT-DECR | post-thesis-build-direction         | Post-thesis council decision     |
+| 036 | AT-THRT | spool-boundary-threat-model         | Spool boundary threat model      |
+| 037 | AT-DSGN | qmd-adapter-source-index-separation | qmd-adapter source/index ADR     |
+| 038 | AT-DECR | retrieval-backend-decision          | Retrieval backend decision       |
+| 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0   | v0.7.0 release report            |
+| 040 | OD-OPSM | brain-api-tailnet-deploy            | Brain API tailnet deploy runbook |
 
-## Next Available Sequence: 040
+## Next Available Sequence: 041

--- a/000-docs/040-OD-OPSM-brain-api-tailnet-deploy.md
+++ b/000-docs/040-OD-OPSM-brain-api-tailnet-deploy.md
@@ -115,8 +115,9 @@ query is the final confirmation.)
   The plaintext bearer secrets sit in `~/.teamkb/tokens.json` and any backup of `~/.teamkb`.
   Re-seed with `hashToken()` output (§4) or SOPS-encrypt the file.
 - **No token expiry/rotation** (`expiresAt: null`); the registry supports it — set one.
-- **`/healthz` requires auth**, so a tailnet uptime probe can't hit it anonymously — add an
-  unauthenticated health route.
+- **Liveness probe:** `/api/health` is **already exempt from auth** (`apps/api/src/middleware/api-key-auth.ts`
+  — `/api/health`, `/openapi.json`, `/docs*` are always public), so a tailnet uptime probe hits it
+  anonymously; every other route still requires the bearer token. (Not a gap — point probes at `/api/health`.)
 - **Soak host:** runs on the dev box (which also runs Claude sessions + has OOM history); migrate to
   a dedicated tailnet VM once load-bearing (D27).
 

--- a/000-docs/040-OD-OPSM-brain-api-tailnet-deploy.md
+++ b/000-docs/040-OD-OPSM-brain-api-tailnet-deploy.md
@@ -1,0 +1,127 @@
+# Runbook — the governed brain API on the tailnet team-server
+
+| Field       | Value                                                             |
+| ----------- | ----------------------------------------------------------------- |
+| **Code**    | `040-OD-OPSM`                                                     |
+| **Type**    | Operations runbook                                                |
+| **Date**    | 2026-06-21                                                        |
+| **Service** | `teamkb-brain-api.service` (systemd **--user**)                   |
+| **Bead**    | `compile-then-govern-650.5` (deploy, closed) · hardening: `650.6` |
+
+The deployed, tailnet-only query surface of the governed brain (`apps/api`). This is the **D27
+single remote brain**: one token-authenticated host that the team reaches over Tailscale. It runs
+on the **team-server (the dev box)** for the soak — **not the VPS** (D27, D17 blast radius) — and
+migrates to a dedicated tailnet VM once load-bearing (`650.6`).
+
+## 1. What runs, and where
+
+- **Host:** the dev box, on the tailnet as `team-server` / `dev` (`tailscale ip -4`).
+- **Bind:** the tailnet IP only, port **3847** (`TEAMKB_API_HOST=<tailnet-ip>`) — never `0.0.0.0`,
+  never public. Reachable only by tailnet peers.
+- **Brain:** `~/.teamkb/teamkb.db` (tenant `intent-solutions`), qmd export `~/.teamkb/kb-export`.
+- **Auth:** every route requires `Authorization: Bearer <token>`; no token → `401`.
+
+## 2. The service
+
+systemd **user** unit (persists across logout/reboot because `loginctl enable-linger jeremy` is on
+and the unit is `WantedBy=default.target`). It is ordered after `tailscaled` so it binds the tailnet
+IP only once the interface is up.
+
+```ini
+# ~/.config/systemd/user/teamkb-brain-api.service  (abridged)
+[Unit]
+After=network-online.target tailscaled.service
+[Service]
+WorkingDirectory=/home/jeremy/000-projects/qmd-team-intent-kb
+ExecStart=/usr/bin/node apps/api/dist/main.js
+Environment=TEAMKB_API_HOST=<tailnet-ip>   TEAMKB_API_PORT=3847
+Environment=TEAMKB_DB_PATH=/home/jeremy/.teamkb/teamkb.db
+Environment=TEAMKB_TENANT_ID=intent-solutions
+Environment=TEAMKB_EXPORT_DIR=/home/jeremy/.teamkb/kb-export
+Environment=TEAMKB_TOKENS_FILE=/home/jeremy/.teamkb/tokens.json
+Environment=NODE_ENV=production
+Restart=on-failure
+[Install]
+WantedBy=default.target
+```
+
+After a code change: `pnpm -F @qmd-team-intent-kb/api build` then restart (below). The unit runs the
+built `apps/api/dist/main.js`, not `tsx`.
+
+## 3. Operate it
+
+```bash
+systemctl --user status  teamkb-brain-api.service     # state
+systemctl --user restart teamkb-brain-api.service     # apply a rebuild / token change
+systemctl --user stop    teamkb-brain-api.service     # take it down
+journalctl --user -u teamkb-brain-api.service -n 50 --no-pager   # logs (JSON lines)
+```
+
+## 4. Tokens (add / rotate a teammate)
+
+Tokens live in `~/.teamkb/tokens.json` (mode 600) — a JSON array of records:
+
+```json
+[
+  { "actor": "jeremy", "role": "admin", "tenants": null, "expiresAt": null },
+  { "actor": "ope", "role": "member", "tenants": null, "expiresAt": null }
+]
+```
+
+Each record's `token` field is the bearer secret. The registry accepts **either** a plaintext
+secret (hashed with scrypt on load) **or** a pre-hashed `scrypt$<salt>$<hash>` form
+(`hashToken()` in `apps/api/src/auth/token-registry.ts`). To add a teammate:
+
+1. Generate a random secret (e.g. `openssl rand -hex 24`).
+2. Add a record. **Prefer the pre-hashed form** — `node -e 'import("./apps/api/dist/auth/token-registry.js").then(m=>console.log(m.hashToken(process.argv[1])))' <secret>` — so no plaintext bearer token rests on disk (see §7).
+3. `systemctl --user restart teamkb-brain-api.service`.
+4. Hand the **plaintext** secret to the teammate over a secure channel — never in chat, commits, or
+   this repo. `role: member` = read + propose; `admin` = promote/govern. `tenants: ["intent-os"]`
+   scopes a token to one tenant; `null` = all.
+
+## 5. Clients — team mode
+
+The unified `governed-second-brain` plugin auto-selects **team mode** when `TEAMKB_API_URL` is set
+(otherwise it runs the local in-process brain). A teammate points it at this server:
+
+```bash
+TEAMKB_API_URL=http://<tailnet-ip>:3847
+TEAMKB_API_TOKEN=<their bearer secret>
+```
+
+Team mode exposes the unified `brain_search` (read); capture/govern stay governed server-side.
+
+## 6. Verify
+
+```bash
+# no token → 401 (gate is on)
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://<tailnet-ip>:3847/api/search \
+  -H 'content-type: application/json' -d '{"query":"x"}'        # → 401
+
+# with a token → cited hits from the brain
+curl -s -H "Authorization: Bearer <secret>" -X POST http://<tailnet-ip>:3847/api/search \
+  -H 'content-type: application/json' \
+  -d '{"query":"system map","pagination":{"page":1,"pageSize":3}}'   # → {"hits":[{"citation":"qmd://...
+```
+
+Verified 2026-06-21 against a same-artifact ephemeral instance: authed `/api/search` returns
+`qmd://`-cited hits, and the unified plugin in team mode proxies to the API and returns the same
+cited shape. (Functional path proven without mutating the live service; a real teammate's authed
+query is the final confirmation.)
+
+## 7. Known gaps / follow-ons (`compile-then-govern-650.6`)
+
+- **Tokens are stored plaintext on disk** today (`tokens.json` records are not `scrypt$`-prefixed).
+  The plaintext bearer secrets sit in `~/.teamkb/tokens.json` and any backup of `~/.teamkb`.
+  Re-seed with `hashToken()` output (§4) or SOPS-encrypt the file.
+- **No token expiry/rotation** (`expiresAt: null`); the registry supports it — set one.
+- **`/healthz` requires auth**, so a tailnet uptime probe can't hit it anonymously — add an
+  unauthenticated health route.
+- **Soak host:** runs on the dev box (which also runs Claude sessions + has OOM history); migrate to
+  a dedicated tailnet VM once load-bearing (D27).
+
+## 8. References
+
+- D27 (single remote brain, not the VPS): `intent-os decision-log/004-…`.
+- The unified plugin (local | team): `governed-second-brain-plugin`; decision `intent-os/000-docs/014-AT-DECR-…`.
+- The dogfood proof: `intent-os/000-docs/015-AA-AACR-…`.


### PR DESCRIPTION
## What

Operations runbook for the deployed governed brain API (`apps/api`) — `000-docs/040-OD-OPSM-brain-api-tailnet-deploy.md`.

The API is **deployed and live** as the D27 single remote brain: a `systemd --user` service (`teamkb-brain-api.service`, ordered after `tailscaled`, `Restart=on-failure`, persisted via linger) bound to the **tailnet IP** on the team-server (the dev box — **not** the VPS, per D27), serving `~/.teamkb` over bearer auth. The bead said "built, not deployed" — it's the latest stale-plan-vs-reality; this documents the running deployment.

Covers: what runs & where, the unit + env, operate (restart/logs), token management (add/rotate a teammate), team-mode client wiring (the unified plugin's `TEAMKB_API_URL`), verify steps, and the known hardening gaps.

## Verified this session (functional, not just listening)

Against a same-artifact **ephemeral** instance (zero production mutation):
- authed `/api/search` → `qmd://kb-curated/…` cited hits;
- no token → `401`;
- the unified plugin in **team mode** → the deployed API → `source=brain-api`, `qmd://` citation over the proxy (the U2 path).

## Hardening flagged (`compile-then-govern-650.6`)

- **`tokens.json` stores bearer secrets in plaintext on disk** (records aren't `scrypt$`-prefixed) — re-seed pre-hashed or SOPS-encrypt.
- No token expiry (`expiresAt: null`); `/healthz` requires auth; soak host is the dev box (migrate to a dedicated tailnet VM when load-bearing).

## Tracking

Documents deploy bead `compile-then-govern-650.5` (closed). Filed `OD-OPSM` to match the existing `027-OD-OPSM-edge-daemon-runbook`.

- Jeremy Longshore
intentsolutions.io