### PR TITLE
Govern-decision efficacy eval (per-check precision/recall) + R10 boundary-scan fix (e06.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
         # the in-memory unit tests above with a real-DB regression guard.
         run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
 
+      - name: Govern-decision eval (per-check precision/recall, fail-closed on missed secret/PII)
+        # 010-AT-RISK R5/R10 · bead compile-then-govern-e06.3: runs the govern
+        # decision over the versioned adversarial labeled set (dataset/v1) and
+        # prints PER-CHECK precision/recall + the false-negative list. Fails
+        # CLOSED on any UNDOCUMENTED false-negative — a missed secret/PII the
+        # dataset did not already flag as a known, tracked gap (i.e. a regression
+        # or a new evasion). Documented gaps (split keys, base64, boundary blind
+        # spots) are reported, not failed. Determinism is not efficacy; this gate
+        # makes the moat's catch-rate a required, measured property.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,14 @@ jobs:
         # with forks disclosed; a tampered brain must FAIL closed.
         run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
 
+      - name: Govern-decision eval (per-check precision/recall, fail-closed on missed secret/PII)
+        # 010-AT-RISK R5/R10 · bead compile-then-govern-e06.3: nightly run of the
+        # govern-decision efficacy eval over the adversarial labeled set. Prints
+        # per-check precision/recall; fails closed on any undocumented
+        # false-negative (a missed secret/PII the dataset did not flag as a known
+        # gap). Documented gaps are reported, not failed.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
+
       - name: Put workspace bins on PATH (qmd for the search-health canary)
         # qmd is a pinned root devDependency (@tobilu/qmd); the workspace bin
         # makes it discoverable so the reindex+canary CLI runs against a real

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+# gitleaks configuration — qmd-team-intent-kb
+#
+# Extends gitleaks' built-in ruleset (hundreds of curated provider rules) and
+# adds a TIGHTLY PATH-SCOPED allowlist for the govern-decision eval's adversarial
+# test fixtures. Those fixtures deliberately embed realistic-SHAPED but non-live
+# secret material to exercise the secret/PII detectors (bead
+# compile-then-govern-e06.3, risk 010-AT-RISK). Without this, gitleaks flags the
+# fixtures as real leaks and fails CI on the very test that PROVES the scanners
+# work.
+#
+# Safety: `useDefault = true` keeps every real gitleaks rule active repo-wide.
+# The allowlist is scoped by PATH regex to exactly the three fixture-bearing
+# files — a real key committed anywhere else still fails the scan. The AWS value
+# is AWS's own published EXAMPLE access-key id; the JWT is a random-body
+# fixture; neither is a live credential.
+
+title = "qmd-team-intent-kb gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "govern-decision eval adversarial test fixtures — non-live, shape-only secret material (e06.3)"
+# Path-scoped: only these fixture files are exempt. Anchored so a real leak
+# elsewhere is never allowlisted.
+paths = [
+  '''packages/eval-surface/src/govern-decision/dataset/v1/index\.ts''',
+  '''packages/eval-surface/src/__tests__/govern-decision\.test\.ts''',
+  '''apps/api/src/__tests__/services\.test\.ts''',
+]

--- a/apps/api/src/__tests__/services.test.ts
+++ b/apps/api/src/__tests__/services.test.ts
@@ -132,6 +132,86 @@ describe('CandidateService', () => {
     }
   });
 
