### PR TITLE
fix(eval-surface): provenance-integrity passes on no-tampering, discloses benign forks (e06.2 / R5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,18 @@ jobs:
       - name: Test (with coverage)
         # Switched from pnpm test:ci to pnpm test:coverage so coverage/lcov.info
         # is produced for the Codecov upload step below. test:coverage runs the
-        # same test set; only the coverage instrumentation is added.
+        # same test set (incl. the eval-surface provenance-integrity unit tests);
+        # only the coverage instrumentation is added.
         run: pnpm test:coverage
+
+      - name: Provenance-integrity eval (real on-disk brain, forks pass / tamper fails)
+        # A REAL end-to-end run of evaluateProvenanceIntegrity against a seeded
+        # throwaway brain carrying a benign CHAIN_FORK. Named gate for
+        # 010-AT-RISK R5 / bead compile-then-govern-e06.2: proves the eval passes
+        # on a forked-but-untampered chain (the live brain's shape: 155 forks,
+        # 0 tamper) while still failing closed on genuine tampering. Complements
+        # the in-memory unit tests above with a real-DB regression guard.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly
 
 on:
-  # schedule:
-  #   - cron: '0 4 * * *' # Daily 4am UTC
+  schedule:
+    - cron: '0 4 * * *' # Daily 4am UTC
   workflow_dispatch:
 
 permissions:
@@ -29,6 +29,12 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Provenance-integrity eval (real on-disk brain, forks pass / tamper fails)
+        # 010-AT-RISK R5 / bead compile-then-govern-e06.2: nightly real-DB run of
+        # evaluateProvenanceIntegrity — a forked-but-untampered brain must PASS
+        # with forks disclosed; a tampered brain must FAIL closed.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
 
       - name: Dependency audit
         run: pnpm audit --audit-level=moderate

--- a/packages/eval-surface/package.json
+++ b/packages/eval-surface/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "test": "vitest run",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "provenance:ci": "tsx scripts/ci-provenance-integrity.ts"
   },
   "dependencies": {
     "@qmd-team-intent-kb/common": "workspace:*",

--- a/packages/eval-surface/scripts/ci-provenance-integrity.ts
+++ b/packages/eval-surface/scripts/ci-provenance-integrity.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+/**
+ * CI provenance-integrity smoke — a REAL end-to-end run of
+ * `evaluateProvenanceIntegrity` against a freshly-seeded, on-disk throwaway
+ * brain that carries a BENIGN CHAIN_FORK.
+ *
+ * Why this exists (010-AT-RISK R5 / bead compile-then-govern-e06.2, umbrella #27):
+ * the fixed evaluator must PASS on a forked-but-untampered chain (the exact
+ * shape of the live brain's 155 CHAIN_FORKs, 0 tamper) while still DISCLOSING
+ * the forks, and still FAIL CLOSED on genuine tampering. The eval-surface unit
+ * tests assert this on in-memory repos; this script re-proves it on a REAL
+ * on-disk DB seeded with real memories + a real audit chain, so CI catches any
+ * regression the in-memory doubles could miss.
+ *
+ * It builds a throwaway brain in a temp dir (never touches ~/.teamkb), seeds a
+ * memory + a 3-row audit chain, splices a CHAIN_FORK, runs the evaluator, and
+ * asserts { passed:true, chain_forks>0, tamper_signatures:0 }. Then it seeds a
+ * genuine tamper break and asserts { passed:false, tamper_signatures>0 }.
+ *
+ * Exit 0 on success; non-zero (with a diagnostic) on any assertion failure.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { AuditEvent, CuratedMemory } from '@qmd-team-intent-kb/schema';
+import {
+  AuditRepository,
+  CURRENT_AUDIT_HASH_VERSION,
+  MemoryRepository,
+  computeEntryHash,
+  createDatabase,
+} from '@qmd-team-intent-kb/store';
+
+import { evaluateProvenanceIntegrity } from '../src/index.js';
+
+const TENANT = 'ci-provenance';
+
+function fail(msg: string): never {
+  process.stderr.write(`ci-provenance-integrity FAILED: ${msg}\n`);
+  process.exit(1);
+}
+
+function makeMemory(content: string): CuratedMemory {
+  const now = '2026-06-30T00:00:00.000Z';
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content,
+    title: 'ci-seed',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'ci', name: 'CI' },
+    tenantId: TENANT,
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: now,
+    promotedBy: { type: 'human', id: 'ci', name: 'CI' },
+    updatedAt: now,
+    version: 1,
+  };
+}
+
+function makeEvent(i: number): AuditEvent {
+  return {
+    id: `00000000-0000-4000-8000-0000000000${(i + 1).toString(16).padStart(2, '0')}`,
+    action: 'promoted',
+    memoryId: '11111111-1111-4111-8111-111111111111',
+    tenantId: TENANT,
+    actor: { type: 'human', id: 'ci' },
+    reason: `r${i}`,
+    details: { test: true },
+    timestamp: `2026-05-29T08:0${i}:00.000Z`,
+  };
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'gsb-ci-provenance-'));
+const dbPath = join(dir, 'teamkb.db');
+// A manifest path that does NOT exist → the evaluator's "no amnesty" branch.
+const noManifest = join(dir, 'no-such-exceptions.manifest.json');
+
+try {
+  const db = createDatabase({ path: dbPath });
+  const memRepo = new MemoryRepository(db);
+  const auditRepo = new AuditRepository(db);
+
+  memRepo.insert(makeMemory('ci provenance seed memory'));
+
+  const ids: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    const e = makeEvent(i);
+    ids.push(e.id);
+    auditRepo.insert(e);
+  }
+
+  // --- splice a BENIGN CHAIN_FORK: last row → back to the first, own hash intact.
+  const first = ids[0]!;
+  const last = ids[2]!;
+  const rowA = db.prepare('SELECT entry_hash FROM audit_events WHERE id = ?').get(first) as {
+    entry_hash: string;
+  };
+  const rowC = db.prepare('SELECT * FROM audit_events WHERE id = ?').get(last) as {
+    id: string;
+    action: string;
+    memory_id: string;
+    tenant_id: string;
+    actor_json: string;
+    reason: string | null;
+    details_json: string;
+    timestamp: string;
+  };
+  const forkedEntry = computeEntryHash(
+    {
+      id: rowC.id,
+      action: rowC.action,
+      memory_id: rowC.memory_id,
+      tenant_id: rowC.tenant_id,
+      actor_json: rowC.actor_json,
+      reason: rowC.reason,
+      details_json: rowC.details_json,
+      timestamp: rowC.timestamp,
+      prev_entry_hash: rowA.entry_hash,
+    },
+    CURRENT_AUDIT_HASH_VERSION,
+  );
+  db.prepare('UPDATE audit_events SET prev_entry_hash = ?, entry_hash = ? WHERE id = ?').run(
+    rowA.entry_hash,
+    forkedEntry,
+    last,
+  );
+
+  const forked = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+    tenantId: TENANT,
+    exceptionManifestPath: noManifest,
+  });
+  process.stdout.write(`forked-brain verdict: ${JSON.stringify(forked.details)}\n`);
+  if (!forked.passed) fail('forked-but-untampered brain must PASS, got passed=false');
+  if (Number(forked.details.chain_forks) <= 0)
+    fail(`expected chain_forks > 0, got ${forked.details.chain_forks}`);
+  if (Number(forked.details.tamper_signatures) !== 0)
+    fail(`expected tamper_signatures 0, got ${forked.details.tamper_signatures}`);
+
+  // --- now introduce a REAL tamper break and assert the eval fails closed.
+  db.prepare(`UPDATE audit_events SET reason = 'TAMPERED' WHERE id = ?`).run(ids[1]);
+  const tampered = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+    tenantId: TENANT,
+    exceptionManifestPath: noManifest,
+  });
+  process.stdout.write(`tampered-brain verdict: ${JSON.stringify(tampered.details)}\n`);
+  if (tampered.passed) fail('a tampered brain must FAIL, got passed=true');
+  if (Number(tampered.details.tamper_signatures) <= 0)
+    fail('expected tamper_signatures > 0 on a tampered brain');
+
+  db.close();
+  process.stdout.write(
+    'ci-provenance-integrity OK — forks pass (disclosed), tamper fails closed\n',
+  );
+  process.exit(0);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/eval-surface/scripts/ci-provenance-integrity.ts
+++ b/packages/eval-surface/scripts/ci-provenance-integrity.ts
@@ -39,9 +39,13 @@ import { evaluateProvenanceIntegrity } from '../src/index.js';
 
 const TENANT = 'ci-provenance';
 
+/**
+ * Signal an assertion failure by THROWING (not `process.exit`), so the single
+ * top-level `finally` runs its cleanup (close DB + remove temp dir) before the
+ * process exits non-zero. The top-level catch sets exit code 1.
+ */
 function fail(msg: string): never {
-  process.stderr.write(`ci-provenance-integrity FAILED: ${msg}\n`);
-  process.exit(1);
+  throw new Error(msg);
 }
 
 function makeMemory(content: string): CuratedMemory {
@@ -86,8 +90,13 @@ const dbPath = join(dir, 'teamkb.db');
 // A manifest path that does NOT exist → the evaluator's "no amnesty" branch.
 const noManifest = join(dir, 'no-such-exceptions.manifest.json');
 
+// `db` is declared OUTSIDE the try so the single top-level `finally` can safely
+// `db?.close()` it on every path (success, assertion failure, unexpected throw)
+// before the temp dir is removed.
+let db: ReturnType<typeof createDatabase> | undefined;
+
 try {
-  const db = createDatabase({ path: dbPath });
+  db = createDatabase({ path: dbPath });
   const memRepo = new MemoryRepository(db);
   const auditRepo = new AuditRepository(db);
 
@@ -158,11 +167,22 @@ try {
   if (Number(tampered.details.tamper_signatures) <= 0)
     fail('expected tamper_signatures > 0 on a tampered brain');
 
-  db.close();
   process.stdout.write(
     'ci-provenance-integrity OK — forks pass (disclosed), tamper fails closed\n',
   );
-  process.exit(0);
+  // Success falls through: no `process.exit(0)` here (it would bypass the
+  // finally and leak the temp dir). The process exits 0 naturally once the
+  // event loop drains.
+} catch (err) {
+  // Any assertion failure (thrown by `fail`) or unexpected error lands here.
+  // Print a diagnostic and set a non-zero exit code — but let `finally` run its
+  // cleanup FIRST (setting exitCode does not exit immediately, unlike exit()).
+  process.stderr.write(`ci-provenance-integrity FAILED: ${(err as Error).message}\n`);
+  process.exitCode = 1;
 } finally {
+  // Runs on every path (success, assertion failure, unexpected throw): close the
+  // DB handle if it was opened, then remove the temp dir. `db?.close()` is safe
+  // even if createDatabase threw before assignment.
+  db?.close();
   rmSync(dir, { recursive: true, force: true });
 }

--- a/packages/eval-surface/src/__tests__/eval-surface.test.ts
+++ b/packages/eval-surface/src/__tests__/eval-surface.test.ts
@@ -1,5 +1,17 @@
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { computeContentHash } from '@qmd-team-intent-kb/common';
-import { AuditRepository, MemoryRepository, createTestDatabase } from '@qmd-team-intent-kb/store';
+import {
+  AuditRepository,
+  CURRENT_AUDIT_HASH_VERSION,
+  MemoryRepository,
+  computeEntryHash,
+  computeManifestHash,
+  createTestDatabase,
+} from '@qmd-team-intent-kb/store';
+import type { AuditEvent } from '@qmd-team-intent-kb/schema';
 import { DEFAULT_TENANT, makeMemory } from '@qmd-team-intent-kb/test-fixtures';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -120,13 +132,98 @@ describe('evaluateDedupCatchRate', () => {
 // ---------------------------------------------------------------------------
 
 describe('evaluateProvenanceIntegrity', () => {
+  // A path that will never exist → forces the eval's manifest loader down its
+  // "no amnesty" branch deterministically, regardless of the host filesystem
+  // (never reads a real ~/.teamkb manifest during unit tests).
+  const NO_MANIFEST = join(tmpdir(), 'gsb-eval-no-such-manifest-should-not-exist.json');
+
+  // ---- audit-row helpers (real repo, real chain) ------------------------
+  // Mirrors packages/store/src/__tests__/audit-verify.test.ts idioms: insert
+  // real hashed rows via the repo, then splice a fork/tamper directly in SQL.
+
+  function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+    return {
+      id: `00000000-0000-4000-8000-${Math.random().toString(16).slice(2, 14).padStart(12, '0')}`,
+      action: 'promoted',
+      memoryId: '11111111-1111-4111-8111-111111111111',
+      tenantId: DEFAULT_TENANT,
+      actor: { type: 'human', id: 'curator-1' },
+      reason: 'test',
+      details: { test: true },
+      timestamp: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  /** Insert `n` valid, linearly-chained hashed audit rows via the repo. */
+  function seedChain(n: number): string[] {
+    const ids: string[] = [];
+    for (let i = 0; i < n; i++) {
+      const id = `00000000-0000-4000-8000-0000000000${(i + 1).toString(16).padStart(2, '0')}`;
+      ids.push(id);
+      auditRepo.insert(
+        makeEvent({ id, reason: `r${i}`, timestamp: `2026-05-29T08:0${i}:00.000Z` }),
+      );
+    }
+    return ids;
+  }
+
+  /**
+   * Splice a benign CHAIN_FORK: re-point row C's prev link back to row A (a
+   * real earlier intact row) and recompute C's entry_hash so its OWN hash stays
+   * intact — a non-linear chain with zero tampering (bead yxp). Requires ≥3
+   * rows; forks the last one back to the first.
+   */
+  function forkLastRowBackToFirst(ids: string[]): void {
+    const first = ids[0]!;
+    const last = ids[ids.length - 1]!;
+    const rowA = db.prepare('SELECT entry_hash FROM audit_events WHERE id = ?').get(first) as {
+      entry_hash: string;
+    };
+    const rowC = db.prepare('SELECT * FROM audit_events WHERE id = ?').get(last) as {
+      id: string;
+      action: string;
+      memory_id: string;
+      tenant_id: string;
+      actor_json: string;
+      reason: string | null;
+      details_json: string;
+      timestamp: string;
+    };
+    const forkedEntry = computeEntryHash(
+      {
+        id: rowC.id,
+        action: rowC.action,
+        memory_id: rowC.memory_id,
+        tenant_id: rowC.tenant_id,
+        actor_json: rowC.actor_json,
+        reason: rowC.reason,
+        details_json: rowC.details_json,
+        timestamp: rowC.timestamp,
+        prev_entry_hash: rowA.entry_hash,
+      },
+      CURRENT_AUDIT_HASH_VERSION,
+    );
+    db.prepare('UPDATE audit_events SET prev_entry_hash = ?, entry_hash = ? WHERE id = ?').run(
+      rowA.entry_hash,
+      forkedEntry,
+      last,
+    );
+  }
+
+  // -----------------------------------------------------------------------
+
   it('passes on a clean store (consistent hashes, intact chain)', () => {
     memRepo.insert(makeMemory({ content: 'clean memory one' }));
     memRepo.insert(makeMemory({ content: 'clean memory two' }));
-    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
     expect(r.name).toBe('provenance-integrity');
     expect(r.details.content_hash_mismatches).toBe(0);
-    expect(r.details.audit_chain_breaks).toBe(0);
+    expect(r.details.tamper_signatures).toBe(0);
+    expect(r.details.chain_forks).toBe(0);
     expect(r.passed).toBe(true);
   });
 
@@ -137,14 +234,134 @@ describe('evaluateProvenanceIntegrity', () => {
       contentHash: computeContentHash('a DIFFERENT string than the content'),
     });
     memRepo.insert(tampered);
-    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
     expect(r.details.content_hash_mismatches).toBe(1);
     expect(r.passed).toBe(false);
   });
 
   it('passes on an empty store', () => {
-    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
     expect(r.passed).toBe(true);
     expect(r.score).toBe(1);
+  });
+
+  // -- (a) 010-AT-RISK R5: forks-only chain must PASS, forks disclosed --------
+  it('PASSES on a chain with ONLY CHAIN_FORK breaks and discloses the forks (R5)', () => {
+    memRepo.insert(makeMemory({ content: 'forked-brain memory' }));
+    const ids = seedChain(3);
+    forkLastRowBackToFirst(ids);
+
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
+
+    // A benign fork is NOT tampering → the eval must pass (the whole R5 fix).
+    expect(r.passed).toBe(true);
+    // …but the fork IS disclosed, not silently greened.
+    expect(Number(r.details.chain_forks)).toBeGreaterThan(0);
+    expect(r.details.tamper_signatures).toBe(0);
+    expect(r.details.documented_exceptions).toBe(0);
+    // Forks do not drag the score below threshold on an untampered brain.
+    expect(r.score).toBe(1);
+  });
+
+  // -- (b) a tamper-reason break must FAIL -----------------------------------
+  it('FAILS on a tamper-reason audit break (content of a row altered post-hash)', () => {
+    memRepo.insert(makeMemory({ content: 'tampered-brain memory' }));
+    const ids = seedChain(3);
+    // Alter the middle row's reason WITHOUT recomputing its entry_hash → the
+    // walk recomputes a different hash → ENTRY_HASH_MISMATCH (a tamper reason).
+    db.prepare(`UPDATE audit_events SET reason = 'TAMPERED' WHERE id = ?`).run(ids[1]);
+
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
+
+    expect(Number(r.details.tamper_signatures)).toBeGreaterThan(0);
+    expect(r.passed).toBe(false);
+    expect(r.score).toBeLessThan(1);
+  });
+
+  // -- (c) content-hash mismatch already covered above; assert it does not
+  //        leak into the chain counters -------------------------------------
+  it('a content-hash mismatch fails without inventing chain tamper signatures', () => {
+    memRepo.insert(
+      makeMemory({
+        content: 'real content C',
+        contentHash: computeContentHash('some other content entirely'),
+      }),
+    );
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+      tenantId: DEFAULT_TENANT,
+      exceptionManifestPath: NO_MANIFEST,
+    });
+    expect(r.details.content_hash_mismatches).toBe(1);
+    expect(r.details.tamper_signatures).toBe(0);
+    expect(r.passed).toBe(false);
+  });
+
+  // -- (d) a documented tamper break covered by a manifest → PASSES ----------
+  it('PASSES when a tamper break is byte-pinned in a documented exception manifest', () => {
+    memRepo.insert(makeMemory({ content: 'documented-break memory' }));
+    const ids = seedChain(3);
+    // Create a genuine tamper-reason break on the middle row.
+    db.prepare(`UPDATE audit_events SET reason = 'MIGRATED' WHERE id = ?`).run(ids[1]);
+
+    // Read the break's CURRENT stored tuple to byte-pin it in the manifest.
+    const brokenRow = db.prepare('SELECT * FROM audit_events WHERE id = ?').get(ids[1]) as {
+      id: string;
+      entry_hash: string | null;
+      prev_entry_hash: string | null;
+      hash_version: number | null;
+      seq: number;
+    };
+
+    const entries = [
+      {
+        id: brokenRow.id,
+        entryHash: brokenRow.entry_hash,
+        prevEntryHash: brokenRow.prev_entry_hash,
+        hashVersion: brokenRow.hash_version ?? 1,
+        seq: brokenRow.seq,
+        // The walk reports ENTRY_HASH_MISMATCH for a content-altered row whose
+        // prev link still chains correctly.
+        reason: 'ENTRY_HASH_MISMATCH' as const,
+      },
+    ];
+    const body = {
+      schemaVersion: 1 as const,
+      generatedAt: '2026-06-30T00:00:00.000Z',
+      entryCount: entries.length,
+      entries,
+    };
+    const manifest = { ...body, manifestHash: computeManifestHash(body) };
+
+    const manifestPath = join(
+      tmpdir(),
+      `gsb-eval-manifest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    try {
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: manifestPath,
+      });
+      // The break is DOCUMENTED (byte-pinned) → not a tamper signature → passes,
+      // but is disclosed as a documented exception.
+      expect(r.details.exception_manifest_loaded).toBe(true);
+      expect(r.details.tamper_signatures).toBe(0);
+      expect(Number(r.details.documented_exceptions)).toBeGreaterThan(0);
+      expect(r.passed).toBe(true);
+    } finally {
+      if (existsSync(manifestPath)) rmSync(manifestPath);
+    }
   });
 });

--- a/packages/eval-surface/src/provenance-integrity.ts
+++ b/packages/eval-surface/src/provenance-integrity.ts
@@ -1,34 +1,131 @@
 /**
  * provenance-integrity evaluator — is every curated memory's provenance sound,
- * and is the audit chain intact?
+ * and is the audit chain free of TAMPERING?
  *
  * Two layers of "can you trust this memory":
  *  1. Per-memory content integrity — does each memory's stored `contentHash`
  *     actually match the SHA-256 of its `content`? A mismatch means the content
  *     was altered after the fingerprint was recorded (tampering / corruption).
  *  2. Audit-chain integrity — does the store's append-only SHA-256 audit chain
- *     verify end to end (no broken links)?
+ *     verify with NO tamper signatures?
  *
- * The verdict passes iff every memory's content hash is consistent AND the audit
- * chain has zero breaks.
+ * ## Why this changed (010-AT-RISK R5 / bead compile-then-govern-e06.2, umbrella #27)
  *
- * Pure: takes the memory + audit repositories, returns a verdict. No emit, no
- * sign. (Note: `verifyAuditChain` walks the global chain by design — it is a
- * single append-only ledger across tenants. A tenant-scoped bundle-exposing API
- * is a separate hardening concern, tracked at bead tr08.21.)
+ * The old verdict was `passed = … && chain.breaks.length === 0`. That is
+ * red-by-construction: `verifyAuditChain` returns EVERY break, including benign
+ * `CHAIN_FORK` rows — a non-malicious same-timestamp ordering artifact where
+ * every stored hash is intact (bead yxp). The live governed brain carries ~155
+ * such forks and ZERO tampering, so the eval was `passed:false` forever,
+ * contradicting the ratified posture ("a fork is not tampering").
+ *
+ * This evaluator now uses the merged 3-state classifier
+ * (`classifyChainBreaks`, `@qmd-team-intent-kb/store`) to partition the breaks
+ * into **tamper signatures**, **documented exceptions** (known-migration breaks
+ * byte-pinned in the exception manifest — carried, not failed), and **chain
+ * forks**. The verdict now passes on the SECURITY property:
+ *
+ *     passed = contentHashMismatches === 0
+ *           && invalidSources     === 0
+ *           && tamperSignatures.length === 0
+ *
+ * i.e. it fails ONLY on genuine tampering (a content-hash mismatch, an invalid
+ * source, or a tamper-reason audit break not covered by a byte-pinned
+ * exception). Benign `CHAIN_FORK`s do NOT fail — but they ARE disclosed in
+ * `details` (`chain_forks`), alongside `tamper_signatures` and
+ * `documented_exceptions`, so a forked-but-untampered chain reads as "clean
+ * (integrity + ordering intact) with N disclosed forks", never as a silent
+ * green nor a false red.
+ *
+ * ## The manifest (optional)
+ *
+ * If an exception manifest exists, documented (byte-pinned known-migration)
+ * breaks are surfaced separately and never counted as tampering; ANY drift from
+ * the pinned tuple flips such a break back to a tamper signature (no
+ * laundering — see `exception-manifest.ts`). With no manifest (the default on
+ * the live brain today, which carries only forks), every tamper-reason break is
+ * a tamper signature and correctly fails. The manifest path is configurable
+ * (`options.exceptionManifestPath` or `$TEAMKB_EXCEPTION_MANIFEST`, default
+ * `~/.teamkb/audit/exceptions.manifest.json`); a missing file is not an error.
+ *
+ * Pure w.r.t. durable state: takes the memory + audit repositories, reads the
+ * manifest file if present, returns a verdict. No emit, no sign. (Note:
+ * `verifyAuditChain` walks the global chain by design — it is a single
+ * append-only ledger across tenants. A tenant-scoped bundle-exposing API is a
+ * separate hardening concern, tracked at bead tr08.21.)
  */
 
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import { computeContentHash } from '@qmd-team-intent-kb/common';
-import type { AuditRepository, MemoryRepository } from '@qmd-team-intent-kb/store';
-import { verifyAuditChain } from '@qmd-team-intent-kb/store';
+import type {
+  AuditChainRow,
+  AuditRepository,
+  ExceptionManifest,
+  MemoryRepository,
+  StoredRowTuple,
+} from '@qmd-team-intent-kb/store';
+import { classifyChainBreaks, readManifest, verifyAuditChain } from '@qmd-team-intent-kb/store';
 
 import type { EvaluatorResult } from './types.js';
 
 const VALID_SOURCES = new Set(['claude_session', 'manual', 'import', 'mcp']);
 
+/** Default on-disk location of a brain's byte-pinned exception manifest. */
+const DEFAULT_EXCEPTION_MANIFEST_PATH = join(
+  homedir(),
+  '.teamkb',
+  'audit',
+  'exceptions.manifest.json',
+);
+
 export interface ProvenanceIntegrityOptions {
   /** Tenant to scope the per-memory content-integrity walk. Omit = all tenants. */
   readonly tenantId?: string;
+  /**
+   * Path to the byte-pinned exception manifest of documented known-migration
+   * breaks. When omitted, falls back to `$TEAMKB_EXCEPTION_MANIFEST` then to
+   * `~/.teamkb/audit/exceptions.manifest.json`. A missing file is NOT an error
+   * (no amnesty → every tamper-reason break is a tamper signature).
+   */
+  readonly exceptionManifestPath?: string;
+}
+
+/**
+ * `findAllChronological()` runs `SELECT *`, so the `seq` column is present on
+ * each row object even though `AuditChainRow` does not declare it. Widen the
+ * type to read it for the byte-pinned tuple, matching curator-cli's
+ * generate-exception-manifest.
+ */
+type ChainRowWithSeq = AuditChainRow & { seq: number | null };
+
+/**
+ * Resolve + load the exception manifest, or return `null`. Fail-closed on a
+ * PRESENT-but-corrupt manifest (readManifest throws), so a tampered amnesty
+ * cannot silently launder breaks; treat a merely-absent file as "no amnesty".
+ */
+function loadManifest(explicitPath: string | undefined): ExceptionManifest | null {
+  const path =
+    explicitPath ?? process.env.TEAMKB_EXCEPTION_MANIFEST ?? DEFAULT_EXCEPTION_MANIFEST_PATH;
+  if (!existsSync(path)) return null;
+  // readManifest throws on a corrupt/edited manifest — let it propagate: a
+  // present manifest that fails its own integrity gates must not be ignored.
+  return readManifest(path);
+}
+
+/** Build the classifier's id → current-stored-tuple map from the live audit rows. */
+function rowsByIdOf(rows: readonly ChainRowWithSeq[]): Map<string, StoredRowTuple> {
+  const m = new Map<string, StoredRowTuple>();
+  for (const r of rows) {
+    m.set(r.id, {
+      entry_hash: r.entry_hash,
+      prev_entry_hash: r.prev_entry_hash,
+      hash_version: r.hash_version ?? 1,
+      seq: r.seq ?? 0,
+    });
+  }
+  return m;
 }
 
 export function evaluateProvenanceIntegrity(
@@ -49,17 +146,32 @@ export function evaluateProvenanceIntegrity(
   }
 
   const chain = verifyAuditChain(auditRepo);
-  // CHAIN_FORK rows are non-malicious ordering artifacts (all hashes intact),
-  // NOT tampering — report them apart from tamper breaks (bead yxp). Both still
-  // fail this integrity eval (threshold 1.0); a forked chain is not pristine.
-  const chainForks = chain.breaks.filter((b) => b.reason === 'CHAIN_FORK').length;
-  const chainTamperBreaks = chain.breaks.length - chainForks;
-  const chainAnomalies = chain.breaks.length;
 
-  const passed = contentHashMismatches === 0 && invalidSources === 0 && chainAnomalies === 0;
-  // Score: fraction of all integrity checks that held (memories × 2 checks + chain).
+  // Partition the breaks the walker found into tamper signatures, documented
+  // (byte-pinned) exceptions, and benign CHAIN_FORKs, using the merged 3-state
+  // classifier. `rowsById` is the CURRENT stored tuple of each row, so a
+  // documented break that has since been re-touched byte-drifts and flips back
+  // to a tamper signature (no laundering — see exception-manifest.ts).
+  const manifest = loadManifest(options.exceptionManifestPath);
+  const rows = auditRepo.findAllChronological() as ChainRowWithSeq[];
+  const classified = classifyChainBreaks(chain.breaks, manifest, rowsByIdOf(rows));
+  const tamperSignatures = classified.tamperSignatures.length;
+  const documentedExceptions = classified.documentedExceptions.length;
+  const chainForks = classified.chainForks.length;
+
+  // Pass on the SECURITY property: genuine tampering only. Benign CHAIN_FORKs
+  // and byte-pinned documented exceptions do NOT fail the verdict; they are
+  // disclosed in `details` for honest reporting (010-AT-RISK R5).
+  const passed = contentHashMismatches === 0 && invalidSources === 0 && tamperSignatures === 0;
+
+  // Score: fraction of integrity checks that held. Only the GATING checks count
+  // as failures (content-hash mismatch, invalid source, presence of tamper
+  // signatures); benign forks / documented exceptions are NOT failures, so they
+  // do not drag the score below the 1.0 threshold on an untampered-but-forked
+  // brain. The chain contributes exactly one gating check (tamper-free or not),
+  // matching the pre-fix denominator so a clean brain still scores 1.0.
   const totalChecks = memories.length * 2 + 1;
-  const failedChecks = contentHashMismatches + invalidSources + (chainAnomalies > 0 ? 1 : 0);
+  const failedChecks = contentHashMismatches + invalidSources + (tamperSignatures > 0 ? 1 : 0);
   const score = totalChecks === 0 ? 1 : (totalChecks - failedChecks) / totalChecks;
 
   return {
@@ -72,8 +184,15 @@ export function evaluateProvenanceIntegrity(
       content_hash_mismatches: contentHashMismatches,
       invalid_sources: invalidSources,
       audit_chain_rows: chain.totalRows,
-      audit_chain_breaks: chainTamperBreaks,
-      audit_chain_forks: chainForks,
+      // The gating count: tamper-reason breaks NOT covered by a byte-pinned
+      // exception. Zero on the live brain (155 forks, 0 tamper).
+      tamper_signatures: tamperSignatures,
+      // Disclosed-not-failed: benign same-timestamp ordering forks (bead yxp).
+      chain_forks: chainForks,
+      // Disclosed-not-failed: byte-pinned known-migration breaks (manifest).
+      documented_exceptions: documentedExceptions,
+      // Whether a byte-pinned exception manifest was loaded for this run.
+      exception_manifest_loaded: manifest !== null,
     },
   };
 }


### PR DESCRIPTION
## Problem (010-AT-RISK R5)

`provenance-integrity.ts` set `passed = contentHashMismatches===0 && invalidSources===0 && chainAnomalies===0` where `chainAnomalies = chain.breaks.length` — so it failed on **every** audit-chain break, including benign `CHAIN_FORK`s (a same-timestamp ordering artifact where every stored hash is intact — bead `yxp`). On the live governed brain that means **155 `CHAIN_FORK`s and zero tampering**, so the eval was `passed:false` **forever**, contradicting the ratified posture ("a fork is not tampering"). It also ran in **no CI workflow** (grep `.github/workflows/` for `eval-surface` returned nothing).

## Fix

Uses the newly-merged 3-state classifier `classifyChainBreaks` (`@qmd-team-intent-kb/store`, bead `e06.2` / PR #214) instead of the raw break count:

- Builds the `id → current-stored-tuple` map from `findAllChronological()` (matching curator-cli `generate-exception-manifest`) and loads an **optional** byte-pinned exception manifest — configurable via `options.exceptionManifestPath` → `$TEAMKB_EXCEPTION_MANIFEST` → default `~/.teamkb/audit/exceptions.manifest.json`. A **missing** file = no amnesty (every tamper-reason break is a tamper signature); a **present-but-corrupt** manifest **fails closed** (`readManifest` throws).
- **Passes on the security property only:**
  `passed = contentHashMismatches===0 && invalidSources===0 && tamperSignatures.length===0`.
  - **`chainForks` do NOT fail** — benign, but **disclosed** in `details.chain_forks`.
  - **`documentedExceptions` do NOT fail** — byte-pinned known breaks, **disclosed** in `details.documented_exceptions`.
  - Score counts only *gating* failures, so forks no longer drag an untampered brain below the `1.0` threshold. `details` now carries `tamper_signatures`, `chain_forks`, `documented_exceptions`, `exception_manifest_loaded` (plus the existing `content_hash_mismatches`, `invalid_sources`, `audit_chain_rows`).

## Wired into CI (was running nowhere)

- The eval-surface unit tests already run under `pnpm test:coverage` in the `validate` job (workspace-wide vitest).
- **New named gate**, both in the PR `validate` job and the (now-enabled, daily 04:00 UTC) `nightly` workflow: `pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci` — a **real on-disk seeded brain** with a benign `CHAIN_FORK` → asserts `passed:true` + `chain_forks>0` disclosed, then a genuine tamper break → asserts `passed:false` (fails closed). Script: `packages/eval-surface/scripts/ci-provenance-integrity.ts`.

## Tests (eval-surface, 14 pass)

- forks-only chain → `passed:true`, `chain_forks>0` disclosed;
- tamper-reason break → `passed:false`;
- content-hash mismatch → `passed:false` (without inventing chain tamper signatures);
- documented tamper break covered by a manifest → `passed:true`, `documented_exceptions>0`.

## Live-brain validation (read-only, `~/.teamkb` untouched)

Independent reason breakdown via `curator-cli verify-audit-chain --json` against a **copy** of `~/.teamkb/teamkb.db`:

| Metric | Value |
|---|---|
| total rows | 2374 |
| clean rows | 2219 |
| unverified (pre-migration) | 0 |
| total breaks | 155 |
| **`CHAIN_FORK`** | **155** |
| **tamper reasons** | **0** (`tamperFree: true`) |

Running the **fixed eval** against that live-brain copy (read-only, no manifest present):

```json
{ "passed": true, "score": 1, "threshold": 1,
  "details": { "memories_checked": 2073, "content_hash_mismatches": 0, "invalid_sources": 0,
               "audit_chain_rows": 2374, "tamper_signatures": 0, "chain_forks": 155,
               "documented_exceptions": 0, "exception_manifest_loaded": false } }
```

The eval now returns `passed:true` on the live brain with the 155 forks **disclosed** — the R5 red-by-construction failure is gone, tamper-detection is unchanged.

## Local gates (all green)

format:check · lint · typecheck · depcruise (0 errors) · crap (0 over threshold) · harness-pin · full suite (155 files / 1846 tests) · the real `provenance:ci` smoke.

Refs `compile-then-govern-e06.2`, umbrella #27, `010-AT-RISK` R5. **Do not merge** without review.

- Jeremy Longshore
intentsolutions.io
