### PR TITLE
feat(store): byte-pinned exception manifest + 3-state audit-break classifier (e06.2)

### DIFF
--- a/apps/curator/src/__tests__/cli.test.ts
+++ b/apps/curator/src/__tests__/cli.test.ts
@@ -361,3 +361,150 @@ describe('dispatch usage — verify-audit-chain in help', () => {
     expect(stdoutText()).toMatch(/verify-audit-chain/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// generate-exception-manifest subcommand (bead compile-then-govern-e06.2;
+// 010-AT-RISK R1/R2/R7). The generator pins each tamper-reason break's current
+// stored tuple into a byte-pinned manifest, refusing to overwrite without
+// --force.
+// ---------------------------------------------------------------------------
+
+describe('dispatch generate-exception-manifest', () => {
+  /** Seed a chain, then tamper one row's content to produce a persistent break. */
+  function seedTamperedDb(): {
+    db: ReturnType<typeof createTestDatabase>;
+    tamperedId: string;
+  } {
+    const db = createTestDatabase();
+    const auditRepo = new AuditRepository(db);
+    const ids = [
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000002',
+      '00000000-0000-4000-8000-000000000003',
+    ];
+    for (let i = 0; i < ids.length; i++) {
+      auditRepo.insert({
+        id: ids[i]!,
+        action: 'promoted',
+        memoryId: '11111111-1111-4111-8111-111111111111',
+        tenantId: 'demo-e2e',
+        actor: { type: 'human', id: 'curator-1' },
+        reason: `original ${i}`,
+        details: {},
+        timestamp: `2026-05-29T08:0${i}:00.000Z`,
+      });
+    }
+    // Persistently tamper row 2 in the DB (stands in for a migration break row).
+    db.prepare(`UPDATE audit_events SET reason = 'MIGRATION_ARTIFACT' WHERE id = ?`).run(ids[1]);
+    return { db, tamperedId: ids[1]! };
+  }
+
+  it('exits 2 when --db is missing', async () => {
+    const rc = await dispatch(['generate-exception-manifest'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/missing required flag: --db/);
+  });
+
+  it('exits 2 on unknown flag', async () => {
+    const rc = await dispatch(['generate-exception-manifest', '--db', 'x', '--bogus'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/unknown flag: --bogus/);
+  });
+
+  it('lists the subcommand in help text', async () => {
+    const rc = await dispatch(['help'], testDeps);
+    expect(rc).toBe(0);
+    expect(stdoutText()).toMatch(/generate-exception-manifest/);
+  });
+
+  it('pins the current tuple of every tamper break and round-trips through readManifest', async () => {
+    const { db, tamperedId } = seedTamperedDb();
+    const outPath = join(spoolDir, 'exceptions.manifest.json');
+
+    // The CLI closes the db it was handed in its finally block, so we do the
+    // downstream classify against a FRESH identical db (v2 hashes are
+    // timestamp-independent and ids are fixed, so the two DBs are byte-equal).
+    const rc = await dispatch(
+      ['generate-exception-manifest', '--db', '/ignored', '--out', outPath, '--json'],
+      { createDb: () => db },
+    );
+    expect(rc).toBe(0);
+
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(true);
+    expect(parsed['entryCount']).toBe(1);
+    expect(typeof parsed['manifestHash']).toBe('string');
+    const breakdown = parsed['reasonBreakdown'] as Record<string, number>;
+    expect(breakdown['ENTRY_HASH_MISMATCH']).toBe(1);
+
+    // The written manifest loads + verifies (count-assert + hash re-check).
+    const { readManifest, verifyAuditChain, classifyChainBreaks } =
+      await import('@qmd-team-intent-kb/store');
+    const manifest = readManifest(outPath);
+    expect(manifest.entryCount).toBe(1);
+    expect(manifest.entries[0]!.id).toBe(tamperedId);
+
+    // And the manifest classifies the (byte-identical) live break as a
+    // documented exception — proving the generated manifest COVERS the break it
+    // was made for.
+    const fresh = seedTamperedDb();
+    const auditRepo = new AuditRepository(fresh.db);
+    const { breaks } = verifyAuditChain(auditRepo);
+    const rows = auditRepo.findAllChronological() as unknown as Array<{
+      id: string;
+      entry_hash: string | null;
+      prev_entry_hash: string | null;
+      hash_version: number | null;
+      seq: number | null;
+    }>;
+    const rowsById = new Map(
+      rows.map((r) => [
+        r.id,
+        {
+          entry_hash: r.entry_hash,
+          prev_entry_hash: r.prev_entry_hash,
+          hash_version: r.hash_version ?? 1,
+          seq: r.seq ?? 0,
+        },
+      ]),
+    );
+    const classified = classifyChainBreaks(breaks, manifest, rowsById);
+    expect(classified.documentedExceptions.map((b) => b.id)).toEqual([tamperedId]);
+    expect(classified.tamperSignatures).toHaveLength(0);
+    expect(classified.verified).toBe(true);
+    fresh.db.close();
+  });
+
+  it('refuses to overwrite an existing manifest without --force', async () => {
+    const { db } = seedTamperedDb();
+    const outPath = join(spoolDir, 'exceptions.manifest.json');
+    // Pre-create the file.
+    await writeFile(outPath, '{}', 'utf8');
+
+    const rc = await dispatch(
+      ['generate-exception-manifest', '--db', '/ignored', '--out', outPath, '--json'],
+      { createDb: () => db },
+    );
+    expect(rc).toBe(1);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(false);
+    expect(parsed['code']).toBe('MANIFEST_EXISTS');
+    db.close();
+  });
+
+  it('overwrites an existing manifest WITH --force', async () => {
+    const { db } = seedTamperedDb();
+    const outPath = join(spoolDir, 'exceptions.manifest.json');
+    await writeFile(outPath, '{}', 'utf8');
+
+    const rc = await dispatch(
+      ['generate-exception-manifest', '--db', '/ignored', '--out', outPath, '--force', '--json'],
+      { createDb: () => db },
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(true);
+    expect(parsed['entryCount']).toBe(1);
+    db.close();
+  });
+});

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -21,6 +21,8 @@
  * @module cli
  */
 
+import { existsSync, writeFileSync } from 'node:fs';
+
 import {
   CandidateRepository,
   MemoryRepository,
@@ -28,8 +30,14 @@ import {
   AuditRepository,
   MemoryLinksRepository,
   verifyAuditChain,
+  computeManifestHash,
 } from '@qmd-team-intent-kb/store';
-import type { createDatabase as CreateDatabase } from '@qmd-team-intent-kb/store';
+import type {
+  createDatabase as CreateDatabase,
+  ExceptionManifest,
+  ExceptionManifestEntry,
+  AuditChainRow,
+} from '@qmd-team-intent-kb/store';
 
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
@@ -39,8 +47,13 @@ import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
 // ---------------------------------------------------------------------------
 
 /** Database factory — production wires `createDatabase`; tests wire
- *  `createTestDatabase`. */
-export type DatabaseFactory = (options: { dbPath?: string }) => ReturnType<typeof CreateDatabase>;
+ *  `createTestDatabase`. `readonly` opens the DB without applying DDL /
+ *  migrations / permission changes (used by generate-exception-manifest so it
+ *  can never mutate a live brain). */
+export type DatabaseFactory = (options: {
+  dbPath?: string;
+  readonly?: boolean;
+}) => ReturnType<typeof CreateDatabase>;
 
 export interface CuratorCliDeps {
   /** Returns a connected Database instance. */
@@ -56,6 +69,12 @@ Subcommands:
   verify-audit-chain [--db <path>] [--json]
     Walk the audit_events hash chain and exit 2 if AUDIT_TAMPERED.
 
+  generate-exception-manifest --db <path> [--out <path>] [--force] [--brain-id <id>] [--json]
+    Open a teamkb.db READ-ONLY, verify the audit chain, and capture every
+    tamper-reason break's CURRENT stored tuple into a byte-pinned exception
+    manifest (010-AT-RISK R1/R2). Refuses to overwrite an existing manifest
+    without --force. Prints the entryCount + manifestHash.
+
   help | --help | -h
     Print this message.
 
@@ -69,6 +88,15 @@ Options for 'verify-audit-chain':
   --db <path>     SQLite path (required for any meaningful verify run;
                   an in-memory db is always empty).
   --json          Emit a structured AuditVerifyResult JSON envelope.
+
+Options for 'generate-exception-manifest':
+  --db <path>     SQLite path to read READ-ONLY (required). Never mutated.
+  --out <path>    Manifest output path. Default: <db-dir>/exceptions.manifest.json.
+  --force         Overwrite an existing manifest. Without it, an existing
+                  manifest is a hard error (the manifest is a one-time amnesty;
+                  regenerating silently would re-launder new breaks).
+  --brain-id <id> Optional brain identifier stamped into the manifest.
+  --json          Emit a structured JSON envelope in place of the summary.
 `;
 
 // ---------------------------------------------------------------------------
@@ -86,6 +114,8 @@ export async function dispatch(argv: string[], deps: CuratorCliDeps): Promise<nu
       return cmdIngest(argv.slice(1), deps);
     case 'verify-audit-chain':
       return cmdVerifyAuditChain(argv.slice(1), deps);
+    case 'generate-exception-manifest':
+      return cmdGenerateExceptionManifest(argv.slice(1), deps);
     case 'help':
     case '--help':
     case '-h':
@@ -380,6 +410,193 @@ async function cmdVerifyAuditChain(args: string[], deps: CuratorCliDeps): Promis
     );
     for (const b of forks) writeBreak(b);
     return 1;
+  } finally {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// generate-exception-manifest
+//
+// Capture every tamper-reason audit-chain break's CURRENT stored tuple into a
+// byte-pinned exception manifest (010-AT-RISK R1/R2/R7; 009-AT-DECR D5). The
+// manifest pins each exception by its exact per-row tuple so the classifier
+// can only honour it on a full byte-match — no index-range / date laundering.
+// ---------------------------------------------------------------------------
+
+interface GenManifestOpts {
+  dbPath: string;
+  outPath?: string;
+  brainId?: string;
+  force: boolean;
+  json: boolean;
+}
+
+function parseGenManifestArgs(
+  args: string[],
+): { ok: true; opts: GenManifestOpts } | { ok: false; message: string } {
+  let dbPath: string | undefined;
+  let outPath: string | undefined;
+  let brainId: string | undefined;
+  let force = false;
+  let json = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+    switch (arg) {
+      case '--db':
+        dbPath = args[i + 1];
+        i += 2;
+        break;
+      case '--out':
+        outPath = args[i + 1];
+        i += 2;
+        break;
+      case '--brain-id':
+        brainId = args[i + 1];
+        i += 2;
+        break;
+      case '--force':
+        force = true;
+        i += 1;
+        break;
+      case '--json':
+        json = true;
+        i += 1;
+        break;
+      default:
+        return { ok: false, message: `unknown flag: ${arg}` };
+    }
+  }
+
+  if (dbPath === undefined || dbPath.trim() === '') {
+    return { ok: false, message: 'missing required flag: --db <path>' };
+  }
+  return { ok: true, opts: { dbPath, outPath, brainId, force, json } };
+}
+
+/** Default manifest path sits beside the DB (an ops artifact, not a repo file). */
+function defaultManifestPath(dbPath: string): string {
+  const idx = Math.max(dbPath.lastIndexOf('/'), dbPath.lastIndexOf('\\'));
+  const dir = idx >= 0 ? dbPath.slice(0, idx) : '.';
+  return `${dir}/exceptions.manifest.json`;
+}
+
+/**
+ * The store's AuditChainRow interface does not declare `seq` (it is part of the
+ * ordering contract, not the hash), but `findAllChronological()` runs
+ * `SELECT *` so the column is present on the row object. We read it via this
+ * widened view — `seq` is load-bearing for the byte-pin.
+ */
+type ChainRowWithSeq = AuditChainRow & { seq: number | null };
+
+async function cmdGenerateExceptionManifest(args: string[], deps: CuratorCliDeps): Promise<number> {
+  const parsed = parseGenManifestArgs(args);
+  if (!parsed.ok) {
+    process.stderr.write(`curator-cli generate-exception-manifest: ${parsed.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const { dbPath, brainId, force, json } = parsed.opts;
+  const outPath = parsed.opts.outPath ?? defaultManifestPath(dbPath);
+
+  // Refuse to overwrite an existing manifest without --force: the manifest is a
+  // ONE-TIME amnesty. Regenerating silently would re-launder any breaks that
+  // appeared after the original amnesty (they'd be freshly pinned as
+  // "documented"). Force is an explicit operator override.
+  if (!force && existsSync(outPath)) {
+    const msg = `manifest already exists at ${outPath}; refusing to overwrite without --force`;
+    if (json) {
+      process.stdout.write(
+        JSON.stringify({ ok: false, error: msg, code: 'MANIFEST_EXISTS' }) + '\n',
+      );
+    } else {
+      process.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
+
+  // Open READ-ONLY — the generator must never mutate a live brain.
+  const db = deps.createDb({ dbPath, readonly: true });
+  try {
+    const auditRepo = new AuditRepository(db);
+    const result = verifyAuditChain(auditRepo);
+
+    // Index the current stored tuple of every row by id, so we can pin each
+    // break's exact { entry_hash, prev_entry_hash, hash_version, seq }.
+    const rows = auditRepo.findAllChronological() as ChainRowWithSeq[];
+    const byId = new Map<string, ChainRowWithSeq>();
+    for (const r of rows) byId.set(r.id, r);
+
+    const entries: ExceptionManifestEntry[] = [];
+    for (const brk of result.breaks) {
+      // Only tamper-reason breaks are pinned; a CHAIN_FORK is a non-tamper
+      // ordering artifact and is never granted amnesty.
+      if (brk.reason === 'CHAIN_FORK') continue;
+      const row = byId.get(brk.id);
+      if (row === undefined) continue; // defensive; a break always names a real row
+      entries.push({
+        id: row.id,
+        entryHash: row.entry_hash!, // a tamper-reason break implies a non-null stored hash
+        prevEntryHash: row.prev_entry_hash,
+        hashVersion: row.hash_version ?? 1,
+        seq: row.seq ?? 0,
+        reason: brk.reason,
+      });
+    }
+
+    const body = {
+      schemaVersion: 1 as const,
+      ...(brainId !== undefined ? { brainId } : {}),
+      generatedAt: new Date().toISOString(),
+      entryCount: entries.length,
+      entries,
+    };
+    const manifest: ExceptionManifest = { ...body, manifestHash: computeManifestHash(body) };
+
+    writeFileSync(outPath, JSON.stringify(manifest, null, 2) + '\n', { mode: 0o600 });
+
+    const forks = result.breaks.filter((b) => b.reason === 'CHAIN_FORK').length;
+    const reasonBreakdown: Record<string, number> = {};
+    for (const b of result.breaks) {
+      reasonBreakdown[b.reason] = (reasonBreakdown[b.reason] ?? 0) + 1;
+    }
+
+    if (json) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          out: outPath,
+          entryCount: manifest.entryCount,
+          manifestHash: manifest.manifestHash,
+          totalRows: result.totalRows,
+          unverifiedRows: result.unverifiedRows,
+          cleanRows: result.cleanRows,
+          forks,
+          reasonBreakdown,
+        }) + '\n',
+      );
+      return 0;
+    }
+
+    process.stdout.write(`Wrote exception manifest → ${outPath}\n`);
+    process.stdout.write(`entryCount:    ${manifest.entryCount}\n`);
+    process.stdout.write(`manifestHash:  ${manifest.manifestHash}\n`);
+    process.stdout.write(`Total rows:    ${result.totalRows}\n`);
+    process.stdout.write(`Clean rows:    ${result.cleanRows}\n`);
+    process.stdout.write(`Unverified:    ${result.unverifiedRows} (pre-migration)\n`);
+    if (forks > 0) {
+      process.stdout.write(`CHAIN_FORKs:   ${forks} (NOT pinned — non-tamper ordering artifact)\n`);
+    }
+    process.stdout.write(`Reason breakdown:\n`);
+    for (const [reason, count] of Object.entries(reasonBreakdown)) {
+      process.stdout.write(`  ${reason}: ${count}\n`);
+    }
+    return 0;
   } finally {
     try {
       (db as unknown as { close?: () => void }).close?.();

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -541,7 +541,10 @@ async function cmdGenerateExceptionManifest(args: string[], deps: CuratorCliDeps
       if (row === undefined) continue; // defensive; a break always names a real row
       entries.push({
         id: row.id,
-        entryHash: row.entry_hash!, // a tamper-reason break implies a non-null stored hash
+        // Pin the stored entry_hash AS-IS (nullable): a tamper-reason break can
+        // have a NULL stored hash, and the pin must capture that faithfully so a
+        // later null→value drift reads as tamper (no non-null assertion).
+        entryHash: row.entry_hash,
         prevEntryHash: row.prev_entry_hash,
         hashVersion: row.hash_version ?? 1,
         seq: row.seq ?? 0,

--- a/apps/curator/src/main.ts
+++ b/apps/curator/src/main.ts
@@ -19,8 +19,10 @@ import { dispatch } from './cli.js';
 
 async function main(): Promise<void> {
   const exitCode = await dispatch(process.argv.slice(2), {
-    createDb: ({ dbPath }) =>
-      dbPath !== undefined ? createDatabase({ path: dbPath }) : createTestDatabase(),
+    createDb: ({ dbPath, readonly }) =>
+      dbPath !== undefined
+        ? createDatabase({ path: dbPath, readonly: readonly ?? false })
+        : createTestDatabase(),
   });
   process.exit(exitCode);
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@qmd-team-intent-kb/common": "workspace:*",
     "@qmd-team-intent-kb/schema": "workspace:*",
-    "better-sqlite3": "^12.11.1"
+    "better-sqlite3": "^12.11.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/store/src/exception-manifest.test.ts
+++ b/packages/store/src/exception-manifest.test.ts
@@ -25,6 +25,7 @@ import {
   type ExceptionManifest,
   type ExceptionManifestEntry,
   type StoredRowTuple,
+  type TamperReason,
 } from './exception-manifest.js';
 import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
 
@@ -121,24 +122,27 @@ function rowsByIdOf(rows: AuditChainRow[]): Map<string, StoredRowTuple> {
   return m;
 }
 
+/** Narrowing predicate: a break carrying one of the three tamper reasons. */
+function isTamperBreak(b: AuditChainBreak): b is AuditChainBreak & { reason: TamperReason } {
+  return b.reason !== 'CHAIN_FORK';
+}
+
 /** Build a manifest that pins every tamper-reason break in the given breaks list. */
 function manifestFor(
   breaks: AuditChainBreak[],
   rowsById: Map<string, StoredRowTuple>,
 ): ExceptionManifest {
-  const entries: ExceptionManifestEntry[] = breaks
-    .filter((b) => b.reason !== 'CHAIN_FORK')
-    .map((b) => {
-      const stored = rowsById.get(b.id)!;
-      return {
-        id: b.id,
-        entryHash: stored.entry_hash!,
-        prevEntryHash: stored.prev_entry_hash,
-        hashVersion: stored.hash_version,
-        seq: stored.seq,
-        reason: b.reason,
-      };
-    });
+  const entries: ExceptionManifestEntry[] = breaks.filter(isTamperBreak).map((b) => {
+    const stored = rowsById.get(b.id)!;
+    return {
+      id: b.id,
+      entryHash: stored.entry_hash, // nullable pin — capture the stored hash as-is
+      prevEntryHash: stored.prev_entry_hash,
+      hashVersion: stored.hash_version,
+      seq: stored.seq,
+      reason: b.reason,
+    };
+  });
   const body = {
     schemaVersion: 1 as const,
     generatedAt: '2026-06-30T00:00:00.000Z',
@@ -290,6 +294,92 @@ describe('classifyChainBreaks — ADVERSARIAL no-laundering (R1)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// (b2) NULL stored entry_hash — the nullable-pin case (Gemini review finding 1)
+//
+// A tamper-reason break CAN carry a null stored entry_hash (a row whose hash
+// column was cleared). The pin must capture that null so it byte-matches, AND
+// the anti-laundering guarantee must still hold for the null case: a
+// null->forged-hash drift flips it to tamper.
+// ---------------------------------------------------------------------------
+
+describe('classifyChainBreaks — null stored entry_hash', () => {
+  /**
+   * Build a 3-row v2 chain then a break row whose stored entry_hash is NULL but
+   * whose prev_entry_hash is the real prior head — so the verifier reports a
+   * tamper reason (not a pre-migration unverified row, which needs BOTH null),
+   * and the stored entry_hash the classifier reads is null.
+   */
+  function chainWithNullHashBreak(): { rows: AuditChainRow[]; breakId: string } {
+    const rows: AuditChainRow[] = [];
+    let prev: string | null = null;
+    for (let i = 0; i < 3; i++) {
+      const r = v2Row(i, prev);
+      rows.push(r);
+      prev = r.entry_hash;
+    }
+    const breakId = 'id-nullhash';
+    rows.push({
+      id: breakId,
+      action: 'promoted',
+      memory_id: 'mem-nullhash',
+      tenant_id: 'local',
+      actor_json: '{"type":"ai","id":"curator"}',
+      reason: 'rnull',
+      details_json: '{}',
+      timestamp: '2026-06-17T00:00:09.000Z',
+      hash_version: 2,
+      prev_entry_hash: prev, // real prior head → not a pre-migration row
+      entry_hash: null, // the stored hash is NULL
+    });
+    return { rows, breakId };
+  }
+
+  it('a documented break whose pinned entryHash is NULL classifies as documentedException', () => {
+    const { rows, breakId } = chainWithNullHashBreak();
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+
+    // Sanity: the break exists, is a tamper reason, and its stored hash is null.
+    const brk = breaks.find((b) => b.id === breakId)!;
+    expect(brk).toBeDefined();
+    expect(brk.reason).not.toBe('CHAIN_FORK');
+    expect(rowsById.get(breakId)!.entry_hash).toBeNull();
+
+    // Pin it (nullable) and classify → documented, verified true.
+    const manifest = manifestFor(breaks, rowsById);
+    expect(manifest.entries.find((e) => e.id === breakId)!.entryHash).toBeNull();
+
+    const result = classifyChainBreaks(breaks, manifest, rowsById);
+    expect(result.documentedExceptions.map((b) => b.id)).toContain(breakId);
+    expect(result.tamperSignatures).toHaveLength(0);
+    expect(result.verified).toBe(true);
+  });
+
+  it('ADVERSARIAL: a null-pinned row whose stored hash is forged null->value flips to tamper', () => {
+    const { rows, breakId } = chainWithNullHashBreak();
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+
+    // Baseline: documented under the null pin.
+    expect(
+      classifyChainBreaks(breaks, manifest, rowsById).documentedExceptions.map((b) => b.id),
+    ).toContain(breakId);
+
+    // ATTACK: the row's stored entry_hash moves from null to a forged value.
+    // The pin says null; the live tuple now says "someforgedhash" → drift → tamper.
+    const attacked = new Map(rowsById);
+    const base = attacked.get(breakId)!;
+    attacked.set(breakId, { ...base, entry_hash: 'someforgedhash' });
+
+    const result = classifyChainBreaks(breaks, manifest, attacked);
+    expect(result.documentedExceptions.map((b) => b.id)).not.toContain(breakId);
+    expect(result.tamperSignatures.map((b) => b.id)).toContain(breakId);
+    expect(result.verified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (c) an id NOT in the manifest is a tamperSignature
 // ---------------------------------------------------------------------------
 
@@ -363,7 +453,7 @@ describe('classifyChainBreaks — chain forks', () => {
       entries: [
         {
           id: forkId,
-          entryHash: stored.entry_hash!,
+          entryHash: stored.entry_hash,
           prevEntryHash: stored.prev_entry_hash,
           hashVersion: stored.hash_version,
           seq: stored.seq,
@@ -434,7 +524,7 @@ describe('readManifest — integrity gates', () => {
     expect(() => readManifest(manifestPath)).toThrow(/manifestHash mismatch/);
   });
 
-  it('throws on unsupported schemaVersion', () => {
+  it('throws on unsupported schemaVersion (Zod literal(1) rejects it)', () => {
     writeFileSync(
       manifestPath,
       JSON.stringify({
@@ -445,7 +535,44 @@ describe('readManifest — integrity gates', () => {
         manifestHash: 'x',
       }),
     );
-    expect(() => readManifest(manifestPath)).toThrow(/unsupported schemaVersion/);
+    expect(() => readManifest(manifestPath)).toThrow(ExceptionManifestError);
+    expect(() => readManifest(manifestPath)).toThrow(/schema validation/);
+  });
+
+  it('rejects a manifest entry whose reason is CHAIN_FORK (Zod enum excludes forks)', () => {
+    // A fork is never a documented exception, so the manifest entry `reason`
+    // enum permits only the three tamper reasons. A CHAIN_FORK entry must be
+    // refused at load — it cannot be smuggled in to launder a fork.
+    const entry = {
+      id: 'id-fork',
+      entryHash: 'h',
+      prevEntryHash: null,
+      hashVersion: 2,
+      seq: 3,
+      reason: 'CHAIN_FORK',
+    };
+    // Build with a VALID manifestHash + count so ONLY the reason enum can fail
+    // (proves the rejection is the enum, not a count/hash gate). We hash the
+    // structurally-identical body; readManifest still refuses on the enum first.
+    const body = { schemaVersion: 1 as const, generatedAt: 't', entryCount: 1, entries: [entry] };
+    // computeManifestHash accepts the shape structurally; the value doesn't
+    // matter because schema validation runs before the hash check.
+    writeFileSync(manifestPath, JSON.stringify({ ...body, manifestHash: 'anything' }));
+    expect(() => readManifest(manifestPath)).toThrow(ExceptionManifestError);
+    expect(() => readManifest(manifestPath)).toThrow(/schema validation/);
+  });
+
+  it('accepts a manifest with brainId explicitly null (nullable brainId)', () => {
+    const { rows } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const withNullBrain = manifestFor(breaks, rowsById);
+    // Serialise with an explicit brainId: null; the loader must accept it.
+    writeFileSync(manifestPath, JSON.stringify({ ...withNullBrain, brainId: null }));
+    const loaded = readManifest(manifestPath);
+    expect(loaded.entryCount).toBe(withNullBrain.entryCount);
+    // brainId normalises to absent in the returned body (null === omitted).
+    expect(loaded.brainId).toBeUndefined();
   });
 
   it('throws on non-JSON content', () => {

--- a/packages/store/src/exception-manifest.test.ts
+++ b/packages/store/src/exception-manifest.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Tests for the byte-pinned exception manifest + 3-state audit-break
+ * classifier (bead `compile-then-govern-e06.2`; risk `010-AT-RISK` R1/R2/R7).
+ *
+ * The ADVERSARIAL R1 case ("re-touching a documented row flips it back to
+ * tamper") is the hard gate: it proves the manifest cannot be used to launder
+ * a fresh edit inside the known-migration window.
+ *
+ * @module exception-manifest.test
+ */
+
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { computeEntryHash } from './audit-chain.js';
+import { verifyAuditChain, type AuditChainBreak } from './audit-verify.js';
+import {
+  classifyChainBreaks,
+  computeManifestHash,
+  readManifest,
+  ExceptionManifestError,
+  type ExceptionManifest,
+  type ExceptionManifestEntry,
+  type StoredRowTuple,
+} from './exception-manifest.js';
+import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mixed v1/v2 chain that reproduces a hash-version migration break.
+ *
+ * Rows 0..n are a valid v2 chain. Then we splice in a row written under v1
+ * (timestamp-in-hash) whose stored `entry_hash` was minted with the v1
+ * serialiser, but whose `prev_entry_hash` still chains from the v2 head — a
+ * faithful shape of the real ~155 breaks: intact per-row hash under its own
+ * version, but the chronological walk flags it because the recompute anchor
+ * moved. Here we deliberately craft a break by storing a row whose entry_hash
+ * does NOT recompute under the walk (a genuine ENTRY_HASH_MISMATCH), standing
+ * in for the migration artifact — the classifier treats it the same way.
+ */
+
+/** A valid v2 row. */
+function v2Row(i: number, prev: string | null): AuditChainRow {
+  const base = {
+    id: `id-${i}`,
+    action: 'promoted',
+    memory_id: `mem-${i}`,
+    tenant_id: 'local',
+    actor_json: '{"type":"ai","id":"curator"}',
+    reason: `r${i}`,
+    details_json: '{}',
+    timestamp: `2026-06-17T00:00:0${i}.000Z`,
+    hash_version: 2 as const,
+  };
+  const entry_hash = computeEntryHash({ ...base, prev_entry_hash: prev }, 2);
+  return { ...base, prev_entry_hash: prev, entry_hash };
+}
+
+/**
+ * Seed a chain of `n` valid v2 rows, then append one "migration break" row:
+ * its stored entry_hash is a fixed known value that will NOT recompute (so the
+ * walk reports ENTRY_HASH_MISMATCH), while its prev link chains correctly from
+ * the previous row so the break is isolated to exactly one row. Returns the
+ * rows plus the index/id of the break row.
+ */
+function chainWithMigrationBreak(n: number): {
+  rows: AuditChainRow[];
+  breakId: string;
+} {
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  for (let i = 0; i < n; i++) {
+    const r = v2Row(i, prev);
+    rows.push(r);
+    prev = r.entry_hash;
+  }
+  // The migration break row: valid prev link, but a stored entry_hash that is
+  // frozen to a legacy value (simulating a v1-minted hash that the v2 walk
+  // recompute won't reproduce). This yields exactly one ENTRY_HASH_MISMATCH.
+  const breakId = `id-${n}`;
+  const base = {
+    id: breakId,
+    action: 'promoted',
+    memory_id: `mem-${n}`,
+    tenant_id: 'local',
+    actor_json: '{"type":"ai","id":"curator"}',
+    reason: `r${n}`,
+    details_json: '{}',
+    timestamp: `2026-06-17T00:00:0${n}.000Z`,
+    hash_version: 1 as const,
+    prev_entry_hash: prev,
+  };
+  // A deterministic wrong hash: a v2 recompute of this same row (the walk uses
+  // hash_version=1 for this row, so the two diverge → mismatch).
+  const legacyStored = computeEntryHash({ ...base }, 2);
+  rows.push({ ...base, entry_hash: legacyStored });
+  return { rows, breakId };
+}
+
+function mockRepo(rows: AuditChainRow[]): AuditRepository {
+  return { findAllChronological: () => rows } as unknown as AuditRepository;
+}
+
+/** Build the CURRENT-stored-tuple map the classifier reads (id → tuple). */
+function rowsByIdOf(rows: AuditChainRow[]): Map<string, StoredRowTuple> {
+  const m = new Map<string, StoredRowTuple>();
+  for (const r of rows) {
+    m.set(r.id, {
+      entry_hash: r.entry_hash,
+      prev_entry_hash: r.prev_entry_hash,
+      hash_version: r.hash_version ?? 1,
+      seq: rows.indexOf(r),
+    });
+  }
+  return m;
+}
+
+/** Build a manifest that pins every tamper-reason break in the given breaks list. */
+function manifestFor(
+  breaks: AuditChainBreak[],
+  rowsById: Map<string, StoredRowTuple>,
+): ExceptionManifest {
+  const entries: ExceptionManifestEntry[] = breaks
+    .filter((b) => b.reason !== 'CHAIN_FORK')
+    .map((b) => {
+      const stored = rowsById.get(b.id)!;
+      return {
+        id: b.id,
+        entryHash: stored.entry_hash!,
+        prevEntryHash: stored.prev_entry_hash,
+        hashVersion: stored.hash_version,
+        seq: stored.seq,
+        reason: b.reason,
+      };
+    });
+  const body = {
+    schemaVersion: 1 as const,
+    generatedAt: '2026-06-30T00:00:00.000Z',
+    entryCount: entries.length,
+    entries,
+  };
+  return { ...body, manifestHash: computeManifestHash(body) };
+}
+
+/** Fork fixture: a v2 chain where a later row's prev link points back to a real earlier row. */
+function chainWithFork(): AuditChainRow[] {
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  for (let i = 0; i < 3; i++) {
+    const r = v2Row(i, prev);
+    rows.push(r);
+    prev = r.entry_hash;
+  }
+  // A 4th row that links back to row 0's entry_hash (a real, already-walked
+  // row) rather than row 2 → CHAIN_FORK (own hash intact, prev is a seen hash).
+  const forkBase = {
+    id: 'id-fork',
+    action: 'promoted',
+    memory_id: 'mem-fork',
+    tenant_id: 'local',
+    actor_json: '{"type":"ai","id":"curator"}',
+    reason: 'fork',
+    details_json: '{}',
+    timestamp: '2026-06-17T00:00:09.000Z',
+    hash_version: 2 as const,
+    prev_entry_hash: rows[0]!.entry_hash,
+  };
+  const entry_hash = computeEntryHash({ ...forkBase }, 2);
+  rows.push({ ...forkBase, entry_hash });
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// (a) genuine known breaks classify as documentedExceptions
+// ---------------------------------------------------------------------------
+
+describe('classifyChainBreaks — documented exceptions', () => {
+  it('classifies genuine known-migration breaks as documentedExceptions (verified true)', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+
+    // Sanity: exactly one break, at the migration row.
+    expect(breaks).toHaveLength(1);
+    expect(breaks[0]!.id).toBe(breakId);
+    expect(breaks[0]!.reason).toBe('ENTRY_HASH_MISMATCH');
+
+    const manifest = manifestFor(breaks, rowsById);
+    const result = classifyChainBreaks(breaks, manifest, rowsById);
+
+    expect(result.documentedExceptions.map((b) => b.id)).toEqual([breakId]);
+    expect(result.tamperSignatures).toHaveLength(0);
+    expect(result.chainForks).toHaveLength(0);
+    // Only tamper/fork gate `verified`; a documented exception does not.
+    expect(result.verified).toBe(true);
+  });
+
+  it('a clean chain with no breaks verifies true with an empty manifest', () => {
+    const rows: AuditChainRow[] = [];
+    let prev: string | null = null;
+    for (let i = 0; i < 3; i++) {
+      const r = v2Row(i, prev);
+      rows.push(r);
+      prev = r.entry_hash;
+    }
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    expect(breaks).toHaveLength(0);
+    const result = classifyChainBreaks(breaks, null, rowsByIdOf(rows));
+    expect(result.verified).toBe(true);
+    expect(result.documentedExceptions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) ADVERSARIAL / R1 — re-touching a documented row flips it to tamper
+// ---------------------------------------------------------------------------
+
+describe('classifyChainBreaks — ADVERSARIAL no-laundering (R1)', () => {
+  it('a documented row whose stored entry_hash is MUTATED becomes a tamperSignature', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+
+    // Baseline: the break is documented.
+    expect(
+      classifyChainBreaks(breaks, manifest, rowsById).documentedExceptions.map((b) => b.id),
+    ).toEqual([breakId]);
+
+    // ATTACK: an editor with write access edits the DOCUMENTED row and re-hashes
+    // it forward. In the DB, the row's stored entry_hash is now a NEW value. The
+    // manifest still pins the OLD tuple. Simulate by mutating the current stored
+    // tuple the classifier reads.
+    const attackedRowsById = new Map(rowsById);
+    const original = attackedRowsById.get(breakId)!;
+    attackedRowsById.set(breakId, { ...original, entry_hash: 'attacker-rehashed-value' });
+
+    // The verifier still reports a break for that row (its content changed);
+    // the classifier must NOT excuse it as documented — the pinned tuple no
+    // longer byte-matches the live stored tuple.
+    const result = classifyChainBreaks(breaks, manifest, attackedRowsById);
+
+    expect(result.documentedExceptions).toHaveLength(0);
+    expect(result.tamperSignatures.map((b) => b.id)).toEqual([breakId]);
+    expect(result.verified).toBe(false);
+  });
+
+  it('drift in prev_entry_hash, hash_version, or seq alone each flips to tamper', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+    const base = rowsById.get(breakId)!;
+
+    for (const drift of [
+      { prev_entry_hash: 'moved-prev' },
+      { hash_version: 2 },
+      { seq: base.seq + 100 },
+    ]) {
+      const attacked = new Map(rowsById);
+      attacked.set(breakId, { ...base, ...drift });
+      const result = classifyChainBreaks(breaks, manifest, attacked);
+      expect(result.documentedExceptions).toHaveLength(0);
+      expect(result.tamperSignatures.map((b) => b.id)).toEqual([breakId]);
+      expect(result.verified).toBe(false);
+    }
+  });
+
+  it('a documented row whose live reason CHANGED is no longer covered', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+
+    // The live break now reports a DIFFERENT tamper reason than the manifest
+    // minted for the same id + tuple. Reason drift => not the same exception.
+    const drifted: AuditChainBreak[] = breaks.map((b) =>
+      b.id === breakId ? { ...b, reason: 'PREV_LINK_MISMATCH' as const } : b,
+    );
+    const result = classifyChainBreaks(drifted, manifest, rowsById);
+    expect(result.documentedExceptions).toHaveLength(0);
+    expect(result.tamperSignatures.map((b) => b.id)).toEqual([breakId]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) an id NOT in the manifest is a tamperSignature
+// ---------------------------------------------------------------------------
+
+describe('classifyChainBreaks — unlisted id', () => {
+  it('a break whose id is absent from the manifest is a tamperSignature', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+
+    // Empty manifest → id is not listed → tamper.
+    const empty: ExceptionManifest = {
+      schemaVersion: 1,
+      generatedAt: '2026-06-30T00:00:00.000Z',
+      entryCount: 0,
+      entries: [],
+      manifestHash: computeManifestHash({
+        schemaVersion: 1,
+        generatedAt: '2026-06-30T00:00:00.000Z',
+        entryCount: 0,
+        entries: [],
+      }),
+    };
+    const result = classifyChainBreaks(breaks, empty, rowsById);
+    expect(result.documentedExceptions).toHaveLength(0);
+    expect(result.tamperSignatures.map((b) => b.id)).toEqual([breakId]);
+    expect(result.verified).toBe(false);
+  });
+
+  it('a null manifest makes every tamper-reason break a tamperSignature', () => {
+    const { rows, breakId } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const result = classifyChainBreaks(breaks, null, rowsById);
+    expect(result.tamperSignatures.map((b) => b.id)).toEqual([breakId]);
+    expect(result.verified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) CHAIN_FORK → chainForks, verified false while present
+// ---------------------------------------------------------------------------
+
+describe('classifyChainBreaks — chain forks', () => {
+  it('classifies a CHAIN_FORK into chainForks and reports verified false', () => {
+    const rows = chainWithFork();
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+
+    const forks = breaks.filter((b) => b.reason === 'CHAIN_FORK');
+    expect(forks.length).toBeGreaterThanOrEqual(1);
+
+    const result = classifyChainBreaks(breaks, null, rowsById);
+    expect(result.chainForks.length).toBe(forks.length);
+    expect(result.tamperSignatures).toHaveLength(0);
+    expect(result.verified).toBe(false);
+  });
+
+  it('a manifest cannot green a CHAIN_FORK (reason branch wins first)', () => {
+    const rows = chainWithFork();
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const forkId = breaks.find((b) => b.reason === 'CHAIN_FORK')!.id;
+    const stored = rowsById.get(forkId)!;
+
+    // Craft a (nonsensical) manifest that lists the fork id with a tamper
+    // reason. It must have NO effect: the fork stays a fork.
+    const body = {
+      schemaVersion: 1 as const,
+      generatedAt: '2026-06-30T00:00:00.000Z',
+      entryCount: 1,
+      entries: [
+        {
+          id: forkId,
+          entryHash: stored.entry_hash!,
+          prevEntryHash: stored.prev_entry_hash,
+          hashVersion: stored.hash_version,
+          seq: stored.seq,
+          reason: 'ENTRY_HASH_MISMATCH' as const,
+        },
+      ],
+    };
+    const manifest: ExceptionManifest = { ...body, manifestHash: computeManifestHash(body) };
+    const result = classifyChainBreaks(breaks, manifest, rowsById);
+    expect(result.chainForks.map((b) => b.id)).toContain(forkId);
+    expect(result.documentedExceptions.map((b) => b.id)).not.toContain(forkId);
+    expect(result.verified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) readManifest integrity gates
+// ---------------------------------------------------------------------------
+
+describe('readManifest — integrity gates', () => {
+  let manifestPath: string;
+  beforeEach(() => {
+    manifestPath = join(
+      tmpdir(),
+      `gsb-manifest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+  });
+  afterEach(() => {
+    if (existsSync(manifestPath)) rmSync(manifestPath);
+  });
+
+  it('round-trips a valid manifest', () => {
+    const { rows } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const loaded = readManifest(manifestPath);
+    expect(loaded.entryCount).toBe(manifest.entryCount);
+    expect(loaded.manifestHash).toBe(manifest.manifestHash);
+    expect(loaded.entries.map((e) => e.id)).toEqual(manifest.entries.map((e) => e.id));
+  });
+
+  it('throws when entries.length !== entryCount (R2 hard count-assert)', () => {
+    const { rows } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+    // Bump entryCount so it disagrees with the array length (drop the hash check
+    // out of the way by also leaving manifestHash — count-assert fires first).
+    const tampered = { ...manifest, entryCount: manifest.entryCount + 1 };
+    writeFileSync(manifestPath, JSON.stringify(tampered));
+    expect(() => readManifest(manifestPath)).toThrow(ExceptionManifestError);
+    expect(() => readManifest(manifestPath)).toThrow(/entryCount .* != entries\.length/);
+  });
+
+  it('throws when the manifest body was edited (manifestHash mismatch)', () => {
+    const { rows } = chainWithMigrationBreak(3);
+    const rowsById = rowsByIdOf(rows);
+    const { breaks } = verifyAuditChain(mockRepo(rows));
+    const manifest = manifestFor(breaks, rowsById);
+    // Edit a pinned hash but keep the stale manifestHash + matching count.
+    const edited = {
+      ...manifest,
+      entries: manifest.entries.map((e, i) => (i === 0 ? { ...e, entryHash: 'swapped' } : e)),
+    };
+    writeFileSync(manifestPath, JSON.stringify(edited));
+    expect(() => readManifest(manifestPath)).toThrow(/manifestHash mismatch/);
+  });
+
+  it('throws on unsupported schemaVersion', () => {
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        schemaVersion: 2,
+        generatedAt: 'x',
+        entryCount: 0,
+        entries: [],
+        manifestHash: 'x',
+      }),
+    );
+    expect(() => readManifest(manifestPath)).toThrow(/unsupported schemaVersion/);
+  });
+
+  it('throws on non-JSON content', () => {
+    writeFileSync(manifestPath, 'not json at all {');
+    expect(() => readManifest(manifestPath)).toThrow(/not valid JSON/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeManifestHash — determinism / order-independence
+// ---------------------------------------------------------------------------
+
+describe('computeManifestHash', () => {
+  it('is independent of input entry order (entries are sorted by seq,id)', () => {
+    const entries: ExceptionManifestEntry[] = [
+      {
+        id: 'b',
+        entryHash: 'h2',
+        prevEntryHash: 'h1',
+        hashVersion: 1,
+        seq: 2,
+        reason: 'ENTRY_HASH_MISMATCH',
+      },
+      {
+        id: 'a',
+        entryHash: 'h1',
+        prevEntryHash: null,
+        hashVersion: 1,
+        seq: 1,
+        reason: 'PREV_LINK_MISMATCH',
+      },
+    ];
+    const body1 = { schemaVersion: 1 as const, generatedAt: 't', entryCount: 2, entries };
+    const body2 = {
+      schemaVersion: 1 as const,
+      generatedAt: 't',
+      entryCount: 2,
+      entries: [...entries].reverse(),
+    };
+    expect(computeManifestHash(body1)).toBe(computeManifestHash(body2));
+  });
+
+  it('changes when any pinned field changes', () => {
+    const base = {
+      schemaVersion: 1 as const,
+      generatedAt: 't',
+      entryCount: 1,
+      entries: [
+        {
+          id: 'a',
+          entryHash: 'h1',
+          prevEntryHash: null,
+          hashVersion: 1 as number,
+          seq: 1,
+          reason: 'ENTRY_HASH_MISMATCH' as const,
+        },
+      ],
+    };
+    const h0 = computeManifestHash(base);
+    const h1 = computeManifestHash({
+      ...base,
+      entries: [{ ...base.entries[0]!, entryHash: 'h1-edited' }],
+    });
+    expect(h1).not.toBe(h0);
+  });
+});

--- a/packages/store/src/exception-manifest.ts
+++ b/packages/store/src/exception-manifest.ts
@@ -1,0 +1,384 @@
+/**
+ * Byte-pinned audit-break exception manifest + 3-state break classifier
+ * (bead `compile-then-govern-e06.2`; umbrella `#27`; risk `010-AT-RISK`
+ * R1/R2/R7; decision `009-AT-DECR` D5).
+ *
+ * ## Why this exists
+ *
+ * The live governed brain carries ~155 audit-chain breaks that are NOT
+ * tampering: they are an artifact of the v1→v2 hash-version migration
+ * (see `audit-chain.ts`, migration 6). The council ratified CARRYING those
+ * breaks with a documented exception and NEVER re-hashing them — v1 hashes
+ * are the tamper record, rehashing would erase the evidence (009-AT-DECR D5).
+ *
+ * ## The laundering risk this module closes (R1)
+ *
+ * D5's first wording keyed the exception on an INDEX-RANGE or DATE window.
+ * That is a laundering surface: an attacker who edits any row *inside that
+ * window* still produces an "expected" break and gets silently whitelisted.
+ *
+ * So this manifest pins each exception by its EXACT per-row tuple — the
+ * current stored `{entry_hash, prev_entry_hash, hash_version, seq}` — and the
+ * classifier accepts a break as documented ONLY on a full BYTE-MATCH of that
+ * tuple (plus id + reason). ANY drift (a stored hash changed, an id not in the
+ * manifest, a reason that no longer matches) flips the break to a tamper
+ * signature. An attacker who re-touches a documented row therefore flips it
+ * BACK to tamper — no laundering.
+ *
+ * ## What this module is NOT (R7)
+ *
+ * It never forks the chain walk and never re-hashes anything. It is a pure
+ * POST-PROCESSOR over `verifyAuditChain`'s output: it partitions the breaks
+ * that walker already found. The frozen serialisers in `audit-chain.ts` are
+ * untouched.
+ *
+ * ## TODO (R2 follow-on): anchor the manifest hash
+ *
+ * The immediate follow-on is to cross-reference `manifestHash` into the
+ * append-only anchor log so the amnesty itself is externally tamper-evident
+ * (an attacker can't swap in a wider manifest and re-point the tooling at it).
+ * That is NOT done in this PR because `AnchorRecord`'s `anchorBodyJson` is a
+ * FROZEN serialiser: adding a field would silently invalidate every stored
+ * anchor. It must land as a new anchor record variant (or a sibling
+ * `manifest-anchor.jsonl`), tracked as the e06.2 immediate follow-up — see the
+ * PR body. The manifest is already self-verifying (`readManifest` re-checks the
+ * whole-body hash + count-asserts), so it is not un-anchored today; the anchor
+ * cross-ref adds external, offline-editor-proof evidence on top.
+ *
+ * @module exception-manifest
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import type { AuditChainBreak } from './audit-verify.js';
+
+/** Reason codes that indicate TAMPERING (as opposed to a non-malicious fork). */
+const TAMPER_REASONS: ReadonlySet<AuditChainBreak['reason']> = new Set([
+  'ENTRY_HASH_MISMATCH',
+  'PREV_LINK_MISMATCH',
+  'PREV_LINK_AND_ENTRY_HASH_MISMATCH',
+]);
+
+/**
+ * The current stored identity of one known-migration break row, pinned by its
+ * EXACT tuple. This is the amnesty record: a break matching this tuple
+ * byte-for-byte is a documented exception; any drift from it is tampering.
+ */
+export interface ExceptionManifestEntry {
+  /** Audit row primary key. Names the exception uniquely. */
+  id: string;
+  /** The row's CURRENT stored `entry_hash` at manifest-generation time. */
+  entryHash: string;
+  /** The row's CURRENT stored `prev_entry_hash` (null for the first chained row). */
+  prevEntryHash: string | null;
+  /** The row's stored `hash_version` (1 = pre-migration v1 form, 2 = v2). */
+  hashVersion: number;
+  /** The row's monotonic write-order key. Part of the pinned identity. */
+  seq: number;
+  /**
+   * The break reason this exception covers (a tamper-reason code). The
+   * classifier requires the live break's reason to still match this — a
+   * documented ENTRY_HASH_MISMATCH that later reads as PREV_LINK_MISMATCH is
+   * drift, not the same exception.
+   */
+  reason: AuditChainBreak['reason'];
+}
+
+/**
+ * A frozen, self-describing amnesty for a specific brain's known-migration
+ * breaks. Its `manifestHash` is a SHA-256 over the canonical body, so the
+ * manifest itself is tamper-evident: editing any entry (or the count) changes
+ * the hash, and `readManifest` re-verifies + count-asserts on load.
+ */
+export interface ExceptionManifest {
+  schemaVersion: 1;
+  /** Optional brain identifier (a manifest is brain-specific data). */
+  brainId?: string;
+  /** ISO-8601 timestamp the manifest was generated. */
+  generatedAt: string;
+  /** Frozen count of entries. `readManifest` HARD-asserts entries.length === this (R2). */
+  entryCount: number;
+  /** The pinned exceptions. */
+  entries: ExceptionManifestEntry[];
+  /** SHA-256 hex over the canonical body (everything above, entries sorted). */
+  manifestHash: string;
+}
+
+/** The canonical body over which `manifestHash` is computed — excludes the hash itself. */
+export type ExceptionManifestBody = Omit<ExceptionManifest, 'manifestHash'>;
+
+/**
+ * Deterministic ordering of entries for hashing: by `seq` ascending, then by
+ * `id` lexicographically as a stable tiebreak. Returns a NEW sorted array;
+ * never mutates the input.
+ */
+function sortedEntries(entries: readonly ExceptionManifestEntry[]): ExceptionManifestEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.seq !== b.seq) return a.seq - b.seq;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/**
+ * Serialise the manifest body to a stable JSON string with FIXED key order at
+ * every level (like `canonicalRowJson` / `anchorBodyJson`). Entries are sorted
+ * (seq, id) and each entry's keys are emitted in a hardcoded order, so the
+ * output is byte-identical across runtimes for the same logical manifest.
+ */
+function manifestBodyJson(body: ExceptionManifestBody): string {
+  return JSON.stringify({
+    schemaVersion: body.schemaVersion,
+    brainId: body.brainId ?? null,
+    generatedAt: body.generatedAt,
+    entryCount: body.entryCount,
+    entries: sortedEntries(body.entries).map((e) => ({
+      id: e.id,
+      entryHash: e.entryHash,
+      prevEntryHash: e.prevEntryHash,
+      hashVersion: e.hashVersion,
+      seq: e.seq,
+      reason: e.reason,
+    })),
+  });
+}
+
+/**
+ * Compute the SHA-256 hex digest identifying an exception manifest, over its
+ * canonical body (entries sorted by seq then id, fixed key order, excluding
+ * `manifestHash`).
+ */
+export function computeManifestHash(body: ExceptionManifestBody): string {
+  return createHash('sha256').update(manifestBodyJson(body), 'utf8').digest('hex');
+}
+
+/** Thrown by `readManifest` when a manifest file is malformed or fails an integrity check. */
+export class ExceptionManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExceptionManifestError';
+  }
+}
+
+function isEntry(v: unknown): v is ExceptionManifestEntry {
+  if (typeof v !== 'object' || v === null) return false;
+  const e = v as Record<string, unknown>;
+  return (
+    typeof e['id'] === 'string' &&
+    typeof e['entryHash'] === 'string' &&
+    (e['prevEntryHash'] === null || typeof e['prevEntryHash'] === 'string') &&
+    typeof e['hashVersion'] === 'number' &&
+    typeof e['seq'] === 'number' &&
+    (e['reason'] === 'ENTRY_HASH_MISMATCH' ||
+      e['reason'] === 'PREV_LINK_MISMATCH' ||
+      e['reason'] === 'PREV_LINK_AND_ENTRY_HASH_MISMATCH' ||
+      e['reason'] === 'CHAIN_FORK')
+  );
+}
+
+/**
+ * Read + validate an exception manifest from a single-JSON file.
+ *
+ * File format: one JSON object per file (the `ExceptionManifest` shape).
+ * (JSONL was considered; single-JSON is chosen so the count-assert and the
+ * whole-body hash have one unambiguous canonicalisation — the file is small
+ * and written once.)
+ *
+ * Integrity gates enforced on load (fail-closed):
+ *  1. Structural validation of every field.
+ *  2. **HARD count-assert (R2):** `entries.length === entryCount`, else throw.
+ *     A tampered manifest that adds/drops an entry without fixing `entryCount`
+ *     is rejected here before it can launder or hide a break.
+ *  3. **manifestHash re-verification:** recompute over the canonical body and
+ *     compare; a mismatch means the manifest itself was edited → throw.
+ *
+ * @throws ExceptionManifestError on any malformed/inconsistent manifest.
+ */
+export function readManifest(path: string): ExceptionManifest {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (e) {
+    throw new ExceptionManifestError(`cannot read manifest at ${path}: ${String(e)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new ExceptionManifestError(`manifest at ${path} is not valid JSON: ${String(e)}`);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new ExceptionManifestError(`manifest at ${path} is not a JSON object`);
+  }
+  const m = parsed as Record<string, unknown>;
+
+  if (m['schemaVersion'] !== 1) {
+    throw new ExceptionManifestError(
+      `manifest at ${path}: unsupported schemaVersion ${String(m['schemaVersion'])} (expected 1)`,
+    );
+  }
+  if (typeof m['generatedAt'] !== 'string') {
+    throw new ExceptionManifestError(`manifest at ${path}: generatedAt must be a string`);
+  }
+  if (typeof m['entryCount'] !== 'number') {
+    throw new ExceptionManifestError(`manifest at ${path}: entryCount must be a number`);
+  }
+  if (typeof m['manifestHash'] !== 'string') {
+    throw new ExceptionManifestError(`manifest at ${path}: manifestHash must be a string`);
+  }
+  if (m['brainId'] !== undefined && typeof m['brainId'] !== 'string') {
+    throw new ExceptionManifestError(`manifest at ${path}: brainId must be a string when present`);
+  }
+  if (!Array.isArray(m['entries']) || !m['entries'].every(isEntry)) {
+    throw new ExceptionManifestError(
+      `manifest at ${path}: entries must be an array of valid entries`,
+    );
+  }
+
+  const entries = m['entries'] as ExceptionManifestEntry[];
+  const entryCount = m['entryCount'];
+
+  // (R2) Freeze the entry count: a count that disagrees with the array length
+  // is a tampered manifest — refuse it. This is a HARD assert, not a warning.
+  if (entries.length !== entryCount) {
+    throw new ExceptionManifestError(
+      `manifest at ${path}: entryCount ${entryCount} != entries.length ${entries.length} ` +
+        `(count drift / tampered manifest)`,
+    );
+  }
+
+  const body: ExceptionManifestBody = {
+    schemaVersion: 1,
+    ...(m['brainId'] !== undefined ? { brainId: m['brainId'] as string } : {}),
+    generatedAt: m['generatedAt'],
+    entryCount,
+    entries,
+  };
+  const recomputed = computeManifestHash(body);
+  if (recomputed !== m['manifestHash']) {
+    throw new ExceptionManifestError(
+      `manifest at ${path}: manifestHash mismatch (recomputed ${recomputed} != stored ` +
+        `${String(m['manifestHash'])}) — manifest content was edited`,
+    );
+  }
+
+  return { ...body, manifestHash: m['manifestHash'] };
+}
+
+/**
+ * The CURRENT stored tuple of an audit row, keyed by id. The classifier reads
+ * from this map (the live DB right now) — NOT from the manifest — so it can
+ * detect drift between what the manifest recorded and what the row holds today.
+ */
+export interface StoredRowTuple {
+  entry_hash: string | null;
+  prev_entry_hash: string | null;
+  hash_version: number;
+  seq: number;
+}
+
+/** The 3-state partition of the audit-chain breaks. */
+export interface ClassifiedChainBreaks {
+  /**
+   * True iff the brain is clean: NO tamper signatures AND NO chain forks.
+   * Documented exceptions do NOT fail verification; a fork means not-pristine.
+   */
+  verified: boolean;
+  /** Known-migration breaks that byte-match the manifest — carried, not failed. */
+  documentedExceptions: AuditChainBreak[];
+  /** Tamper signatures: any tamper-reason break not fully covered by the manifest. */
+  tamperSignatures: AuditChainBreak[];
+  /** Non-tamper ordering forks — surfaced separately, never silently greened. */
+  chainForks: AuditChainBreak[];
+}
+
+/**
+ * Partition the breaks `verifyAuditChain` found into documented exceptions,
+ * tamper signatures, and chain forks. A pure post-processor: it reads breaks +
+ * the manifest + the live DB's current row tuples, and mutates nothing.
+ *
+ * ### Rules (the security core — R1)
+ *
+ * - `reason === 'CHAIN_FORK'` → **chainForks**. A fork is not tampering, but it
+ *   is NOT auto-verified either: it is kept separate and counts against a clean
+ *   brain. (A documented exception whose reason is CHAIN_FORK is impossible —
+ *   the manifest only pins tamper-reason breaks — so a manifest-listed
+ *   CHAIN_FORK id has no effect: the reason branch wins first.)
+ *
+ * - A tamper-reason break is a **documentedException** ONLY IF ALL hold:
+ *     1. its `id` is present in the manifest, AND
+ *     2. the row's CURRENT stored `{entry_hash, prev_entry_hash, hash_version,
+ *        seq}` (from `rowsById`, i.e. what the DB holds right now) BYTE-EQUALS
+ *        the manifest entry's recorded tuple, AND
+ *     3. the live break's `reason` still equals the manifest entry's `reason`.
+ *   ANY drift — a stored hash changed, the id is absent, or the reason moved —
+ *   makes it a **tamperSignature**. This is the whole point: re-touching a
+ *   documented row flips it back to tamper (no laundering).
+ *
+ * - `verified === (tamperSignatures.length === 0 && chainForks.length === 0)`.
+ *
+ * @param breaks    The `breaks` array from a `verifyAuditChain` result.
+ * @param manifest  The loaded exception manifest, or `null` (no amnesty → every
+ *                  tamper-reason break is a tamperSignature).
+ * @param rowsById  Map of audit row id → its CURRENT stored tuple (from the DB).
+ */
+export function classifyChainBreaks(
+  breaks: readonly AuditChainBreak[],
+  manifest: ExceptionManifest | null,
+  rowsById: ReadonlyMap<string, StoredRowTuple>,
+): ClassifiedChainBreaks {
+  // Index the manifest by id for O(1) byte-match lookup. A given row id appears
+  // at most once in a well-formed manifest; if a duplicate id somehow slipped
+  // past readManifest, the LAST one wins here — but the byte-match still has to
+  // pass, so a duplicate cannot broaden the amnesty.
+  const manifestById = new Map<string, ExceptionManifestEntry>();
+  if (manifest) {
+    for (const e of manifest.entries) manifestById.set(e.id, e);
+  }
+
+  const documentedExceptions: AuditChainBreak[] = [];
+  const tamperSignatures: AuditChainBreak[] = [];
+  const chainForks: AuditChainBreak[] = [];
+
+  for (const brk of breaks) {
+    // A fork is never tampering and never a documented exception — it is its
+    // own bucket. Decide this FIRST so a manifest-listed id can't reclassify it.
+    if (brk.reason === 'CHAIN_FORK') {
+      chainForks.push(brk);
+      continue;
+    }
+
+    // From here down, brk.reason is a tamper-reason code.
+    const entry = manifestById.get(brk.id);
+    const stored = rowsById.get(brk.id);
+
+    const isDocumented =
+      entry !== undefined &&
+      stored !== undefined &&
+      // Byte-match the CURRENT stored tuple against the pinned tuple.
+      stored.entry_hash === entry.entryHash &&
+      stored.prev_entry_hash === entry.prevEntryHash &&
+      stored.hash_version === entry.hashVersion &&
+      stored.seq === entry.seq &&
+      // …and the break reason must still be the one the exception was minted for.
+      entry.reason === brk.reason &&
+      // Defence-in-depth: a manifest may only ever carry tamper-reason
+      // exceptions. If a CHAIN_FORK somehow got pinned, refuse to honour it.
+      TAMPER_REASONS.has(entry.reason);
+
+    if (isDocumented) {
+      documentedExceptions.push(brk);
+    } else {
+      tamperSignatures.push(brk);
+    }
+  }
+
+  return {
+    verified: tamperSignatures.length === 0 && chainForks.length === 0,
+    documentedExceptions,
+    tamperSignatures,
+    chainForks,
+  };
+}

--- a/packages/store/src/exception-manifest.ts
+++ b/packages/store/src/exception-manifest.ts
@@ -51,39 +51,83 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
+import { z } from 'zod';
+
 import type { AuditChainBreak } from './audit-verify.js';
 
-/** Reason codes that indicate TAMPERING (as opposed to a non-malicious fork). */
-const TAMPER_REASONS: ReadonlySet<AuditChainBreak['reason']> = new Set([
+/**
+ * The THREE tamper-reason codes — the only reasons a manifest entry may carry.
+ * A `CHAIN_FORK` is a non-malicious ordering artifact and is NEVER pinned as a
+ * documented exception, so it is deliberately EXCLUDED from the manifest-entry
+ * reason enum (a manifest listing a fork reason is rejected on load).
+ */
+const TAMPER_REASONS = [
   'ENTRY_HASH_MISMATCH',
   'PREV_LINK_MISMATCH',
   'PREV_LINK_AND_ENTRY_HASH_MISMATCH',
-]);
+] as const;
+
+/** A tamper-reason code (the subset of `AuditChainBreak['reason']` a manifest may pin). */
+export type TamperReason = (typeof TAMPER_REASONS)[number];
+
+/** Set form of the tamper reasons for O(1) defence-in-depth membership checks. */
+const TAMPER_REASON_SET: ReadonlySet<AuditChainBreak['reason']> = new Set(TAMPER_REASONS);
+
+/**
+ * Zod schema for one pinned exception (repo convention: Zod is the source of
+ * truth for on-disk shapes). Note `entryHash` is NULLABLE — a tamper-reason
+ * break can have a NULL stored `entry_hash` (`AuditChainBreak.actualEntryHash`
+ * is `string | null`), e.g. a row whose hash column was cleared. The pin must
+ * capture that null accurately so a later null→value drift reads as tamper.
+ * `reason` is restricted to the three tamper reasons ONLY.
+ */
+export const ExceptionManifestEntrySchema = z.object({
+  /** Audit row primary key. Names the exception uniquely. */
+  id: z.string(),
+  /** The row's CURRENT stored `entry_hash` at manifest-generation time (nullable). */
+  entryHash: z.string().nullable(),
+  /** The row's CURRENT stored `prev_entry_hash` (null for the first chained row). */
+  prevEntryHash: z.string().nullable(),
+  /** The row's stored `hash_version` (1 = pre-migration v1 form, 2 = v2). */
+  hashVersion: z.number(),
+  /** The row's monotonic write-order key. Part of the pinned identity. */
+  seq: z.number(),
+  /**
+   * The tamper reason this exception covers. The classifier requires the live
+   * break's reason to still match this — a documented ENTRY_HASH_MISMATCH that
+   * later reads as PREV_LINK_MISMATCH is drift, not the same exception.
+   * CHAIN_FORK is intentionally NOT a permitted value.
+   */
+  reason: z.enum(TAMPER_REASONS),
+});
 
 /**
  * The current stored identity of one known-migration break row, pinned by its
  * EXACT tuple. This is the amnesty record: a break matching this tuple
  * byte-for-byte is a documented exception; any drift from it is tampering.
  */
-export interface ExceptionManifestEntry {
-  /** Audit row primary key. Names the exception uniquely. */
-  id: string;
-  /** The row's CURRENT stored `entry_hash` at manifest-generation time. */
-  entryHash: string;
-  /** The row's CURRENT stored `prev_entry_hash` (null for the first chained row). */
-  prevEntryHash: string | null;
-  /** The row's stored `hash_version` (1 = pre-migration v1 form, 2 = v2). */
-  hashVersion: number;
-  /** The row's monotonic write-order key. Part of the pinned identity. */
-  seq: number;
-  /**
-   * The break reason this exception covers (a tamper-reason code). The
-   * classifier requires the live break's reason to still match this — a
-   * documented ENTRY_HASH_MISMATCH that later reads as PREV_LINK_MISMATCH is
-   * drift, not the same exception.
-   */
-  reason: AuditChainBreak['reason'];
-}
+export type ExceptionManifestEntry = z.infer<typeof ExceptionManifestEntrySchema>;
+
+/**
+ * Zod schema for the manifest as it appears ON DISK. `brainId` is NULLABLE and
+ * OPTIONAL — it serialises as `null` in the canonical body when omitted, and
+ * the loader must accept an explicit `null`. This schema validates STRUCTURE
+ * only; the R2 count-assert and the `manifestHash` re-verify are additional
+ * gates applied in `readManifest` (they cross-reference fields, not shape).
+ */
+export const ExceptionManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  /** Optional brain identifier (a manifest is brain-specific data); null when absent. */
+  brainId: z.string().nullable().optional(),
+  /** ISO-8601 timestamp the manifest was generated. */
+  generatedAt: z.string(),
+  /** Frozen count of entries. `readManifest` HARD-asserts entries.length === this (R2). */
+  entryCount: z.number(),
+  /** The pinned exceptions. */
+  entries: z.array(ExceptionManifestEntrySchema),
+  /** SHA-256 hex over the canonical body (everything above, entries sorted). */
+  manifestHash: z.string(),
+});
 
 /**
  * A frozen, self-describing amnesty for a specific brain's known-migration
@@ -91,19 +135,7 @@ export interface ExceptionManifestEntry {
  * manifest itself is tamper-evident: editing any entry (or the count) changes
  * the hash, and `readManifest` re-verifies + count-asserts on load.
  */
-export interface ExceptionManifest {
-  schemaVersion: 1;
-  /** Optional brain identifier (a manifest is brain-specific data). */
-  brainId?: string;
-  /** ISO-8601 timestamp the manifest was generated. */
-  generatedAt: string;
-  /** Frozen count of entries. `readManifest` HARD-asserts entries.length === this (R2). */
-  entryCount: number;
-  /** The pinned exceptions. */
-  entries: ExceptionManifestEntry[];
-  /** SHA-256 hex over the canonical body (everything above, entries sorted). */
-  manifestHash: string;
-}
+export type ExceptionManifest = z.infer<typeof ExceptionManifestSchema>;
 
 /** The canonical body over which `manifestHash` is computed — excludes the hash itself. */
 export type ExceptionManifestBody = Omit<ExceptionManifest, 'manifestHash'>;
@@ -160,22 +192,6 @@ export class ExceptionManifestError extends Error {
   }
 }
 
-function isEntry(v: unknown): v is ExceptionManifestEntry {
-  if (typeof v !== 'object' || v === null) return false;
-  const e = v as Record<string, unknown>;
-  return (
-    typeof e['id'] === 'string' &&
-    typeof e['entryHash'] === 'string' &&
-    (e['prevEntryHash'] === null || typeof e['prevEntryHash'] === 'string') &&
-    typeof e['hashVersion'] === 'number' &&
-    typeof e['seq'] === 'number' &&
-    (e['reason'] === 'ENTRY_HASH_MISMATCH' ||
-      e['reason'] === 'PREV_LINK_MISMATCH' ||
-      e['reason'] === 'PREV_LINK_AND_ENTRY_HASH_MISMATCH' ||
-      e['reason'] === 'CHAIN_FORK')
-  );
-}
-
 /**
  * Read + validate an exception manifest from a single-JSON file.
  *
@@ -185,12 +201,17 @@ function isEntry(v: unknown): v is ExceptionManifestEntry {
  * and written once.)
  *
  * Integrity gates enforced on load (fail-closed):
- *  1. Structural validation of every field.
+ *  1. **Structural validation via `ExceptionManifestSchema` (Zod).** Rejects
+ *     any malformed field and any entry whose `reason` is not one of the three
+ *     tamper reasons — a manifest listing `CHAIN_FORK` is refused here.
  *  2. **HARD count-assert (R2):** `entries.length === entryCount`, else throw.
  *     A tampered manifest that adds/drops an entry without fixing `entryCount`
- *     is rejected here before it can launder or hide a break.
+ *     is rejected before it can launder or hide a break.
  *  3. **manifestHash re-verification:** recompute over the canonical body and
  *     compare; a mismatch means the manifest itself was edited → throw.
+ *
+ * Gates 2 and 3 are cross-field checks (they compare `entryCount`/`manifestHash`
+ * against derived values), so they live here rather than in the Zod shape.
  *
  * @throws ExceptionManifestError on any malformed/inconsistent manifest.
  */
@@ -209,62 +230,42 @@ export function readManifest(path: string): ExceptionManifest {
     throw new ExceptionManifestError(`manifest at ${path} is not valid JSON: ${String(e)}`);
   }
 
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new ExceptionManifestError(`manifest at ${path} is not a JSON object`);
-  }
-  const m = parsed as Record<string, unknown>;
-
-  if (m['schemaVersion'] !== 1) {
+  // (1) Structural validation — Zod is the source of truth for the shape.
+  const result = ExceptionManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`);
     throw new ExceptionManifestError(
-      `manifest at ${path}: unsupported schemaVersion ${String(m['schemaVersion'])} (expected 1)`,
+      `manifest at ${path} failed schema validation: ${issues.join('; ')}`,
     );
   }
-  if (typeof m['generatedAt'] !== 'string') {
-    throw new ExceptionManifestError(`manifest at ${path}: generatedAt must be a string`);
-  }
-  if (typeof m['entryCount'] !== 'number') {
-    throw new ExceptionManifestError(`manifest at ${path}: entryCount must be a number`);
-  }
-  if (typeof m['manifestHash'] !== 'string') {
-    throw new ExceptionManifestError(`manifest at ${path}: manifestHash must be a string`);
-  }
-  if (m['brainId'] !== undefined && typeof m['brainId'] !== 'string') {
-    throw new ExceptionManifestError(`manifest at ${path}: brainId must be a string when present`);
-  }
-  if (!Array.isArray(m['entries']) || !m['entries'].every(isEntry)) {
-    throw new ExceptionManifestError(
-      `manifest at ${path}: entries must be an array of valid entries`,
-    );
-  }
+  const m = result.data;
 
-  const entries = m['entries'] as ExceptionManifestEntry[];
-  const entryCount = m['entryCount'];
-
-  // (R2) Freeze the entry count: a count that disagrees with the array length
-  // is a tampered manifest — refuse it. This is a HARD assert, not a warning.
-  if (entries.length !== entryCount) {
+  // (2) (R2) Freeze the entry count: a count that disagrees with the array
+  // length is a tampered manifest — refuse it. HARD assert, not a warning.
+  if (m.entries.length !== m.entryCount) {
     throw new ExceptionManifestError(
-      `manifest at ${path}: entryCount ${entryCount} != entries.length ${entries.length} ` +
+      `manifest at ${path}: entryCount ${m.entryCount} != entries.length ${m.entries.length} ` +
         `(count drift / tampered manifest)`,
     );
   }
 
+  // (3) manifestHash re-verification over the canonical body.
   const body: ExceptionManifestBody = {
     schemaVersion: 1,
-    ...(m['brainId'] !== undefined ? { brainId: m['brainId'] as string } : {}),
-    generatedAt: m['generatedAt'],
-    entryCount,
-    entries,
+    ...(m.brainId !== undefined && m.brainId !== null ? { brainId: m.brainId } : {}),
+    generatedAt: m.generatedAt,
+    entryCount: m.entryCount,
+    entries: m.entries,
   };
   const recomputed = computeManifestHash(body);
-  if (recomputed !== m['manifestHash']) {
+  if (recomputed !== m.manifestHash) {
     throw new ExceptionManifestError(
       `manifest at ${path}: manifestHash mismatch (recomputed ${recomputed} != stored ` +
-        `${String(m['manifestHash'])}) — manifest content was edited`,
+        `${m.manifestHash}) — manifest content was edited`,
     );
   }
 
-  return { ...body, manifestHash: m['manifestHash'] };
+  return { ...body, manifestHash: m.manifestHash };
 }
 
 /**
@@ -357,7 +358,9 @@ export function classifyChainBreaks(
     const isDocumented =
       entry !== undefined &&
       stored !== undefined &&
-      // Byte-match the CURRENT stored tuple against the pinned tuple.
+      // Byte-match the CURRENT stored tuple against the pinned tuple. `===` is
+      // null-aware: a null pin matches a null stored hash, and a null→value (or
+      // value→null) drift is unequal, so it correctly falls through to tamper.
       stored.entry_hash === entry.entryHash &&
       stored.prev_entry_hash === entry.prevEntryHash &&
       stored.hash_version === entry.hashVersion &&
@@ -365,8 +368,9 @@ export function classifyChainBreaks(
       // …and the break reason must still be the one the exception was minted for.
       entry.reason === brk.reason &&
       // Defence-in-depth: a manifest may only ever carry tamper-reason
-      // exceptions. If a CHAIN_FORK somehow got pinned, refuse to honour it.
-      TAMPER_REASONS.has(entry.reason);
+      // exceptions (the Zod enum already excludes CHAIN_FORK). If a fork reason
+      // somehow got pinned, refuse to honour it.
+      TAMPER_REASON_SET.has(entry.reason);
 
     if (isDocumented) {
       documentedExceptions.push(brk);

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -14,6 +14,19 @@ export { verifyAuditChain, type AuditVerifyResult, type AuditChainBreak } from '
 export { computeEntryHash, canonicalRowJson, CURRENT_AUDIT_HASH_VERSION } from './audit-chain.js';
 export type { CanonicalAuditRow, AuditHashVersion } from './audit-chain.js';
 export { appendAnchor, verifyAnchors, computeAnchorHash, readAnchors } from './audit-anchor.js';
+export {
+  computeManifestHash,
+  readManifest,
+  classifyChainBreaks,
+  ExceptionManifestError,
+} from './exception-manifest.js';
+export type {
+  ExceptionManifestEntry,
+  ExceptionManifest,
+  ExceptionManifestBody,
+  StoredRowTuple,
+  ClassifiedChainBreaks,
+} from './exception-manifest.js';
 export type {
   AnchorRecord,
   AnchorVerifyResult,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -19,11 +19,14 @@ export {
   readManifest,
   classifyChainBreaks,
   ExceptionManifestError,
+  ExceptionManifestEntrySchema,
+  ExceptionManifestSchema,
 } from './exception-manifest.js';
 export type {
   ExceptionManifestEntry,
   ExceptionManifest,
   ExceptionManifestBody,
+  TamperReason,
   StoredRowTuple,
   ClassifiedChainBreaks,
 } from './exception-manifest.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@qmd-team-intent-kb/test-fixtures':
         specifier: workspace:*


### PR DESCRIPTION
## What

The security-critical core of **e06.2**: a **byte-pinned exception manifest** + a **3-state audit-break classifier** for the govern engine, plus a read-only **generator CLI**. This lets the govern engine carry the known hash-version-migration audit breaks under a *documented, un-launderable* amnesty instead of re-hashing them.

Bead `compile-then-govern-e06.2` · umbrella `#27` · risk `010-AT-RISK` **R1/R2/R7** · decision `009-AT-DECR` **D5**.

**Feature branch / review only — do NOT merge yet.**

## Why — the laundering risk (read carefully)

The live brain carries ~155 pre-existing chain breaks from the v1→v2 hash-version migration (NOT tampering). The council ratified **carrying** them with a documented exception and **never** re-hashing (D5) — the v1 hashes *are* the tamper record; rehashing erases the evidence.

But D5's original wording keyed the exception on an **index-range / date window**. That is a **laundering surface**: an attacker who edits *any* row inside that window still produces an "expected" break and gets silently whitelisted. So the manifest here pins each exception by its **exact per-row tuple** and the classifier honours it **only on a full byte-match** (R1).

## Deliverables

### 1. Byte-pin manifest — `packages/store/src/exception-manifest.ts`
- `ExceptionManifestEntry` = `{ id, entryHash, prevEntryHash, hashVersion, seq, reason }` — the row's **current stored** tuple.
- `ExceptionManifest` = `{ schemaVersion:1, brainId?, generatedAt, entryCount, entries[], manifestHash }`.
- `manifestHash = sha256hex` over the canonical body — **entries sorted by `seq` then `id`, fixed key order, `manifestHash` excluded**. `computeManifestHash(body)` provided.
- **File format: single-JSON** (one object per file — chosen so the count-assert and whole-body hash have one unambiguous canonicalisation; the file is small and written once).
- `readManifest(path)` **fail-closes** on: malformed JSON, structural invalidity, **`entries.length !== entryCount`** (R2 hard count-assert), and **`manifestHash` mismatch** (body edited).

### 2. 3-state classifier — `classifyChainBreaks(breaks, manifest, rowsById)`
A pure **post-processor** over `verifyAuditChain`'s output (never forks the walk, never re-hashes — **R7**). Partitions into `documentedExceptions` / `tamperSignatures` / `chainForks`:
- `CHAIN_FORK` → `chainForks` (non-tamper, but **not** auto-verified — kept separate, never silently greened).
- A tamper-reason break is a `documentedException` **only if**: its `id` is in the manifest **AND** the row's **current** stored `{entry_hash, prev_entry_hash, hash_version, seq}` (from `rowsById`, i.e. the DB right now) **byte-equals** the pinned tuple **AND** the reason matches. **Any drift → `tamperSignature`.**
- `verified === (tamperSignatures.length === 0 && chainForks.length === 0)`.

### 3. Generator — `curator-cli generate-exception-manifest` (`apps/curator/src/cli.ts`)
Opens `teamkb.db` **`-readonly`**, runs `verifyAuditChain`, pins every tamper-reason break's current tuple, writes `<audit-dir>/exceptions.manifest.json` (0600). **Refuses to overwrite without `--force`** (the amnesty is one-time; silent regen would re-launder new breaks). Prints `entryCount` + `manifestHash` + reason breakdown. Lives as a curator subcommand alongside `verify-audit-chain`, reusing the `createDb` factory (now `readonly`-aware).

## The adversarial R1 test (the hard gate)

`packages/store/src/exception-manifest.test.ts` proves **no laundering**: take a manifest-listed break row, mutate its **stored `entry_hash`** (simulate an attacker editing a documented row + re-hashing forward) → re-run classify → the break **moves from `documentedExceptions` to `tamperSignatures`**, `verified` flips to `false`. Same for drift in `prev_entry_hash`, `hash_version`, `seq`, and `reason` individually, plus: unlisted id → tamper, null manifest → tamper, `CHAIN_FORK` → forks (never greened by a manifest), and all `readManifest` integrity gates.

## Live validation (read-only, `~/.teamkb/teamkb.db`, output to a temp path — NOT committed)

```json
{
  "totalRows": 2380, "cleanRows": 2225, "unverifiedRows": 0,
  "totalBreaks": 155,
  "breakReasonBreakdown": { "CHAIN_FORK": 155 },
  "manifestEntryCount": 0,
  "manifestHash": "b041385f4b96a98eafcbc05a3f931f2445369085f54778e0ee562b901b20ad30",
  "classified": { "verified": false, "documentedExceptions": 0, "tamperSignatures": 0, "chainForks": 155 }
}
```

### Key finding — the 155 live breaks are all `CHAIN_FORK`, not tamper-reason
The task anticipated ~155 `documentedExceptions`. The **live reality**: all 155 breaks classify as **`CHAIN_FORK`** — the non-malicious same-timestamp ordering artifact from bead `yxp`, *not* `ENTRY_HASH_MISMATCH`. So:
- **`tamperSignatures: 0`** — the critical safety property holds: **zero tampering** on the live brain.
- **`manifestEntryCount: 0`** — there are legitimately **no tamper-reason breaks to pin**; the amnesty manifest is correctly empty.
- The 155 are surfaced as `chainForks` (hence `verified:false` — a fork means not-pristine, correctly not greened).

This is a *stronger* outcome than the amnesty scenario: the govern engine's known breaks need **no** hash amnesty at all — they're already recognised as non-tamper forks. The manifest+classifier machinery is in place and correct for the day a genuine migration-hash break appears; today it pins nothing because there is nothing tamper-shaped to pin. (The live manifest is brain-specific data → belongs in `~/.teamkb/audit/` as an ops step, **not** the repo — not committed.)

## Gates

- Store: **211/211** tests pass (16 new). Curator: **258/258** (16 new CLI tests).
- `tsc --noEmit` clean on both packages. ESLint clean on both.
- `audit-chain.ts` frozen serialisers **untouched**. Nothing re-hashed. `~/.teamkb` **unmodified** (verified: db mtime unchanged, no manifest written there).

## Scope boundaries / follow-ups

- **R5** (`provenance-integrity.ts`) and **R8** (plugin wiring) are deliberately **out of scope** — they *consume* this classifier; kept out to keep this PR reviewable.
- **Manifest anchoring (R2 cross-ref)** — the immediate follow-on: cross-reference `manifestHash` into the append-only anchor log for external tamper-evidence. **Not done here** because `AnchorRecord`'s `anchorBodyJson` is a **frozen serialiser** — adding a field would invalidate every stored anchor. It needs a new anchor record variant (or a sibling `manifest-anchor.jsonl`). TODO left in the module header. The manifest is already self-verifying on load (whole-body hash + count-assert), so it is not un-protected today.

- Jeremy Longshore
intentsolutions.io