+  // ---- R10 gap closure: tenantId + author free-text (Gemini HIGH) -----------
+  //
+  // The early-check's hand-maintained field list MISSED `tenantId` and the
+  // `author` free-text (`author.name` / `author.id`) even though the repository
+  // backstop (`assertDisclosureClean`) already scanned them — a bypass where a
+  // secret / PII hidden there slipped the EARLY gate and only tripped the deeper
+  // choke point. The fix derives the scanned set structurally via
+  // `collectFreeTextFields`, so the early gate now covers exactly the backstop's
+  // fields. These SPY-repo tests prove the early gate — not the backstop — now
+  // fires on those two surfaces (insert() never reached).
+
+  it('intake rejects an SSN hidden in tenantId at the early-check (R10 gap)', () => {
+    const { repo: stub, inserted } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'an ordinary architecture note',
+      tenantId: 'ssn-123-45-6789',
+    });
+    let status = 0;
+    try {
+      svc.intake(data);
+    } catch (err) {
+      if (err instanceof ApiError) status = err.statusCode;
+    }
+    expect(status).toBe(422);
+    // The early gate fired BEFORE the repository backstop.
+    expect(inserted()).toBe(false);
+  });
+
+  it('intake rejects a credential hidden in author.name at the early-check (R10 gap)', () => {
+    const { repo: stub, inserted } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'note about the deploy pipeline',
+      author: { type: 'ai', id: 'claude-1', name: 'AKIAIOSFODNN7EXAMPLE' },
+    });
+    let status = 0;
+    try {
+      svc.intake(data);
+    } catch (err) {
+      if (err instanceof ApiError) status = err.statusCode;
+    }
+    expect(status).toBe(422);
+    expect(inserted()).toBe(false);
+  });
+
+  it('intake rejects an SSN hidden in author.id at the early-check (R10 gap)', () => {
+    const { repo: stub, inserted } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'clean body',
+      author: { type: 'human', id: '123-45-6789' },
+    });
+    let status = 0;
+    try {
+      svc.intake(data);
+    } catch (err) {
+      if (err instanceof ApiError) status = err.statusCode;
+    }
+    expect(status).toBe(422);
+    expect(inserted()).toBe(false);
+  });
+
+  it('intake 422 for a tenantId leak does NOT echo the flagged value back (R10 gap)', () => {
+    const { repo: stub } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'clean',
+      tenantId: 'ssn-123-45-6789',
+    });
+    try {
+      svc.intake(data);
+      throw new Error('expected intake to reject');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        expect(err.message).not.toContain('123-45-6789');
+      }
+    }
+  });
+
   it('intake still accepts a clean candidate with benign metadata (R10 precision guard)', () => {
     // Uses the REAL repo so the accept path runs end-to-end (backstop included).
     const data = makeCandidate({

--- a/apps/api/src/__tests__/services.test.ts
+++ b/apps/api/src/__tests__/services.test.ts
@@ -51,6 +51,101 @@ describe('CandidateService', () => {
       }
     }
   });
+
+  // ---- R10: intake early-check scans metadata odd fields --------------------
+  //
+  // 010-AT-RISK R10 / bead compile-then-govern-e06.3: the intake() early-check
+  // used to scan only content/title/tags, so a secret or PII hidden in
+  // metadata.filePaths / projectContext bypassed THIS boundary and only tripped
+  // the deeper repository backstop. These tests use a SPY repo whose insert()
+  // throws if reached, so a clean 422 with insert() NEVER called proves the
+  // EARLY gate — not the backstop — now catches the odd-field leak.
+
+  /** A CandidateRepository double whose insert() fails the test if reached. */
+  function spyRepo(): { repo: CandidateRepository; inserted: () => boolean } {
+    let didInsert = false;
+    const stub = {
+      insert: () => {
+        didInsert = true;
+        throw new Error('repo.insert reached — the intake early-check did NOT gate this leak');
+      },
+      findById: () => null,
+      findByTenant: () => [],
+      findByContentHash: () => null,
+    } as unknown as CandidateRepository;
+    return { repo: stub, inserted: () => didInsert };
+  }
+
+  it('intake rejects an SSN hidden in metadata.filePaths at the early-check (R10)', () => {
+    const { repo: stub, inserted } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'a perfectly ordinary architecture note',
+      metadata: { filePaths: ['/records/patient-123-45-6789.txt'], tags: [] },
+    });
+    let status = 0;
+    try {
+      svc.intake(data);
+    } catch (err) {
+      if (err instanceof ApiError) status = err.statusCode;
+    }
+    expect(status).toBe(422);
+    // The early gate fired BEFORE the repository backstop.
+    expect(inserted()).toBe(false);
+  });
+
+  it('intake rejects a credential hidden in metadata.projectContext at the early-check (R10)', () => {
+    const { repo: stub, inserted } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'note about the deploy pipeline',
+      metadata: {
+        filePaths: [],
+        tags: [],
+        projectContext: 'onboarding for AKIAIOSFODNN7EXAMPLE',
+      },
+    });
+    let status = 0;
+    try {
+      svc.intake(data);
+    } catch (err) {
+      if (err instanceof ApiError) status = err.statusCode;
+    }
+    expect(status).toBe(422);
+    expect(inserted()).toBe(false);
+  });
+
+  it('intake 422 for an odd-field leak does NOT echo the flagged value back (R10)', () => {
+    const { repo: stub } = spyRepo();
+    const svc = new CandidateService(stub);
+    const data = makeCandidate({
+      content: 'clean',
+      metadata: { filePaths: ['/records/patient-123-45-6789.txt'], tags: [] },
+    });
+    try {
+      svc.intake(data);
+      throw new Error('expected intake to reject');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        expect(err.message).not.toContain('123-45-6789');
+      }
+    }
+  });
+
+  it('intake still accepts a clean candidate with benign metadata (R10 precision guard)', () => {
+    // Uses the REAL repo so the accept path runs end-to-end (backstop included).
+    const data = makeCandidate({
+      content: 'the store layer keeps raw and derived content separate',
+      metadata: {
+        filePaths: ['packages/store/src/repositories/policy-repository.ts'],
+        tags: ['store'],
+        projectContext: 'governed brain intake',
+      },
+    });
+    const candidate = service.intake(data);
+    expect(candidate.id).toBe(data['id']);
+    expect(repo.findById(candidate.id)).not.toBeNull();
+  });
 });
 
 describe('MemoryService', () => {

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -31,10 +31,34 @@ export class CandidateService {
     // at the repository choke point as the real backstop — see
     // CandidateRepository.insert). The matched value is never echoed back
     // (PII non-leak).
+    //
+    // R10 fix (010-AT-RISK · bead compile-then-govern-e06.3): the early-check
+    // scanned only content/title/tags, so a secret or PII hidden in an "odd"
+    // metadata field (e.g. an SSN in `metadata.filePaths`, a key in
+    // `projectContext`) slipped THIS boundary and only tripped the deeper
+    // repository choke point — a worse error surface, and a real leak the moment
+    // any path skips that backstop. The govern-decision eval demonstrates the
+    // exact filePath leak this closes. We now scan the same free-text metadata
+    // surface: filePaths, projectContext, repoUrl, branch, language, sessionId.
+    // `category` is enum-constrained (MemoryCategory) so it carries no
+    // attacker-controlled free text, but it is scanned too for parity with the
+    // R10 spec — a no-op on the closed vocabulary, cheap insurance if the enum
+    // ever widens.
+    const meta = candidate.metadata;
+    const metadataFreeText = [
+      ...meta.filePaths,
+      ...(meta.projectContext !== undefined ? [meta.projectContext] : []),
+      ...(meta.repoUrl !== undefined ? [meta.repoUrl] : []),
+      ...(meta.branch !== undefined ? [meta.branch] : []),
+      ...(meta.language !== undefined ? [meta.language] : []),
+      ...(meta.sessionId !== undefined ? [meta.sessionId] : []),
+    ];
     const violation = scanDisclosureFields([
       candidate.content,
       candidate.title,
+      candidate.category,
       ...candidate.metadata.tags,
+      ...metadataFreeText,
     ]);
     if (violation !== null) {
       const kind =

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -1,6 +1,10 @@
 import type { CandidateRepository } from '@qmd-team-intent-kb/store';
 import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
-import { computeContentHash, scanDisclosureFields } from '@qmd-team-intent-kb/common';
+import {
+  computeContentHash,
+  scanDisclosureFields,
+  collectFreeTextFields,
+} from '@qmd-team-intent-kb/common';
 import { badRequest, notFound, unprocessable } from '../errors.js';
 
 /**
@@ -33,33 +37,24 @@ export class CandidateService {
     // (PII non-leak).
     //
     // R10 fix (010-AT-RISK · bead compile-then-govern-e06.3): the early-check
-    // scanned only content/title/tags, so a secret or PII hidden in an "odd"
-    // metadata field (e.g. an SSN in `metadata.filePaths`, a key in
-    // `projectContext`) slipped THIS boundary and only tripped the deeper
-    // repository choke point — a worse error surface, and a real leak the moment
-    // any path skips that backstop. The govern-decision eval demonstrates the
-    // exact filePath leak this closes. We now scan the same free-text metadata
-    // surface: filePaths, projectContext, repoUrl, branch, language, sessionId.
-    // `category` is enum-constrained (MemoryCategory) so it carries no
-    // attacker-controlled free text, but it is scanned too for parity with the
-    // R10 spec — a no-op on the closed vocabulary, cheap insurance if the enum
-    // ever widens.
-    const meta = candidate.metadata;
-    const metadataFreeText = [
-      ...meta.filePaths,
-      ...(meta.projectContext !== undefined ? [meta.projectContext] : []),
-      ...(meta.repoUrl !== undefined ? [meta.repoUrl] : []),
-      ...(meta.branch !== undefined ? [meta.branch] : []),
-      ...(meta.language !== undefined ? [meta.language] : []),
-      ...(meta.sessionId !== undefined ? [meta.sessionId] : []),
-    ];
-    const violation = scanDisclosureFields([
-      candidate.content,
-      candidate.title,
-      candidate.category,
-      ...candidate.metadata.tags,
-      ...metadataFreeText,
-    ]);
+    // scanned only a HAND-MAINTAINED subset (content/title/tags, later a few
+    // metadata fields), so a secret or PII hidden in any un-enumerated free-text
+    // surface slipped THIS boundary and only tripped the deeper repository choke
+    // point — a worse error surface, and a real leak the moment any path skips
+    // that backstop. The last-enumerated list still MISSED `tenantId` and the
+    // `author` free-text (`author.name`, `author.id`), both of which the backstop
+    // (`assertDisclosureClean`) and the govern-decision eval already scan — a
+    // known bypass.
+    //
+    // The fix (Gemini review, HIGH): derive the scanned set STRUCTURALLY via
+    // `collectFreeTextFields(candidate)` — the exact same walker the repository
+    // backstop uses. This scans every persisted free-text surface (content,
+    // title, tenantId, every tag, all ContentMetadata free-text, and the author
+    // free-text), skipping only enum-constrained fields by name. The early gate
+    // now covers EXACTLY the same fields as the backstop, so no un-enumerated
+    // free-text column can bypass it, and future schema additions are covered
+    // automatically with no manual list to drift.
+    const violation = scanDisclosureFields(collectFreeTextFields(candidate));
     if (violation !== null) {
       const kind =
         violation.category === 'pii'

--- a/packages/eval-surface/package.json
+++ b/packages/eval-surface/package.json
@@ -17,10 +17,13 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "provenance:ci": "tsx scripts/ci-provenance-integrity.ts"
+    "provenance:ci": "tsx scripts/ci-provenance-integrity.ts",
+    "govern:ci": "tsx scripts/ci-govern-decision.ts"
   },
   "dependencies": {
+    "@qmd-team-intent-kb/claude-runtime": "workspace:*",
     "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/policy-engine": "workspace:*",
     "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/store": "workspace:*"
   },

--- a/packages/eval-surface/scripts/ci-govern-decision.ts
+++ b/packages/eval-surface/scripts/ci-govern-decision.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+/**
+ * CI govern-decision gate — runs the govern-decision efficacy eval over the
+ * versioned adversarial labeled set (dataset/v1) and FAILS CLOSED if any
+ * KNOWN-POSITIVE case is an UNDOCUMENTED false-negative (a missed secret/PII
+ * that the dataset did not already flag as a known gap).
+ *
+ * Why this exists (010-AT-RISK R5/R10 · bead compile-then-govern-e06.3 · umbrella #27):
+ * the 8 govern rules are verified-deterministic but were UNEVALUATED for
+ * efficacy. Determinism is not correctness — a line-based regex secret-scan is
+ * deterministic AND misses a split/base64 key (the CISO's top fear). This gate
+ * makes the govern decision's efficacy a required, measured property:
+ *
+ *   - It prints PER-CHECK precision / recall / F1 and the full false-negative
+ *     list (documented gaps + any surprises) so the numbers are visible in CI
+ *     logs — the deliverable is real numbers, even when they reveal gaps.
+ *   - It EXITS NON-ZERO on any UNDOCUMENTED false-negative: a regression where a
+ *     check that used to catch a positive stops firing, or a labeled catch that
+ *     silently fails. Documented gaps (split keys, base64, boundary blind spots)
+ *     do NOT fail the build — they are tracked follow-ups, surfaced not hidden.
+ *
+ * Mirrors packages/eval-surface/scripts/ci-provenance-integrity.ts (the R5 gate
+ * pattern): a real end-to-end run, wired into ci.yml + nightly.yml as a named
+ * step. No durable state touched — the eval is pure.
+ *
+ * Exit 0 when there are zero undocumented false-negatives; non-zero (with a
+ * diagnostic) otherwise.
+ */
+
+import { evaluateGovernDecision } from '../src/index.js';
+import type { GovernDecisionReport } from '../src/index.js';
+
+const result = evaluateGovernDecision();
+const report = JSON.parse(String(result.details.report_json)) as GovernDecisionReport;
+
+process.stdout.write(
+  `govern-decision eval — dataset v${String(result.details.dataset_version)}: ` +
+    `${report.totalCases} cases (${report.positives} positive / ${report.negatives} negative)\n`,
+);
+
+process.stdout.write('\nPER-CHECK precision / recall / F1:\n');
+for (const m of report.perCheck) {
+  process.stdout.write(
+    `  ${m.check.padEnd(22)} P=${m.precision.toFixed(4)} R=${m.recall.toFixed(4)} ` +
+      `F1=${m.f1.toFixed(4)}  (TP=${m.truePositives} FP=${m.falsePositives} ` +
+      `FN=${m.falseNegatives} TN=${m.trueNegatives})\n`,
+  );
+}
+process.stdout.write(`\nmean F1 (reporting score): ${result.score}\n`);
+
+if (report.falseNegatives.length > 0) {
+  process.stdout.write('\nFalse-negatives (documented = a known, tracked gap):\n');
+  for (const f of report.falseNegatives) {
+    process.stdout.write(
+      `  ${f.caseId.padEnd(28)} ${f.check.padEnd(22)} ` +
+        `class=${f.sensitiveClass} surface=${f.surface} documented=${f.documented}\n`,
+    );
+  }
+}
+
+if (report.undocumentedFalseNegatives.length > 0) {
+  process.stderr.write(
+    `\nci-govern-decision FAILED: ${report.undocumentedFalseNegatives.length} ` +
+      `UNDOCUMENTED false-negative(s) — a missed secret/PII the dataset did not ` +
+      `already flag as a known gap. Either the govern decision regressed, or a ` +
+      `new evasion needs a fix (not a relabel). Cases:\n`,
+  );
+  for (const f of report.undocumentedFalseNegatives) {
+    process.stderr.write(`  - ${f.caseId} (${f.check}, ${f.sensitiveClass}/${f.surface})\n`);
+  }
+  process.exitCode = 1;
+} else {
+  process.stdout.write(
+    '\nci-govern-decision OK — zero undocumented false-negatives ' +
+      '(all misses are documented, tracked gaps).\n',
+  );
+}

--- a/packages/eval-surface/src/__tests__/govern-decision.test.ts
+++ b/packages/eval-surface/src/__tests__/govern-decision.test.ts
@@ -1,0 +1,144 @@
+/**
+ * govern-decision evaluator unit tests.
+ *
+ * Asserts the eval's structural guarantees on the v1 labeled set:
+ *  - It scores ≥30 cases with the four checks.
+ *  - Inline secrets/PII are CAUGHT (recall > 0 on the relevant checks).
+ *  - Benign negatives do NOT fire (no false positives → precision 1.0).
+ *  - There are ZERO undocumented false-negatives on the shipped set (so the
+ *    default CI gate is green), and the documented gaps ARE reported.
+ *  - Fed a SYNTHETIC set, it correctly flags a regression (a case that should be
+ *    caught but is not) as an undocumented FN → passed:false, and correctly
+ *    flags a false positive on a benign case.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { evaluateGovernDecision, GOVERN_CASES, GOVERN_DATASET_VERSION } from '../index.js';
+import type { GovernCase, GovernDecisionReport } from '../index.js';
+
+function report(result: ReturnType<typeof evaluateGovernDecision>): GovernDecisionReport {
+  return JSON.parse(String(result.details.report_json)) as GovernDecisionReport;
+}
+
+describe('evaluateGovernDecision — shipped v1 set', () => {
+  it('scores at least 30 labeled cases with a version stamp', () => {
+    const r = evaluateGovernDecision();
+    expect(r.name).toBe('govern-decision');
+    expect(Number(r.details.total_cases)).toBeGreaterThanOrEqual(30);
+    expect(r.details.dataset_version).toBe(GOVERN_DATASET_VERSION);
+    expect(GOVERN_CASES.length).toBe(Number(r.details.total_cases));
+  });
+
+  it('PASSES on the shipped set — zero UNDOCUMENTED false-negatives', () => {
+    const r = evaluateGovernDecision();
+    // The gating property: every miss is either an expected catch that fired, or
+    // a documented (tracked) gap. A surprise miss would flip this false.
+    expect(r.details.undocumented_false_negatives).toBe(0);
+    expect(r.passed).toBe(true);
+  });
+
+  it('reports the documented gaps rather than hiding them', () => {
+    const r = evaluateGovernDecision();
+    // Split keys, base64 tokens, odd-field leaks etc. ARE documented FNs — the
+    // honest output of the eval. There must be several.
+    expect(Number(r.details.documented_false_negatives)).toBeGreaterThan(0);
+  });
+
+  it('the boundary-disclosure filter has ZERO false positives (precision 1.0)', () => {
+    const rep = report(evaluateGovernDecision());
+    const boundary = rep.perCheck.find((m) => m.check === 'boundary-disclosure');
+    expect(boundary!.falsePositives).toBe(0);
+    expect(boundary!.precision).toBe(1);
+  });
+
+  it('the ONLY false positives are the documented UUID over-block (heroku-key regex)', () => {
+    // Real precision finding (see README §5): the `heroku-api-key` rule is a bare
+    // UUID regex, so a UUID in prose (neg-uuid-in-prose-01) is over-flagged by
+    // scanForSecrets / classifyContent, dragging those three checks below 1.0.
+    // This is surfaced, not hidden — but it must stay bounded to exactly that one
+    // benign case (FP ≤ 1 per check), so a NEW over-block regression is caught.
+    const rep = report(evaluateGovernDecision());
+    for (const m of rep.perCheck) {
+      expect(m.falsePositives).toBeLessThanOrEqual(1);
+    }
+    // The three content checks lose precision only via that single case.
+    const contentChecks = rep.perCheck.filter((m) => m.check !== 'boundary-disclosure');
+    for (const m of contentChecks) {
+      expect(m.precision).toBeGreaterThan(0.85);
+    }
+  });
+
+  it('catches inline secrets on the line-based secret scanner (recall > 0)', () => {
+    const rep = report(evaluateGovernDecision());
+    const secretScanner = rep.perCheck.find((m) => m.check === 'secret-scanner');
+    expect(secretScanner).toBeDefined();
+    expect(secretScanner!.truePositives).toBeGreaterThan(0);
+    expect(secretScanner!.recall).toBeGreaterThan(0);
+  });
+
+  it('surfaces split-key and base64 evasions as documented false-negatives', () => {
+    const rep = report(evaluateGovernDecision());
+    const surfaces = new Set(rep.falseNegatives.map((f) => f.surface));
+    expect(surfaces.has('split-multiline')).toBe(true);
+    expect(surfaces.has('base64-encoded')).toBe(true);
+  });
+
+  it('demonstrates the boundary filter catching odd-field (filePath) leaks (R10)', () => {
+    const rep = report(evaluateGovernDecision());
+    const boundary = rep.perCheck.find((m) => m.check === 'boundary-disclosure');
+    // The boundary check scans the derived free-text surface incl. metadata, so
+    // the filePath/projectContext/tenant-spoof cases are TRUE POSITIVES for it —
+    // proving the leak the R10 intake fix closes is a real one the filter sees.
+    expect(boundary!.truePositives).toBeGreaterThan(0);
+  });
+});
+
+describe('evaluateGovernDecision — synthetic regression detection', () => {
+  it('flags an UNDOCUMENTED miss (a should-catch case that does not fire) as passed:false', () => {
+    // A case that SHOULD be caught by the secret-scanner but carries no secret →
+    // the scanner will NOT fire → an undocumented false-negative → fail closed.
+    const regression: GovernCase = {
+      id: 'synthetic-regression-01',
+      description: 'labeled positive that the scanner cannot see (simulated regression)',
+      sensitiveClass: 'secret',
+      surface: 'inline',
+      candidate: { content: 'this text contains no secret at all, just prose' },
+      expectCaughtBy: ['secret-scanner'],
+    };
+    const r = evaluateGovernDecision({ cases: [regression] });
+    expect(r.details.undocumented_false_negatives).toBe(1);
+    expect(r.passed).toBe(false);
+  });
+
+  it('counts a firing check on a benign case as a false positive (precision < 1)', () => {
+    const falsePositiveProbe: GovernCase = {
+      id: 'synthetic-fp-01',
+      description: 'a benign case that actually carries an inline key (mislabeled negative)',
+      sensitiveClass: 'none',
+      surface: 'benign',
+      candidate: { content: 'oops AKIAIOSFODNN7EXAMPLE leaked into a "benign" case' },
+      expectCaughtBy: [],
+    };
+    const rep = report(evaluateGovernDecision({ cases: [falsePositiveProbe] }));
+    const secretScanner = rep.perCheck.find((m) => m.check === 'secret-scanner');
+    expect(secretScanner!.falsePositives).toBe(1);
+    expect(secretScanner!.precision).toBeLessThan(1);
+  });
+
+  it('a case whose miss is DOCUMENTED does not fail the eval', () => {
+    const documentedGap: GovernCase = {
+      id: 'synthetic-documented-01',
+      description: 'a base64-wrapped key we already know the scanner misses',
+      sensitiveClass: 'secret',
+      surface: 'base64-encoded',
+      candidate: { content: `blob ${Buffer.from('sk-xxx', 'utf8').toString('base64')}` },
+      expectCaughtBy: [],
+      knownFalseNegativeOf: ['secret-scanner'],
+    };
+    const r = evaluateGovernDecision({ cases: [documentedGap] });
+    expect(r.details.undocumented_false_negatives).toBe(0);
+    expect(Number(r.details.documented_false_negatives)).toBeGreaterThanOrEqual(1);
+    expect(r.passed).toBe(true);
+  });
+});

--- a/packages/eval-surface/src/govern-decision.ts
+++ b/packages/eval-surface/src/govern-decision.ts
@@ -1,0 +1,289 @@
+/**
+ * govern-decision evaluator — does the deterministic govern decision actually
+ * CATCH what it must, or is it merely deterministic?
+ *
+ * ## Why (010-AT-RISK R5/R10 · bead compile-then-govern-e06.3 · umbrella #27)
+ *
+ * The 8 policy rules are verified-*deterministic* (same input → same verdict)
+ * but their EFFICACY was never measured. Determinism is not correctness: a
+ * line-based regex secret-scan is perfectly deterministic AND misses a key
+ * split across two lines or a base64-wrapped token — the CISO's top fear (a
+ * leaked key promoted with a clean receipt). This evaluator runs the govern
+ * decision over an adversarial labeled set (dataset/v1) and reports PER-CHECK
+ * precision / recall + a false-negative list, so the moat's efficacy is a
+ * measured number, not a claim.
+ *
+ * It scores four independent detection surfaces (see {@link GovernCheck}):
+ *   - `policy-pipeline`     — the full `PolicyPipeline.evaluate` verdict (rejected?)
+ *   - `secret-scanner`      — `scanForSecrets` (claude-runtime)
+ *   - `content-classifier`  — `classifyContent` (claude-runtime) → non-public?
+ *   - `boundary-disclosure` — `scanForDisclosure` over the SAME free-text surfaces
+ *                             the repository-boundary gate (`assertDisclosureClean`)
+ *                             walks — content + title + tags + metadata free-text
+ *                             (filePaths, projectContext, …) + tenantId + author.
+ *
+ * Scoring is honest by construction: labels in the dataset are empirical, and a
+ * MEASURED false-negative NOT already documented in a case's
+ * `knownFalseNegativeOf` is surfaced in `undocumentedFalseNegatives` — the CI
+ * gate fails closed on any such surprise. Documented gaps (split keys, base64,
+ * boundary-filter blind spots) are reported but do not fail the build; they are
+ * the honest output of the eval, tracked as follow-ups, never hidden by
+ * weakening a rule.
+ *
+ * Pure w.r.t. durable state: takes no repositories, reads no files, emits/signs
+ * nothing. It classifies in-memory candidates and returns a verdict — the same
+ * measure-don't-mutate posture as the other eval-surface evaluators.
+ */
+
+import { classifyContent, scanForSecrets } from '@qmd-team-intent-kb/claude-runtime';
+import { collectFreeTextFields, scanDisclosureFields } from '@qmd-team-intent-kb/common';
+import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import { GovernancePolicy, type MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+import type { EvaluatorResult } from './types.js';
+import type {
+  CheckMetrics,
+  FalseNegative,
+  GovernCase,
+  GovernCheck,
+  GovernDecisionReport,
+} from './govern-decision/types.js';
+import { DATASET_VERSION } from './govern-decision/dataset/v1/index.js';
+import { loadDataset, type LoadedCase } from './govern-decision/dataset/v1/load.js';
+
+const ALL_CHECKS: readonly GovernCheck[] = [
+  'policy-pipeline',
+  'secret-scanner',
+  'content-classifier',
+  'boundary-disclosure',
+];
+
+/**
+ * The govern policy the eval exercises: the security-relevant subset of the 8
+ * rules, both set to `reject`, so `policy-pipeline` = "does the govern decision
+ * REJECT this candidate". Priorities mirror the production ordering (secret
+ * detection first). Built via Zod parse so it is a real GovernancePolicy.
+ */
+function buildGovernPolicy(): GovernancePolicy {
+  return GovernancePolicy.parse({
+    id: '00000000-0000-4000-8000-00000000e063',
+    name: 'govern-decision eval policy (secret + sensitivity, reject)',
+    tenantId: 'govern-eval-tenant',
+    rules: [
+      {
+        id: 'rule-secret-detect',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+      {
+        id: 'rule-sensitivity-gate',
+        type: 'sensitivity_gate',
+        action: 'reject',
+        enabled: true,
+        priority: 1,
+        // Block the two most-sensitive levels (restricted = creds, confidential
+        // = PII). `internal` (path leaks) is intentionally NOT rejected — the
+        // content_sanitization rule FLAGS those; rejecting would over-block.
+        parameters: { blockedLevels: ['restricted', 'confidential'] },
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: '2026-06-30T00:00:00.000Z',
+    updatedAt: '2026-06-30T00:00:00.000Z',
+  });
+}
+
+/** Did a given check FIRE on this candidate (detect something sensitive)? */
+function checkFired(
+  check: GovernCheck,
+  candidate: MemoryCandidate,
+  pipeline: PolicyPipeline,
+): boolean {
+  switch (check) {
+    case 'policy-pipeline': {
+      // The govern decision fires when the pipeline REJECTS the candidate.
+      return pipeline.evaluate(candidate).outcome === 'rejected';
+    }
+    case 'secret-scanner': {
+      return scanForSecrets(candidate.content).length > 0;
+    }
+    case 'content-classifier': {
+      // Fires when the content is classified above `public` (internal / PII /
+      // credentials all count as "the classifier saw something").
+      return classifyContent(candidate.content).sensitivityLevel !== 'public';
+    }
+    case 'boundary-disclosure': {
+      // Scan the SAME derived free-text surface the repository-boundary gate
+      // walks (content, title, tags, ALL metadata free-text incl. filePaths /
+      // projectContext, tenantId, author) — the structural set from
+      // collectFreeTextFields. This is what `assertDisclosureClean` enforces and
+      // what the R10 fix makes the API intake early-check consistent with.
+      return scanDisclosureFields(collectFreeTextFields(candidate)) !== null;
+    }
+  }
+}
+
+/** Compute precision / recall / F1 from raw confusion-matrix counts. */
+function metricsFor(
+  check: GovernCheck,
+  tp: number,
+  fp: number,
+  fn: number,
+  tn: number,
+): CheckMetrics {
+  const precision = tp + fp === 0 ? 1 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 1 : tp / (tp + fn);
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+  return {
+    check,
+    truePositives: tp,
+    falsePositives: fp,
+    falseNegatives: fn,
+    trueNegatives: tn,
+    precision: Number(precision.toFixed(4)),
+    recall: Number(recall.toFixed(4)),
+    f1: Number(f1.toFixed(4)),
+  };
+}
+
+/** Whether the case documented this check as a known miss. */
+function isDocumentedMiss(def: GovernCase, check: GovernCheck): boolean {
+  return (def.knownFalseNegativeOf ?? []).includes(check);
+}
+
+export interface GovernDecisionOptions {
+  /** Override the labeled set (defaults to dataset/v1). Used by tests. */
+  readonly cases?: readonly GovernCase[];
+  /**
+   * Pass threshold for the aggregate score. The GATING property, however, is
+   * not the score — it is "zero UNDOCUMENTED false-negatives" (see below).
+   * Default 0.0 (score is reporting-only; the binary gate is FN-driven).
+   */
+  readonly threshold?: number;
+}
+
+/**
+ * Run the govern-decision efficacy eval.
+ *
+ * Verdict (`passed`) is the SECURITY property, mirroring provenance-integrity's
+ * "fail only on genuine tampering":
+ *
+ *     passed = undocumentedFalseNegatives.length === 0
+ *
+ * i.e. every positive case is either CAUGHT by an expected check, or its miss
+ * is already DOCUMENTED in the dataset (a known, tracked gap). A NEW miss —
+ * a regression where a check that used to catch a case stops firing, or a case
+ * whose expected catch silently fails — flips `passed:false`. Documented gaps
+ * (split keys, base64, boundary blind spots) are reported in `details` but do
+ * NOT fail the build: they are the honest measured output, tracked as
+ * follow-up beads, and the point of the whole eval is to surface them.
+ *
+ * The continuous `score` is the mean per-check F1 across all four checks — a
+ * reporting number, never the pass/fail decision (per the eval-surface
+ * contract: the platform refuses gradient scores AS the verdict).
+ */
+export function evaluateGovernDecision(options: GovernDecisionOptions = {}): EvaluatorResult {
+  const loaded: LoadedCase[] = loadDataset(options.cases);
+  const pipeline = new PolicyPipeline(buildGovernPolicy());
+
+  const positives = loaded.filter((l) => l.def.sensitiveClass !== 'none');
+  const negatives = loaded.filter((l) => l.def.sensitiveClass === 'none');
+
+  const perCheck: CheckMetrics[] = [];
+  const falseNegatives: FalseNegative[] = [];
+
+  for (const check of ALL_CHECKS) {
+    let tp = 0;
+    let fp = 0;
+    let fn = 0;
+    let tn = 0;
+
+    for (const { def, candidate } of positives) {
+      // A positive is "in scope" for a check when the case expects THAT check to
+      // catch it, OR documents that check as a known miss. Checks a case never
+      // names (e.g. secret-scanner on a pure-PII case — SSNs are not secrets)
+      // are out of scope for that case and do not count toward its recall.
+      const expected = def.expectCaughtBy.includes(check);
+      const documentedMiss = isDocumentedMiss(def, check);
+      if (!expected && !documentedMiss) continue;
+
+      const fired = checkFired(check, candidate, pipeline);
+      if (fired) {
+        tp += 1;
+      } else {
+        fn += 1;
+        falseNegatives.push({
+          caseId: def.id,
+          check,
+          sensitiveClass: def.sensitiveClass,
+          surface: def.surface,
+          documented: documentedMiss,
+        });
+      }
+    }
+
+    for (const { candidate } of negatives) {
+      // Every negative is in scope for every check: a firing check on a benign
+      // case is a FALSE POSITIVE (precision hit), regardless of labels.
+      const fired = checkFired(check, candidate, pipeline);
+      if (fired) fp += 1;
+      else tn += 1;
+    }
+
+    perCheck.push(metricsFor(check, tp, fp, fn, tn));
+  }
+
+  const undocumentedFalseNegatives = falseNegatives.filter((f) => !f.documented);
+
+  const report: GovernDecisionReport = {
+    totalCases: loaded.length,
+    positives: positives.length,
+    negatives: negatives.length,
+    perCheck,
+    falseNegatives,
+    undocumentedFalseNegatives,
+  };
+
+  const meanF1 =
+    perCheck.length === 0 ? 1 : perCheck.reduce((s, m) => s + m.f1, 0) / perCheck.length;
+
+  // GATING property: zero undocumented (surprise / regression) false-negatives.
+  const passed = undocumentedFalseNegatives.length === 0;
+  const threshold = options.threshold ?? 0;
+
+  return {
+    name: 'govern-decision',
+    passed,
+    score: Number(meanF1.toFixed(4)),
+    threshold,
+    details: {
+      dataset_version: DATASET_VERSION,
+      total_cases: report.totalCases,
+      positives: report.positives,
+      negatives: report.negatives,
+      undocumented_false_negatives: undocumentedFalseNegatives.length,
+      documented_false_negatives: falseNegatives.length - undocumentedFalseNegatives.length,
+      mean_f1: Number(meanF1.toFixed(4)),
+      // Per-check precision/recall as flat, JSON-serialisable fields (the
+      // EvaluatorResult.details value type is number|string|boolean).
+      ...flattenPerCheck(perCheck),
+      // The full structured report for the CI script / bundle, as JSON.
+      report_json: JSON.stringify(report),
+    },
+  };
+}
+
+/** Flatten per-check metrics into `precision.<check>` / `recall.<check>` fields. */
+function flattenPerCheck(perCheck: readonly CheckMetrics[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const m of perCheck) {
+    out[`precision.${m.check}`] = m.precision;
+    out[`recall.${m.check}`] = m.recall;
+    out[`f1.${m.check}`] = m.f1;
+  }
+  return out;
+}

--- a/packages/eval-surface/src/govern-decision/dataset/v1/README.md
+++ b/packages/eval-surface/src/govern-decision/dataset/v1/README.md
@@ -1,0 +1,125 @@
+# govern-decision adversarial labeled set — v1
+
+**Version:** `1.0.0` · **Cases:** 32 (22 positive · 10 negative) ·
+**Bead:** `compile-then-govern-e06.3` · **Risk:** `010-AT-RISK` R5 / R10 ·
+**Umbrella:** `intent-solutions-io/governed-second-brain#27`
+
+This is the versioned, labeled adversarial set that measures the **efficacy** of
+the Governed Second Brain's deterministic govern decision — not merely its
+determinism. The 8 policy rules are verified-_deterministic_ (same input →
+same verdict), but a line-based regex secret-scan is perfectly deterministic
+**and** misses a key split across two lines or a base64-wrapped token. This set
+plus the `evaluateGovernDecision` evaluator (`../../../govern-decision.ts`) turn
+that unmeasured moat into **per-check precision / recall** numbers, with a
+false-negative list that is surfaced, never hidden.
+
+> The CISO's top fear: a leaked key promoted with a clean receipt. This set
+> exists to prove — or disprove — that we catch it.
+
+## What each case is
+
+Every entry in `index.ts` (`GOVERN_CASES`) is a `GovernCase`:
+
+| field                  | meaning                                                                                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | stable, unique, human-readable (e.g. `sec-split-openai-01`)                                                                                                     |
+| `sensitiveClass`       | `secret` · `pii` · `internal-path` · `none` (negative)                                                                                                          |
+| `surface`              | the smuggling technique: `inline`, `split-multiline`, `base64-encoded`, `hex-encoded`, `metadata-filepath`, `metadata-projectcontext`, `tenant-spoof`, `benign` |
+| `candidate`            | a partial `MemoryCandidate` (merged over a benign default, Zod-parsed)                                                                                          |
+| `expectCaughtBy`       | the checks a **healthy** moat fires on this positive                                                                                                            |
+| `knownFalseNegativeOf` | checks **empirically confirmed** to miss it today (documented gaps)                                                                                             |
+
+The four scored **checks** are the independent detection surfaces of the govern
+decision:
+
+- **`policy-pipeline`** — the full `PolicyPipeline.evaluate` verdict (rejected?),
+  using the security subset of the 8 rules (`secret_detection` +
+  `sensitivity_gate`, both `reject`).
+- **`secret-scanner`** — `scanForSecrets` (claude-runtime), the signal behind
+  the `secret_detection` rule.
+- **`content-classifier`** — `classifyContent` (claude-runtime), the signal
+  behind the `sensitivity_gate` rule.
+- **`boundary-disclosure`** — `scanForDisclosure` over the derived free-text
+  surface the repository choke point walks (content + title + tags + **all
+  metadata free-text incl. `filePaths` / `projectContext`** + `tenantId` +
+  `author`). This is the surface the R10 intake fix makes the API early-check
+  consistent with.
+
+## How the labels were set (honesty guarantee)
+
+Every `expectCaughtBy` / `knownFalseNegativeOf` was set from an **empirical
+probe** of the real scanners on the exact case material — not from assumption.
+The evaluator re-derives those outcomes at run time and **fails closed** if a
+label drifts (an undocumented false-negative). So the dataset and the code
+cannot silently disagree: a relabel that hides a real miss is caught by the CI
+gate, and a code regression that breaks a real catch is caught the same way.
+
+## Measured results (v1.0.0, this commit)
+
+Reporting score = mean per-check F1 = **0.7333**. Gate = **zero undocumented
+false-negatives** → PASS.
+
+| check                 | precision  | recall | F1     | TP  | FP  | FN  | TN  |
+| --------------------- | ---------- | ------ | ------ | --- | --- | --- | --- |
+| `policy-pipeline`     | 0.9167     | 0.5789 | 0.7097 | 11  | 1   | 8   | 9   |
+| `secret-scanner`      | 0.9000     | 0.5625 | 0.6923 | 9   | 1   | 7   | 9   |
+| `content-classifier`  | 0.9333     | 0.6364 | 0.7568 | 14  | 1   | 8   | 9   |
+| `boundary-disclosure` | **1.0000** | 0.6316 | 0.7742 | 12  | 0   | 7   | 10  |
+
+Recall in the ~0.56–0.64 band is **the point of the eval**, not a bug to paper
+over: the missed positives are the documented evasions below. The scoping rule
+is that a check only counts toward a case's recall when the case names it in
+`expectCaughtBy` or `knownFalseNegativeOf` — so e.g. the secret-scanner is not
+penalised for "missing" an SSN (SSNs are PII, not secrets).
+
+## Documented gaps this set proves (real findings — follow-up bead candidates)
+
+These are the honest output of the eval. They are **documented**, so they do not
+fail CI, but each is a genuine hole in the moat worth a follow-up bead. **None
+was fixed by weakening a rule.**
+
+1. **Split-across-newline keys → FALSE NEGATIVE on all in-content checks.**
+   `scanForSecrets` splits on `\n` and matches each line, so a key broken across
+   two lines (`sec-split-openai-01`, `sec-split-aws-01`) is invisible to the
+   secret scanner, the classifier, the policy pipeline, **and** the boundary
+   filter. _This is the CISO's exact fear._ Fix candidate: a windowed / newline-
+   collapsed pre-pass before the line scan.
+
+2. **Base64-wrapped tokens → FALSE NEGATIVE everywhere.** No detector decodes
+   base64 before matching (`sec-b64-openai-01`, `sec-b64-github-01`). Fix
+   candidate: a bounded base64-decode-and-rescan pass on high-entropy blobs.
+
+3. **The line-scanner and the boundary filter have DIVERGENT rule sets.**
+   - Boundary filter misses: DB connection strings (`sec-inline-connstr-01`),
+     generic `KEY=value` env assignments (`sec-inline-envassign-01`), and
+     hex-encoded keys (`sec-hex-aws-01`) — all caught by the line scanner.
+   - The claude-runtime classifier misses **DOB** (`pii-inline-dob-01`): its PII
+     set is EMAIL / PHONE / SSN only, while the boundary filter's PII pattern
+     includes `date of birth` / `DOB:`. So a DOB-only leak passes the policy
+     pipeline but is caught at the repository boundary.
+   - The boundary filter misses **email** (`pii-inline-email-01`) by design
+     (email is often legitimate); the classifier flags it.
+     Fix candidate: converge the two vocabularies (or document the split as
+     intentional per field).
+
+4. **Odd-field leaks (`metadata.filePaths` / `projectContext`) and
+   `tenantId` spoofing are invisible to the content-only checks.** The policy
+   pipeline scans `candidate.content` only, so a secret/PII in `filePaths`
+   (`pii-filepath-ssn-01`, `sec-filepath-aws-01`), `projectContext`
+   (`pii-projectcontext-ssn-01`), or a spoofed `tenantId`
+   (`spoof-tenant-secret-01`) is caught **only** by the boundary filter. The
+   **R10 fix** in this PR extends the API intake early-check to that surface so
+   it is caught at the boundary too (not just the deeper repository backstop).
+
+5. **PRECISION finding — the `heroku-api-key` rule is a bare UUID regex.** A
+   plain UUID in prose (`neg-uuid-in-prose-01`) is flagged as a credential by
+   `scanForSecrets` / `classifyContent`, so those checks lose precision
+   (0.90 / 0.93) and the policy pipeline over-rejects a benign note. The
+   boundary filter (no UUID rule) stays at precision 1.0. Fix candidate: gate
+   the UUID rule behind a key-context keyword, or drop it.
+
+## Bumping the set
+
+Bump `DATASET_VERSION` in `index.ts` on any add / remove / relabel, so the eval
+report, the CI gate, and any future baseline pin the exact set they scored.
+Re-run the empirical probe when adding a case — never label from assumption.

--- a/packages/eval-surface/src/govern-decision/dataset/v1/index.ts
+++ b/packages/eval-surface/src/govern-decision/dataset/v1/index.ts
@@ -1,0 +1,480 @@
+/**
+ * govern-decision adversarial labeled dataset — v1.
+ *
+ * A versioned (dataset/v1), self-describing set of ≥30 labeled cases that
+ * measures the EFFICACY of the govern decision, not just its determinism.
+ * See ./README.md for the schema, the class/surface taxonomy, and the list of
+ * documented false-negatives this set proves out.
+ *
+ * ## Provenance of the labels (010-AT-RISK R5/R10 · bead compile-then-govern-e06.3)
+ *
+ * Every `expectCaughtBy` / `knownFalseNegativeOf` label was set from an
+ * EMPIRICAL probe of the real scanners (claude-runtime `scanForSecrets` /
+ * `classifyContent`, common `scanForDisclosure`) on this exact material — not
+ * from assumption. The govern-decision eval then re-derives those outcomes and
+ * fails closed if a label drifts (see the eval's undocumented-FN gate). So the
+ * dataset and the code cannot silently disagree.
+ *
+ * The set is intentionally kept as data (this module) rather than fixtures so it
+ * can be consumed by the eval, the tests, and the CI script identically.
+ *
+ * DATASET_VERSION is bumped on any change to the case set so the eval report,
+ * the CI gate, and any future baseline can pin the exact set they scored.
+ */
+
+import type { GovernCase } from '../../types.js';
+
+/** Semantic version of THIS labeled set. Bump on any case add/remove/relabel. */
+export const DATASET_VERSION = '1.0.0';
+
+/* -------------------------------------------------------------------------- */
+/* Fixture material — realistic-shaped but non-live secrets.                   */
+/*                                                                             */
+/* NONE of these are real credentials: the AWS id is the AWS-published EXAMPLE */
+/* value, the OpenAI/GitHub/JWT shapes are structurally valid but random. They */
+/* exist only to exercise the detectors. Keeping them here (not inline in each */
+/* case) documents that fact in one place.                                     */
+/* -------------------------------------------------------------------------- */
+
+/** AWS's own documented example access-key id (safe to commit). */
+const AWS_EXAMPLE_KEY = 'AKIAIOSFODNN7EXAMPLE';
+/** Structurally-valid OpenAI-style key (random body, not a live key). */
+const OPENAI_SHAPE = 'sk-abcdefghij1234567890KLMNOPqrstuvWX';
+/** Structurally-valid GitHub PAT shape (40-char body). */
+const GITHUB_SHAPE = `ghp_${'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'}`;
+/** A three-segment JWT (random-ish base64url segments). */
+const JWT_SHAPE =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpEb2UifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+/** An SSN-shaped string. */
+const SSN_SHAPE = '123-45-6789';
+
+/** base64 of the OpenAI-shaped key — the encoded-token evasion. */
+const OPENAI_B64 = Buffer.from(OPENAI_SHAPE, 'utf8').toString('base64');
+/** base64 of the GitHub-shaped token. */
+const GITHUB_B64 = Buffer.from(GITHUB_SHAPE, 'utf8').toString('base64');
+
+/**
+ * The labeled cases. ≥30 spanning:
+ *   POSITIVES — inline / split-multiline / base64 / hex secrets; PII inline and
+ *   in odd metadata fields; internal-path leaks; a tenant-spoof case.
+ *   NEGATIVES — benign code + prose that merely MENTIONS "password"/"secret".
+ *
+ * `expectCaughtBy` = the checks a healthy moat fires; `knownFalseNegativeOf` =
+ * the checks empirically confirmed to MISS the case today (documented gaps).
+ */
+export const GOVERN_CASES: readonly GovernCase[] = [
+  /* ---------------------- SECRETS · inline (should catch) ------------------ */
+  {
+    id: 'sec-inline-aws-01',
+    description: 'AWS access-key id inline in content',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: `Deploy uses key ${AWS_EXAMPLE_KEY} for the S3 bucket.` },
+    expectCaughtBy: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-inline-openai-01',
+    description: 'OpenAI-style sk- key inline in content',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: `Set OPENAI_API_KEY to ${OPENAI_SHAPE} in the env.` },
+    expectCaughtBy: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-inline-github-01',
+    description: 'GitHub PAT inline in content',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: `git remote set-url origin https://${GITHUB_SHAPE}@github.com/x/y.git` },
+    expectCaughtBy: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-inline-jwt-01',
+    description: 'JWT (three base64url segments) inline in content',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: `Authorization: Bearer ${JWT_SHAPE}` },
+    expectCaughtBy: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-inline-pem-01',
+    description: 'PEM private-key block header inline in content',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: {
+      content: 'The deploy key is:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...',
+    },
+    expectCaughtBy: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-inline-connstr-01',
+    description: 'Postgres connection string with embedded credentials inline',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: 'DB is postgres://admin:hunter2pass@db.host:5432/prod for the app.' },
+    // The line-based secret-scanner catches the connection-string pattern; the
+    // boundary filter's SECRET_PATTERNS do not include DB connection strings.
+    expectCaughtBy: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+    knownFalseNegativeOf: ['boundary-disclosure'],
+  },
+  {
+    id: 'sec-inline-envassign-01',
+    description: 'Environment-variable secret assignment inline',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    candidate: { content: 'Add API_KEY="s3cr3t-value-not-a-known-prefix-12345" to the config.' },
+    // Caught by the env-secret regex in the line scanner; the boundary filter
+    // is prefix-anchored to known providers and does not match a generic assign.
+    expectCaughtBy: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+    knownFalseNegativeOf: ['boundary-disclosure'],
+  },
+
+  /* --------- SECRETS · split across two lines (the CISO's fear) ------------ */
+  {
+    id: 'sec-split-openai-01',
+    description: 'OpenAI-style key split across two lines (defeats line-based scan)',
+    sensitiveClass: 'secret',
+    surface: 'split-multiline',
+    candidate: {
+      content: `The key is sk-abcdefghij1234567890\nKLMNOPqrstuvWX and it authenticates.`,
+    },
+    // DOCUMENTED GAP: both the line-based secret scanner and the boundary
+    // filter miss a key broken across a newline. This is the moat hole R5/e06.3
+    // exists to surface — reported, never hidden.
+    expectCaughtBy: [],
+    knownFalseNegativeOf: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-split-aws-01',
+    description: 'AWS access-key id split across two lines',
+    sensitiveClass: 'secret',
+    surface: 'split-multiline',
+    candidate: { content: 'access key:\nAKIAIOSFO\nDNN7EXAMPLE\nendkey' },
+    expectCaughtBy: [],
+    knownFalseNegativeOf: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+
+  /* --------------- SECRETS · base64-encoded (no decode step) --------------- */
+  {
+    id: 'sec-b64-openai-01',
+    description: 'OpenAI-style key wrapped in base64 (no decode step in scanners)',
+    sensitiveClass: 'secret',
+    surface: 'base64-encoded',
+    candidate: { content: `Decoded at runtime: ${OPENAI_B64}` },
+    expectCaughtBy: [],
+    knownFalseNegativeOf: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+  {
+    id: 'sec-b64-github-01',
+    description: 'GitHub PAT wrapped in base64',
+    sensitiveClass: 'secret',
+    surface: 'base64-encoded',
+    candidate: { content: `token blob = ${GITHUB_B64}` },
+    expectCaughtBy: [],
+    knownFalseNegativeOf: [
+      'policy-pipeline',
+      'secret-scanner',
+      'content-classifier',
+      'boundary-disclosure',
+    ],
+  },
+
+  /* ----------------------- SECRETS · hex-encoded -------------------------- */
+  {
+    id: 'sec-hex-aws-01',
+    description: 'AWS key hex-encoded (40 hex chars trips the high-entropy-hex rule)',
+    sensitiveClass: 'secret',
+    surface: 'hex-encoded',
+    candidate: { content: `hexval ${Buffer.from(AWS_EXAMPLE_KEY, 'utf8').toString('hex')}` },
+    // The line-based scanner's high-entropy-hex rule (40+ hex) fires; the
+    // boundary filter has no hex rule → documented miss there.
+    expectCaughtBy: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+    knownFalseNegativeOf: ['boundary-disclosure'],
+  },
+
+  /* --------------------------- PII · inline ------------------------------- */
+  {
+    id: 'pii-inline-ssn-01',
+    description: 'SSN inline in content',
+    sensitiveClass: 'pii',
+    surface: 'inline',
+    candidate: { content: `Employee record: SSN ${SSN_SHAPE} on file.` },
+    // classify + boundary flag PII; the SECRET scanner is secrets-only (SSN is
+    // not a secret pattern) so it correctly does not fire — that is not a miss.
+    expectCaughtBy: ['policy-pipeline', 'content-classifier', 'boundary-disclosure'],
+  },
+  {
+    id: 'pii-inline-dob-01',
+    description: 'Date-of-birth field inline in content',
+    sensitiveClass: 'pii',
+    surface: 'inline',
+    candidate: { content: 'HR note — DOB: 1984-07-02, hired last spring.' },
+    // DOCUMENTED GAP (real finding, follow-up bead candidate): the boundary
+    // disclosure filter's PII_PATTERN includes `date of birth` / `DOB:`, but
+    // claude-runtime's classifyContent PII set is EMAIL / PHONE / SSN only — no
+    // DOB — so a DOB-only leak passes the policy pipeline (which gates on
+    // classifyContent) and is caught only at the repository boundary. The two
+    // PII vocabularies have drifted; the classifier is the weaker one. Surfaced
+    // here, not hidden by loosening a rule.
+    expectCaughtBy: ['boundary-disclosure'],
+    knownFalseNegativeOf: ['policy-pipeline', 'content-classifier'],
+  },
+  {
+    id: 'pii-inline-email-01',
+    description: 'Email address inline (classifier flags PII; boundary filter does not)',
+    sensitiveClass: 'pii',
+    surface: 'inline',
+    candidate: { content: 'Reach the on-call at jane.doe@internal-corp.example for escalations.' },
+    // classifyContent's PII_PATTERNS include email → confidential. The boundary
+    // filter's PII_PATTERN is SSN/DOB/background-check only (email is often
+    // legitimate), so it does NOT flag — documented divergence, not a bug.
+    expectCaughtBy: ['policy-pipeline', 'content-classifier'],
+    knownFalseNegativeOf: ['boundary-disclosure'],
+  },
+
+  /* -------------- PII / secrets hidden in ODD metadata fields ------------- */
+  {
+    id: 'pii-filepath-ssn-01',
+    description: 'SSN smuggled into metadata.filePaths (an odd field)',
+    sensitiveClass: 'pii',
+    surface: 'metadata-filepath',
+    candidate: {
+      content: 'A perfectly ordinary architecture note about the intake service.',
+      metadata: { filePaths: [`/records/patient-${SSN_SHAPE}.txt`], tags: [] },
+    },
+    // The R10 target: the boundary filter WOULD catch this string — but only if
+    // the API intake scanner is extended to pass filePaths (this PR's fix). The
+    // policy pipeline scans candidate.content only, so it never sees filePaths.
+    expectCaughtBy: ['boundary-disclosure'],
+    knownFalseNegativeOf: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+  },
+  {
+    id: 'sec-filepath-aws-01',
+    description: 'AWS key smuggled into metadata.filePaths',
+    sensitiveClass: 'secret',
+    surface: 'metadata-filepath',
+    candidate: {
+      content: 'Ordinary note about the deploy pipeline layout.',
+      metadata: { filePaths: [`/keys/${AWS_EXAMPLE_KEY}.pem`], tags: [] },
+    },
+    expectCaughtBy: ['boundary-disclosure'],
+    knownFalseNegativeOf: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+  },
+  {
+    id: 'pii-projectcontext-ssn-01',
+    description: 'SSN smuggled into metadata.projectContext',
+    sensitiveClass: 'pii',
+    surface: 'metadata-projectcontext',
+    candidate: {
+      content: 'Note about the payroll importer.',
+      metadata: { filePaths: [], tags: [], projectContext: `onboarding for SSN ${SSN_SHAPE}` },
+    },
+    expectCaughtBy: ['boundary-disclosure'],
+    knownFalseNegativeOf: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+  },
+
+  /* --------------------- internal-path leaks (flag) ----------------------- */
+  {
+    id: 'path-unix-home-01',
+    description: 'Unix /home/<user>/ path leaked inline (content_sanitization flags)',
+    sensitiveClass: 'internal-path',
+    surface: 'inline',
+    candidate: { content: 'The log is at /home/jeremy/.teamkb/audit/anchors.jsonl on the box.' },
+    // classifyContent marks internal → not restricted; content_sanitization
+    // FLAGS (does not reject). We score the classifier catching "internal".
+    expectCaughtBy: ['content-classifier'],
+  },
+  {
+    id: 'path-macos-01',
+    description: 'macOS /Users/<user>/ path leaked inline',
+    sensitiveClass: 'internal-path',
+    surface: 'inline',
+    candidate: { content: 'Built from /Users/alice/dev/secret-project/main.ts locally.' },
+    expectCaughtBy: ['content-classifier'],
+  },
+  {
+    id: 'path-windows-01',
+    description: 'Windows absolute path leaked inline',
+    sensitiveClass: 'internal-path',
+    surface: 'inline',
+    candidate: { content: 'Output written to C:\\Users\\bob\\build\\artifact.exe on the runner.' },
+    expectCaughtBy: ['content-classifier'],
+  },
+
+  /* --------------------- tenancy / author spoofing ------------------------ */
+  {
+    id: 'spoof-tenant-secret-01',
+    description:
+      'Attacker sets tenantId to a different tenant AND hides a key there (tenancy-guard evasion + leak)',
+    sensitiveClass: 'secret',
+    surface: 'tenant-spoof',
+    candidate: {
+      content: 'Routine note.',
+      tenantId: `victim-tenant ${OPENAI_SHAPE}`,
+    },
+    // The boundary filter (structural walk in assertDisclosureClean) scans
+    // tenantId and catches the key; the intake early-check and the policy
+    // pipeline (content-only) do NOT — documented, and the reason R9/R10 both
+    // gate the public ship.
+    expectCaughtBy: ['boundary-disclosure'],
+    knownFalseNegativeOf: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+  },
+
+  /* ---------------------------- NEGATIVES --------------------------------- */
+  {
+    id: 'neg-mentions-password-01',
+    description: 'Prose that merely MENTIONS the word "password" (must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'Always hash the password with a slow KDF; never store it in plaintext.',
+    },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-mentions-secret-01',
+    description: 'Prose mentioning "secret" / "token" as concepts (must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'Rotate the API token quarterly and keep the secret out of the repo.',
+    },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-code-snippet-01',
+    description: 'Ordinary TypeScript with no credentials (must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'export function add(a: number, b: number): number {\n  return a + b;\n}',
+    },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-semver-01',
+    description: 'A semver-looking string (not a secret; must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: { content: 'Upgraded the kernel package to version 1.2.3 in this release.' },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-short-hex-01',
+    description: 'A short git SHA (7 hex) — below the high-entropy-hex threshold (must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: { content: 'Fixed in commit 1a2b3c4 on the main branch.' },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-uuid-in-prose-01',
+    description:
+      'A UUID used as an id in prose (heroku-key regex is UUID-shaped — precision guard)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'The request id was 3f2504e0-4f89-41d3-9a0c-0305e82c3301 in the trace.',
+    },
+    // NOTE: this is a deliberate PRECISION probe. The heroku-api-key rule is a
+    // bare UUID regex, so classify/secret-scanner treat any UUID as a secret.
+    // We expect NO check to fire; if one does it is a FALSE POSITIVE and drags
+    // that check's precision — surfaced, not hidden. (Documented in README.)
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-ratio-technical-01',
+    description: 'A 60/40 traffic split in technical context (boundary comp-gate must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: { content: 'We route a 60/40 traffic split between the two regions.' },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-plain-note-01',
+    description: 'A plain architecture note (must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'The compiler keeps raw and derived content strictly separate with provenance.',
+    },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-relative-path-01',
+    description: 'A relative repo path (not an internal absolute path; must NOT fire)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: { content: 'See packages/policy-engine/src/pipeline.ts for the evaluate loop.' },
+    expectCaughtBy: [],
+  },
+  {
+    id: 'neg-benign-filepath-01',
+    description: 'A clean relative path in metadata.filePaths (odd-field precision guard)',
+    sensitiveClass: 'none',
+    surface: 'benign',
+    candidate: {
+      content: 'A note about the store layer.',
+      metadata: { filePaths: ['packages/store/src/repositories/policy-repository.ts'], tags: [] },
+    },
+    expectCaughtBy: [],
+  },
+];
+
+/**
+ * Default candidate scaffold that every case is merged over, so each case is a
+ * complete Zod-valid `MemoryCandidate`. Deliberately benign — a case only turns
+ * "positive" by overriding a field with sensitive material.
+ */
+export const CASE_DEFAULTS = {
+  status: 'inbox' as const,
+  source: 'claude_session' as const,
+  title: 'govern-eval fixture',
+  category: 'reference' as const,
+  trustLevel: 'medium' as const,
+  author: { type: 'ai' as const, id: 'govern-eval' },
+  tenantId: 'govern-eval-tenant',
+  metadata: { filePaths: [], tags: [] },
+  prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+  capturedAt: '2026-06-30T00:00:00.000Z',
+};

--- a/packages/eval-surface/src/govern-decision/dataset/v1/load.ts
+++ b/packages/eval-surface/src/govern-decision/dataset/v1/load.ts
@@ -1,0 +1,46 @@
+/**
+ * dataset/v1 loader — turns each labeled {@link GovernCase} into a real,
+ * Zod-valid `MemoryCandidate` by deep-merging its partial candidate over
+ * {@link CASE_DEFAULTS} and parsing through the schema. This guarantees the
+ * eval scores the SAME candidate shape the govern pipeline sees in production
+ * (no ad-hoc objects), so a false-negative the eval measures is a real one.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+import type { GovernCase } from '../../types.js';
+import { CASE_DEFAULTS, GOVERN_CASES } from './index.js';
+
+/** A case paired with its parsed, schema-valid candidate. */
+export interface LoadedCase {
+  readonly def: GovernCase;
+  readonly candidate: MemoryCandidate;
+}
+
+/**
+ * Build the schema-valid candidate for one case. `metadata` is merged one level
+ * deep (so a case that only sets `metadata.filePaths` keeps the default
+ * `tags: []`), everything else is a shallow override. Each candidate gets a
+ * fresh UUID so dedup/id logic never collides across cases.
+ */
+export function loadCase(def: GovernCase): LoadedCase {
+  const overrides = def.candidate;
+  const mergedMetadata = {
+    ...CASE_DEFAULTS.metadata,
+    ...(overrides.metadata ?? {}),
+  };
+  const candidate = MemoryCandidate.parse({
+    ...CASE_DEFAULTS,
+    ...overrides,
+    id: randomUUID(),
+    metadata: mergedMetadata,
+  });
+  return { def, candidate };
+}
+
+/** Load the whole v1 set. */
+export function loadDataset(cases: readonly GovernCase[] = GOVERN_CASES): LoadedCase[] {
+  return cases.map(loadCase);
+}

--- a/packages/eval-surface/src/govern-decision/types.ts
+++ b/packages/eval-surface/src/govern-decision/types.ts
@@ -1,0 +1,134 @@
+/**
+ * govern-decision eval types — the labeled-case schema and the per-check
+ * precision/recall report shapes for the govern-decision efficacy eval.
+ *
+ * ## Why this exists (010-AT-RISK R5 / R10 · bead compile-then-govern-e06.3 · umbrella #27)
+ *
+ * The 8 deterministic policy rules are verified-*deterministic* but
+ * UNEVALUATED for *correctness*. Determinism is not efficacy: a line-based
+ * regex secret-scan is perfectly deterministic AND misses a key split across
+ * two lines or a base64-wrapped token. This module carries the labeled
+ * adversarial set + the machinery that measures whether the govern decision
+ * (the policy pipeline + the two content-classification signals) actually
+ * catches what it must.
+ *
+ * The set is deliberately *versioned* (dataset/v1) and self-describing: each
+ * case names the sensitive material class, the surface it is smuggled through,
+ * and the govern outcome we assert. False negatives are DATA, not test
+ * failures — a documented FN (see the dataset README) is a real gap in the
+ * moat, surfaced honestly rather than hidden by weakening a rule.
+ */
+
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/**
+ * The independent "checks" whose efficacy we score. Each is one detection
+ * surface in the govern decision, scored separately so a gap in one (e.g. the
+ * line-based secret scanner) is not masked by another (e.g. the boundary
+ * disclosure filter).
+ */
+export type GovernCheck =
+  /** The full policy pipeline verdict (`PolicyPipeline.evaluate` → rejected). */
+  | 'policy-pipeline'
+  /** `scanForSecrets` (claude-runtime) — the signal behind the secret_detection rule. */
+  | 'secret-scanner'
+  /** `classifyContent` (claude-runtime) — the signal behind the sensitivity_gate rule. */
+  | 'content-classifier'
+  /** `scanForDisclosure` (common) — the API/repository-boundary disclosure filter. */
+  | 'boundary-disclosure';
+
+/** The class of sensitive material a positive case carries (or `none` for a negative). */
+export type SensitiveClass =
+  | 'secret' // credential / API key / token / private key
+  | 'pii' // SSN / DOB / background-check / (email)
+  | 'internal-path' // leaked internal filesystem / host / private IP
+  | 'none'; // benign — a known-negative
+
+/**
+ * The surface / smuggling technique a case exercises. Names the evasion so the
+ * report can group false-negatives by *how* they slipped through.
+ */
+export type Surface =
+  | 'inline' // plainly present in a single line of content
+  | 'split-multiline' // broken across two lines (defeats the line-based scanner)
+  | 'base64-encoded' // wrapped in base64 (no decode step in the scanners)
+  | 'hex-encoded' // hex-encoded
+  | 'metadata-filepath' // hidden in metadata.filePaths (an "odd field")
+  | 'metadata-projectcontext' // hidden in metadata.projectContext
+  | 'tenant-spoof' // attacker-set tenantId / author (tenancy-guard evasion)
+  | 'benign'; // negative — no sensitive material
+
+/**
+ * One labeled adversarial (or benign) case.
+ *
+ * `expectCaught` is the GROUND TRUTH we assert per check: for a positive case
+ * (`sensitiveClass !== 'none'`) at least the checks listed in `expectCaughtBy`
+ * SHOULD fire; for a negative case, NO check should fire (a firing check is a
+ * false positive). `knownFalseNegativeOf` documents checks we have empirically
+ * confirmed MISS this case today — those do not count against precision/recall
+ * as surprises, but they ARE reported as documented gaps.
+ */
+export interface GovernCase {
+  /** Stable, human-readable id, e.g. `sec-split-openai-01`. Unique in the set. */
+  readonly id: string;
+  /** One-line description of what this case smuggles and how. */
+  readonly description: string;
+  /** The class of sensitive material (or `none` for a known-negative). */
+  readonly sensitiveClass: SensitiveClass;
+  /** The surface / evasion technique exercised. */
+  readonly surface: Surface;
+  /**
+   * A partial candidate — merged over a valid default by the dataset loader so
+   * every case is a real, Zod-valid `MemoryCandidate`. Put the sensitive
+   * material on whichever field the surface targets (content, or a metadata
+   * field).
+   */
+  readonly candidate: Partial<MemoryCandidate>;
+  /**
+   * For a POSITIVE case: the checks that SHOULD catch it (a healthy moat fires
+   * at least one of these). Empty for a negative case.
+   */
+  readonly expectCaughtBy: readonly GovernCheck[];
+  /**
+   * Checks we have EMPIRICALLY CONFIRMED miss this case today (documented gaps,
+   * not surprises). Reported as `documentedFalseNegatives`, never hidden.
+   */
+  readonly knownFalseNegativeOf?: readonly GovernCheck[];
+}
+
+/** Per-check confusion-matrix counts + derived precision / recall / F1. */
+export interface CheckMetrics {
+  readonly check: GovernCheck;
+  readonly truePositives: number;
+  readonly falsePositives: number;
+  readonly falseNegatives: number;
+  readonly trueNegatives: number;
+  /** TP / (TP + FP); 1 when the check never fired (vacuously precise). */
+  readonly precision: number;
+  /** TP / (TP + FN); 1 when there were no positives to catch. */
+  readonly recall: number;
+  /** Harmonic mean of precision and recall; 0 when both are 0. */
+  readonly f1: number;
+}
+
+/** One false-negative the eval measured: a positive case a check failed to fire on. */
+export interface FalseNegative {
+  readonly caseId: string;
+  readonly check: GovernCheck;
+  readonly sensitiveClass: SensitiveClass;
+  readonly surface: Surface;
+  /** True when the case's `knownFalseNegativeOf` already documented this miss. */
+  readonly documented: boolean;
+}
+
+/** The full govern-decision efficacy report (attached to the EvaluatorResult details as JSON). */
+export interface GovernDecisionReport {
+  readonly totalCases: number;
+  readonly positives: number;
+  readonly negatives: number;
+  readonly perCheck: readonly CheckMetrics[];
+  /** Every false-negative measured, both surprising and documented. */
+  readonly falseNegatives: readonly FalseNegative[];
+  /** Subset of `falseNegatives` NOT covered by a case's `knownFalseNegativeOf`. */
+  readonly undocumentedFalseNegatives: readonly FalseNegative[];
+}

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -1,15 +1,18 @@
 /**
  * @qmd-team-intent-kb/eval-surface — QMD's functional eval surface.
  *
- * Three pure evaluators that measure whether the curated memory store is doing
- * its job, each returning an Evidence-Bundle-friendly EvaluatorResult:
+ * Pure evaluators that measure whether the governed brain is doing its job,
+ * each returning an Evidence-Bundle-friendly EvaluatorResult:
  *  - memory-utility       — retrieval recall@k against held-out probes
  *  - dedup-catch-rate     — exact content-hash dedup catch (+ false-positive guard)
  *  - provenance-integrity — per-memory content-hash consistency + audit-chain intactness
+ *  - govern-decision      — per-check precision/recall of the deterministic govern
+ *                           decision over an adversarial labeled set (is the moat
+ *                           merely deterministic, or actually EFFECTIVE?)
  *
  * This package MEASURES. It does not emit or sign Evidence Bundles — wiring the
  * results into a signed bundle at promotion time is bead tr08.19. Keeping
- * measurement pure (no I/O beyond the repositories handed in) makes each
+ * measurement pure (no I/O beyond the repositories/data handed in) makes each
  * evaluator independently testable and side-effect-free.
  */
 
@@ -19,4 +22,18 @@ export {
   evaluateProvenanceIntegrity,
   type ProvenanceIntegrityOptions,
 } from './provenance-integrity.js';
+export { evaluateGovernDecision, type GovernDecisionOptions } from './govern-decision.js';
+export {
+  DATASET_VERSION as GOVERN_DATASET_VERSION,
+  GOVERN_CASES,
+} from './govern-decision/dataset/v1/index.js';
+export type {
+  GovernCase,
+  GovernCheck,
+  SensitiveClass,
+  Surface,
+  CheckMetrics,
+  FalseNegative,
+  GovernDecisionReport,
+} from './govern-decision/types.js';
 export type { EvaluatorResult, RetrievalProbe, DedupProbe } from './types.js';

--- a/packages/eval-surface/tsconfig.json
+++ b/packages/eval-surface/tsconfig.json
@@ -12,6 +12,8 @@
     { "path": "../schema" },
     { "path": "../store" },
     { "path": "../common" },
+    { "path": "../claude-runtime" },
+    { "path": "../policy-engine" },
     { "path": "../test-fixtures" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,9 +278,15 @@ importers:
 
   packages/eval-surface:
     dependencies:
+      '@qmd-team-intent-kb/claude-runtime':
+        specifier: workspace:*
+        version: link:../claude-runtime
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../common
+      '@qmd-team-intent-kb/policy-engine':
+        specifier: workspace:*
+        version: link:../policy-engine
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../schema


### PR DESCRIPTION
## Why

The 8 deterministic policy rules are verified-**deterministic** but were
**UNEVALUATED** for efficacy. Determinism is not correctness: a line-based regex
secret-scan is perfectly deterministic **and** misses a key split across two
lines or a base64-wrapped token — the CISO's top fear (a leaked key promoted with
a clean receipt). This PR turns the moat's catch-rate into a measured, required
property.

**Risk:** `010-AT-RISK` R5 / R10 · **Bead:** `compile-then-govern-e06.3` ·
**Umbrella:** #27 → `intent-solutions-io/governed-second-brain#27`

## What lands

1. **Adversarial labeled set** — `packages/eval-surface/src/govern-decision/dataset/v1/`
   (versioned, 32 cases: 22 positive / 10 negative). Split-multiline keys,
   base64/hex-encoded tokens, JWTs, PII in odd fields (`metadata.filePaths`,
   `projectContext`), a tenant-spoof case, and known-negatives (benign code, prose
   that merely mentions "password"/"secret"). **Labels are empirical** — probed
   against the real scanners, not assumed — and version-pinned.

2. **The eval** — `evaluateGovernDecision` (`packages/eval-surface/src/govern-decision.ts`)
   runs the policy pipeline + `scanForSecrets` + `classifyContent` + the boundary
   disclosure filter over the set and reports **per-check precision / recall / F1**
   + a false-negative list. Beside `provenance-integrity`; matches the repo's
   eval + vitest + Zod conventions. Verdict fails closed on any **undocumented**
   false-negative; documented gaps are reported, never hidden by weakening a rule.

3. **R10 fix** — `apps/api/.../candidate-service.ts intake()` scanned only
   `content` / `title` / `tags`. It now also scans `metadata.filePaths` +
   `projectContext` + `repoUrl`/`branch`/`language`/`sessionId` + `category`,
   closing the odd-field leak the eval demonstrates (an SSN/key hidden in
   `filePaths`). Proven by spy-repo tests: the early gate fires **before** the
   repository backstop.

4. **CI gate** — `govern:ci` (`packages/eval-surface/scripts/ci-govern-decision.ts`)
   wired into `ci.yml` + `nightly.yml`, mirroring e06.2's `provenance:ci`. Exits
   non-zero on any missed secret/PII known-positive (fail-closed).

## Measured per-check numbers (dataset v1.0.0)

| check | precision | recall | F1 |
|---|---|---|---|
| `policy-pipeline` | 0.9167 | 0.5789 | 0.7097 |
| `secret-scanner` | 0.9000 | 0.5625 | 0.6923 |
| `content-classifier` | 0.9333 | 0.6364 | 0.7568 |
| `boundary-disclosure` | **1.0000** | 0.6316 | 0.7742 |

mean F1 = **0.7333**. Gate = zero undocumented false-negatives → **PASS**.

## Real false-negatives surfaced (documented, not hidden)

Per the brief — where the eval found a real gap, it is DOCUMENTED as a follow-up,
not papered over by weakening a rule:

- **Split-across-newline keys** and **base64-wrapped tokens** evade **all**
  in-content scanners (`scanForSecrets` splits on `\n`; no decode step). → bead
  `compile-then-govern-e06.14`.
- **PII vocabulary divergence:** the claude-runtime classifier PII set is
  email/phone/SSN only — it **misses DOB** that the boundary filter catches, so a
  DOB-only leak passes the policy pipeline but is caught at the repository
  boundary.
- **Precision:** the `heroku-api-key` rule is a bare UUID regex that **over-blocks
  benign UUIDs** in prose (drops secret-scanner/classifier precision to
  0.90/0.93). → bead `compile-then-govern-e06.15`.

## Validation

`typecheck` · `lint` · `format:check` · `depcruise` (0 errors) · `crap` ·
`harness-pin` · full `test` (1861 pass / 156 files) · `govern:ci` (exit 0) — all
green locally.

Do **not** merge — opened for CI + review per the workflow.

- Jeremy Longshore
intentsolutions.io