### PR TITLE
feat(eval): first real retrieval number — hand-labeled Recall@10/nDCG@10 over the live corpus (e06.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "report:cited-queries": "node apps/api/dist/reports/weekly-cited-queries-cli.js",
     "reindex": "node packages/qmd-adapter/dist/cli.js reindex",
     "search-canary": "node packages/qmd-adapter/dist/cli.js canary",
+    "eval:retrieval": "tsx scripts/eval-retrieval.ts",
     "depcruise": "depcruise --config .dependency-cruiser.cjs apps packages",
     "crap": "tsx scripts/crap-score.ts",
     "harness-pin": "bash scripts/harness-pin.sh --verify",

--- a/packages/qmd-adapter/src/__tests__/eval-qmd-retrieval.test.ts
+++ b/packages/qmd-adapter/src/__tests__/eval-qmd-retrieval.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { QmdAdapter } from '../adapter.js';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { qmdRetrievalFn } from '../eval/qmd-retrieval.js';
+
+const TENANT = 'intent-solutions';
+
+function adapterWith(mock: MockQmdExecutor): QmdAdapter {
+  return new QmdAdapter({ tenantId: TENANT, exportDir: '/tmp/does-not-matter' }, mock);
+}
+
+/** A qmd `search --json` payload with ranked qmd:// citations. */
+const HITS = JSON.stringify([
+  { docid: '#a', score: 0.95, file: 'qmd://kb-curated/aaa.md', title: 'A', snippet: '' },
+  { docid: '#b', score: 0.9, file: 'qmd://kb-guides/bbb.md', title: 'B', snippet: '' },
+]);
+
+describe('qmdRetrievalFn', () => {
+  it('returns the ranked qmd:// citation ids from the production query path', async () => {
+    const mock = new MockQmdExecutor();
+    mock.queueSuccess(HITS);
+    const retrieve = qmdRetrievalFn(adapterWith(mock), TENANT, 'all');
+
+    const ids = await retrieve('some query', 10);
+
+    expect(ids).toEqual(['qmd://kb-curated/aaa.md', 'qmd://kb-guides/bbb.md']);
+    // Went through the real search command, not a re-implementation.
+    expect(mock.lastCommand).toEqual(['search', '--json', '--', 'some query']);
+  });
+
+  it('defaults to curated scope', async () => {
+    const mock = new MockQmdExecutor();
+    // curated scope filters to kb-curated/kb-decisions/kb-guides; both hits qualify.
+    mock.queueSuccess(HITS);
+    const retrieve = qmdRetrievalFn(adapterWith(mock), TENANT);
+
+    const ids = await retrieve('q', 10);
+    expect(ids).toContain('qmd://kb-curated/aaa.md');
+  });
+
+  it('returns [] when the search command fails', async () => {
+    const mock = new MockQmdExecutor();
+    mock.queueFailure('boom', 1);
+    const retrieve = qmdRetrievalFn(adapterWith(mock), TENANT, 'all');
+
+    expect(await retrieve('q', 10)).toEqual([]);
+  });
+
+  it('returns [] when the tenant does not match the bound adapter (fail-closed guard)', async () => {
+    const mock = new MockQmdExecutor();
+    mock.queueSuccess(HITS);
+    const retrieve = qmdRetrievalFn(adapterWith(mock), 'a-different-tenant', 'all');
+
+    // The adapter's guard short-circuits before any search command runs.
+    expect(await retrieve('q', 10)).toEqual([]);
+    expect(mock.commands.length).toBe(0);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/eval-retrieval-live.test.ts
+++ b/packages/qmd-adapter/src/__tests__/eval-retrieval-live.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Live retrieval-eval reproduction (bead compile-then-govern-e06.4 / umbrella
+ * #27 / ADR 038-AT-DECR).
+ *
+ * This is the CI-runnable proof that the FIRST REAL retrieval number reproduces:
+ * it runs the hand-labeled `governed-brain-v1` query set through the production
+ * `adapter.query()` BM25 path against the LIVE `~/.teamkb` qmd index (the same
+ * one `brain_search` serves) and asserts the harness computes a coherent
+ * stratified report + applies the 0.85 gate.
+ *
+ * Read-only: it searches an already-built index and never reindexes or writes.
+ *
+ * Skipped (not failed) when qmd is not on PATH OR the live index returns nothing
+ * — so CI without a warm `~/.teamkb` stays green. The reported numbers live in
+ * the PR body / `pnpm eval:retrieval` output; this test guards that the pipeline
+ * that produced them still runs and that the dataset's gold ids are well-formed.
+ *
+ * @module __tests__/eval-retrieval-live.test
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { QmdAdapter } from '../adapter.js';
+import { runEval } from '../eval/run-eval.js';
+import { stratify } from '../eval/stratified-report.js';
+import { qmdRetrievalFn } from '../eval/qmd-retrieval.js';
+import { GOVERNED_BRAIN_V1_DATASET } from '../eval/datasets/governed-brain-v1.js';
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const TENANT = process.env['TEAMKB_TENANT'] ?? 'intent-solutions';
+const BASE = process.env['TEAMKB_BASE_PATH'] ?? join(homedir(), '.teamkb');
+const EXPORT_DIR = join(BASE, 'kb-export');
+const INDEX_DIR = join(BASE, 'qmd-index', TENANT);
+
+// Only meaningful when qmd exists AND the tenant's index has been built.
+const CAN_RUN = qmdAvailable() && existsSync(EXPORT_DIR) && existsSync(INDEX_DIR);
+
+describe('governed-brain-v1 dataset integrity', () => {
+  it('has gold citations that are all well-formed qmd:// ids in default-searchable collections', () => {
+    const allowed = /^qmd:\/\/kb-(curated|decisions|guides)\/[0-9a-f-]+\.md$/;
+    for (const q of GOVERNED_BRAIN_V1_DATASET.queries) {
+      expect(q.relevant.length, `query ${q.id} has no gold citation`).toBeGreaterThan(0);
+      for (const cite of q.relevant) {
+        expect(cite, `query ${q.id} gold id "${cite}" malformed`).toMatch(allowed);
+      }
+    }
+  });
+
+  it('is stratified with a semantic-weighted split (ADR 038 requires the semantic stratum)', () => {
+    const kinds = GOVERNED_BRAIN_V1_DATASET.queries.map((q) => q.kind);
+    const semantic = kinds.filter((k) => k === 'semantic').length;
+    const lexical = kinds.filter((k) => k === 'lexical').length;
+    expect(semantic).toBeGreaterThan(0);
+    expect(lexical).toBeGreaterThan(0);
+    // Weighted toward semantic — that's where the recall wall shows.
+    expect(semantic).toBeGreaterThanOrEqual(lexical);
+    expect(GOVERNED_BRAIN_V1_DATASET.queries.length).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe.skipIf(!CAN_RUN)('governed-brain-v1 ↔ live qmd BM25 index', () => {
+  it('reproduces a coherent stratified retrieval report against the real index', async () => {
+    const adapter = new QmdAdapter({ tenantId: TENANT, exportDir: EXPORT_DIR });
+    const retrieve = qmdRetrievalFn(adapter, TENANT, 'curated');
+
+    const report = await runEval(GOVERNED_BRAIN_V1_DATASET, retrieve, {
+      k: 10,
+      backend: 'qmd-bm25',
+    });
+
+    expect(report.queryCount).toBe(GOVERNED_BRAIN_V1_DATASET.queries.length);
+    // The live index must actually answer at least some queries (else it's unbuilt).
+    expect(report.perQuery.some((r) => r.retrieved.length > 0)).toBe(true);
+
+    // Every retrieved id is a real qmd:// citation (the production id space).
+    for (const r of report.perQuery) {
+      for (const id of r.retrieved) {
+        expect(id.startsWith('qmd://')).toBe(true);
+      }
+    }
+
+    const sr = stratify(report, GOVERNED_BRAIN_V1_DATASET.queries);
+    // Metrics are bounded [0,1] and the strata sum to the whole.
+    expect(sr.overall.meanRecallAtK).toBeGreaterThanOrEqual(0);
+    expect(sr.overall.meanRecallAtK).toBeLessThanOrEqual(1);
+    expect(sr.overall.meanNdcgAtK).toBeGreaterThanOrEqual(0);
+    expect(sr.overall.meanNdcgAtK).toBeLessThanOrEqual(1);
+    const summed = sr.byKind.reduce((n, s) => n + s.queryCount, 0);
+    expect(summed).toBe(report.queryCount);
+
+    const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+    expect(semantic).toBeDefined();
+  }, 60000);
+});

--- a/packages/qmd-adapter/src/__tests__/eval-stratified.test.ts
+++ b/packages/qmd-adapter/src/__tests__/eval-stratified.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+
+import { stratify, formatStratifiedReport } from '../eval/stratified-report.js';
+import type { EvalReport, EvalQuery } from '../eval/eval-types.js';
+
+const QUERIES: EvalQuery[] = [
+  { id: 'lex1', query: 'q-lex1', relevant: ['d1'], kind: 'lexical' }, // d1 @ rank 1 → perfect
+  { id: 'lex2', query: 'q-lex2', relevant: ['d2'], kind: 'lexical' }, // d2 @ rank 2
+  { id: 'sem1', query: 'q-sem1', relevant: ['d3'], kind: 'semantic' }, // miss
+  { id: 'unt1', query: 'q-unt1', relevant: ['d4'], kind: undefined }, // untagged, d4 @ rank 1
+];
+
+const REPORT: EvalReport = {
+  dataset: 'test',
+  backend: 'mock',
+  k: 10,
+  queryCount: 4,
+  meanRecallAtK: 0, // not used by stratify
+  meanNdcgAtK: 0,
+  perQuery: [
+    {
+      id: 'lex1',
+      query: 'q-lex1',
+      kind: 'lexical',
+      retrieved: ['d1', 'x'],
+      recallAtK: 1,
+      ndcgAtK: 1,
+    },
+    {
+      id: 'lex2',
+      query: 'q-lex2',
+      kind: 'lexical',
+      retrieved: ['x', 'd2'],
+      recallAtK: 1,
+      ndcgAtK: 0.6309,
+    },
+    {
+      id: 'sem1',
+      query: 'q-sem1',
+      kind: 'semantic',
+      retrieved: ['x', 'y'],
+      recallAtK: 0,
+      ndcgAtK: 0,
+    },
+    { id: 'unt1', query: 'q-unt1', kind: undefined, retrieved: ['d4'], recallAtK: 1, ndcgAtK: 1 },
+  ],
+};
+
+describe('stratify', () => {
+  it('splits metrics by kind plus an overall row', () => {
+    const sr = stratify(REPORT, QUERIES);
+
+    expect(sr.dataset).toBe('test');
+    expect(sr.backend).toBe('mock');
+    expect(sr.k).toBe(10);
+
+    expect(sr.overall.queryCount).toBe(4);
+    // overall mean recall = (1 + 1 + 0 + 1) / 4
+    expect(sr.overall.meanRecallAtK).toBeCloseTo(0.75, 4);
+
+    const lexical = sr.byKind.find((s) => s.stratum === 'lexical');
+    const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+    const untagged = sr.byKind.find((s) => s.stratum === 'untagged');
+
+    expect(lexical?.queryCount).toBe(2);
+    expect(lexical?.meanRecallAtK).toBe(1); // both found
+    expect(semantic?.queryCount).toBe(1);
+    expect(semantic?.meanRecallAtK).toBe(0); // missed
+    expect(untagged?.queryCount).toBe(1);
+    expect(untagged?.stratum).toBe('untagged');
+  });
+
+  it('computes MRR from the retrieved lists and gold sets', () => {
+    const sr = stratify(REPORT, QUERIES);
+    const lexical = sr.byKind.find((s) => s.stratum === 'lexical');
+    // lex1: first relevant at rank 1 → RR 1; lex2: rank 2 → RR 0.5; mean = 0.75
+    expect(lexical?.mrr).toBeCloseTo(0.75, 4);
+
+    const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+    expect(semantic?.mrr).toBe(0); // never retrieved
+  });
+
+  it('sums strata counts back to the whole', () => {
+    const sr = stratify(REPORT, QUERIES);
+    const summed = sr.byKind.reduce((n, s) => n + s.queryCount, 0);
+    expect(summed).toBe(sr.overall.queryCount);
+  });
+
+  it('treats a query id with no matching gold entry as zero reciprocal rank', () => {
+    // Report references an id absent from the queries list → empty gold set.
+    const orphan: EvalReport = {
+      ...REPORT,
+      queryCount: 1,
+      perQuery: [
+        { id: 'ghost', query: 'q', kind: 'semantic', retrieved: ['d1'], recallAtK: 0, ndcgAtK: 0 },
+      ],
+    };
+    const sr = stratify(orphan, QUERIES);
+    expect(sr.overall.mrr).toBe(0);
+  });
+});
+
+describe('formatStratifiedReport', () => {
+  it('renders the overall row and one line per kind', () => {
+    const out = formatStratifiedReport(stratify(REPORT, QUERIES));
+    expect(out).toContain('backend=mock');
+    expect(out).toContain('overall');
+    expect(out).toContain('lexical');
+    expect(out).toContain('semantic');
+    expect(out).toContain('Recall@10=');
+    expect(out).toContain('MRR=');
+  });
+});

--- a/packages/qmd-adapter/src/eval/datasets/README.md
+++ b/packages/qmd-adapter/src/eval/datasets/README.md
@@ -1,0 +1,56 @@
+# Retrieval eval datasets
+
+Hand-labeled query sets that gate the retrieval-backend decision in
+[ADR 038-AT-DECR](../../../../../000-docs/038-AT-DECR-retrieval-backend-decision-2026-06-18.md):
+**does BM25-on-qmd clear Recall@10 ≥ 0.85, or is the deferred sqlite-vec semantic
+backend (bead `qmd-team-intent-kb-0t9.3`) justified?**
+
+| Dataset                      | File                                             | Corpus                                       | Purpose                                                                                      |
+| ---------------------------- | ------------------------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `governed-second-brain-seed` | [`seed-queries.ts`](./seed-queries.ts)           | _(none — placeholder ids)_                   | SHAPE/starter only. Runnable against a mock backend in unit tests. **Not a real benchmark.** |
+| `governed-brain-v1`          | [`governed-brain-v1.ts`](./governed-brain-v1.ts) | live `~/.teamkb` (tenant `intent-solutions`) | The **first real number** (bead `compile-then-govern-e06.4` / umbrella #27).                 |
+
+## `governed-brain-v1` — how it was built (methodology)
+
+The number is only as honest as the labels. This set was constructed to _avoid_
+the two ways a retrieval benchmark lies (cherry-picking easy queries; rewording
+queries until the keyword index hits):
+
+1. **Real corpus, real id space.** Gold citations are exact `qmd://kb-{curated,
+decisions,guides}/<uuid>.md` strings drawn from the live export tree — the
+   same id space `brain_search` / `QmdSearchResult.file` returns. Only the three
+   default-searchable collections are targeted (inbox/archive are out of default
+   scope).
+
+2. **Labeled from the corpus, not from search.** Each query's gold doc was chosen
+   by reading the doc's title + body summary in the export tree and deciding it
+   genuinely answers the query — _before_ running any search. Search was then run
+   only to confirm the gold doc exists and is reachable in principle, and to
+   record whether BM25 finds it and at what rank.
+
+3. **Stratified, weighted toward semantic.** Each query is tagged `lexical`
+   (exact term/name/title — BM25's home turf) or `semantic` (paraphrase / concept
+   / plain-language question that deliberately avoids the target's headline
+   keywords). The set is weighted toward `semantic` because that is the stratum
+   where the recall wall shows up and where ADR 038 weights the decision.
+
+4. **No cherry-picking, no gate-chasing.** A BM25 _miss_ on a valid semantic
+   query is kept, not discarded — that miss is the signal the ADR gate measures.
+   Queries were never reworded to make BM25 succeed.
+
+## Reproduce the number
+
+```bash
+# 1. warm the live index (read-only search needs a built index)
+pnpm reindex
+
+# 2. run the eval against the live index — prints overall + lexical/semantic
+#    Recall@10 / nDCG@10 / MRR and the ADR 038 verdict
+pnpm eval:retrieval
+```
+
+The CI-runnable reproduction lives in
+[`../../__tests__/eval-retrieval-live.test.ts`](../../__tests__/eval-retrieval-live.test.ts)
+— it runs the same dataset through the production `adapter.query()` BM25 path
+against the live index and asserts the pipeline reproduces, skipping cleanly when
+qmd or a built `~/.teamkb` index is absent.

--- a/packages/qmd-adapter/src/eval/datasets/governed-brain-v1.ts
+++ b/packages/qmd-adapter/src/eval/datasets/governed-brain-v1.ts
@@ -1,0 +1,380 @@
+import type { EvalDataset } from '../eval-types.js';
+
+/**
+ * The FIRST REAL hand-labeled retrieval eval dataset for the Governed Second
+ * Brain (bead compile-then-govern-e06.4 / umbrella #27 / ADR 038-AT-DECR).
+ *
+ * Unlike the seed/placeholder set, every gold `relevant` id here is a real
+ * `qmd://` citation drawn from the live `~/.teamkb` corpus (tenant
+ * `intent-solutions`), confirmed present in the export tree. Queries are
+ * stratified `lexical` (exact term/name — BM25's home turf) vs `semantic`
+ * (paraphrase/concept that avoids the target's headline keywords), WEIGHTED
+ * toward semantic because that is the stratum where the recall wall shows up
+ * and where ADR 038 weights the BM25-vs-sqlite-vec decision.
+ *
+ * Composition: 42 queries — 14 lexical, 28 semantic.
+ *
+ * Methodology + reproduction: `./README.md`. Run: `pnpm eval:retrieval`.
+ * `notes` records the empirical observation (gold rank / BM25 miss) at label
+ * time — a BM25 miss on a valid semantic query is kept, not discarded.
+ */
+export const GOVERNED_BRAIN_V1_DATASET: EvalDataset = {
+  name: 'governed-brain-v1',
+  idSpace: 'qmd:// citation',
+  queries: [
+    {
+      id: 'q01',
+      kind: 'lexical',
+      query: 'confused deputy problem',
+      relevant: ['qmd://kb-curated/00c95f4e-e1ee-51ad-9331-3aefd68a1629.md'],
+      notes:
+        'Exact title term. Gold at rank 1 (score 0.95). BM25 nails the named security anti-pattern.',
+    },
+    {
+      id: 'q02',
+      kind: 'lexical',
+      query: 'compile then govern',
+      relevant: [
+        'qmd://kb-curated/c68ad991-6134-50c8-a577-2aa12c4e9d81.md',
+        'qmd://kb-curated/081bce4f-1801-539d-a852-add50f441e50.md',
+      ],
+      notes:
+        'Signature architecture name. Both gold docs (Compile-Then-Govern rank 1, Compile-Then-Govern Architecture rank 3) in top-10.',
+    },
+    {
+      id: 'q03',
+      kind: 'lexical',
+      query: 'hash chain audit log',
+      relevant: ['qmd://kb-curated/03a1e7c7-9b85-58fb-aa77-08ac74e8486a.md'],
+      notes:
+        "Exact concept term (spaces, not hyphens). Gold 'Hash-Chain Audit Log' at rank 1 (0.90). Hyphenated 'hash-chain' string returns 0 due to strict-AND tokenization; space form works.",
+    },
+    {
+      id: 'q04',
+      kind: 'lexical',
+      query: 'rapid write race condition',
+      relevant: ['qmd://kb-curated/d09ddcef-9754-5ef4-8402-0fe397ebe4ce.md'],
+      notes:
+        "Named bd-sync bug. Gold 'Rapid-Write Race Condition' at rank 1 (0.96). Note: 'bd-sync' as a bare hyphenated token returns 0; the descriptive phrase hits.",
+    },
+    {
+      id: 'q05',
+      kind: 'lexical',
+      query: 'pgvector HNSW index parameters',
+      relevant: ['qmd://kb-curated/46c53844-2b99-53d4-94be-9bfc538e4ca9.md'],
+      notes:
+        "Exact technical terms. Gold 'pgvector Extension' at rank 2 (0.96); an open-question guide about HNSW params is rank 1. Gold in top-10.",
+    },
+    {
+      id: 'q06',
+      kind: 'lexical',
+      query: 'row level security',
+      relevant: ['qmd://kb-curated/c39f9b40-f1cf-5e96-b6af-47faa598e935.md'],
+      notes:
+        "Exact term. Gold 'Row Level Security (RLS)' at rank 1 (0.90). Adding trailing token 'RLS' + 'multi-tenant' can drop it to 0 under strict-AND; the clean term hits.",
+    },
+    {
+      id: 'q07',
+      kind: 'lexical',
+      query: 'single tasking',
+      relevant: ['qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md'],
+      notes:
+        "Exact productivity concept. Gold 'Single-Tasking' at rank 2 (0.87); an open-question guide about single-tasking is rank 1. Gold in top-10.",
+    },
+    {
+      id: 'q08',
+      kind: 'lexical',
+      query: 'curated only default search',
+      relevant: ['qmd://kb-curated/5c600718-4993-5ae6-b0e3-125a25bae51d.md'],
+      notes:
+        "Exact design-decision term. Gold 'Curated-Only Default Search' at rank 1 (0.93). Hyphenated 'curated-only' as one token returns 0; space form hits.",
+    },
+    {
+      id: 'q09',
+      kind: 'lexical',
+      query: 'beads post compaction recovery',
+      relevant: [
+        'qmd://kb-curated/d2dd0c93-851d-526e-9f26-4e14b5dd6dff.md',
+        'qmd://kb-curated/6dc4a43f-3b1e-577d-9b21-fffd78e35425.md',
+      ],
+      notes:
+        'Exact feature terms. Both gold docs in top-10 (Post-Compaction Recovery (Beads) rank 1, Task Tracking and Post-Compaction Recovery with Beads rank 3).',
+    },
+    {
+      id: 'q10',
+      kind: 'lexical',
+      query: 'SOPS age secrets management',
+      relevant: ['qmd://kb-curated/6243141f-aa38-4a4b-b3e7-87df102befc7.md'],
+      notes: "Exact tooling name. Gold 'SOPS + Age Secrets Management' at rank 1 (0.94).",
+    },
+    {
+      id: 'q11',
+      kind: 'lexical',
+      query: 'Z3 formal verification',
+      relevant: ['qmd://kb-curated/270376d1-cdf5-58e0-86f5-29f1c8ae5d1f.md'],
+      notes: "Exact named technique. Gold 'Z3 Formal Verification' at rank 1 (0.95).",
+    },
+    {
+      id: 'q12',
+      kind: 'lexical',
+      query: 'ultralight travel',
+      relevant: ['qmd://kb-curated/69bf58b3-35d0-5588-8199-9b0a2292034b.md'],
+      notes:
+        "Exact lifestyle topic title. Gold 'Ultralight Travel' at rank 1 (0.96). Only 2 docs match.",
+    },
+    {
+      id: 'q13',
+      kind: 'lexical',
+      query: 'spool boundary threat model',
+      relevant: ['qmd://kb-curated/45e98c3c-8da9-5e73-ae55-6ec24012fbfd.md'],
+      notes:
+        "Exact security-doc title. Gold curated 'Spool Boundary Threat Model' at rank 1 (0.95).",
+    },
+    {
+      id: 'q14',
+      kind: 'lexical',
+      query: 'token passthrough prohibited MCP',
+      relevant: ['qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md'],
+      notes:
+        "Exact anti-pattern name plus qualifier. Gold 'Token Passthrough' at rank 1 (0.95). Adding the token 'anti-pattern' alone returns 0 (not in doc); 'prohibited MCP' co-occur and hit.",
+    },
+    {
+      id: 'q15',
+      kind: 'semantic',
+      query: "when a server gets tricked into using its own credentials for someone else's request",
+      relevant: ['qmd://kb-curated/00c95f4e-e1ee-51ad-9331-3aefd68a1629.md'],
+      notes:
+        'Plain-language paraphrase of the confused-deputy concept, deliberately avoiding the term. Gold NOT in top-10 (0 results) — genuine BM25 miss: no single doc contains all these common tokens under strict-AND.',
+    },
+    {
+      id: 'q16',
+      kind: 'semantic',
+      query:
+        'the model can propose actions but the deterministic system owns durable state and control',
+      relevant: [
+        'qmd://kb-curated/316bf636-cc61-507b-afa9-1d811ed441d7.md',
+        'qmd://kb-curated/44021ba6-1510-5393-b2d0-7b483b706ea2.md',
+      ],
+      notes:
+        "Paraphrase of the deterministic-control-plane thesis without the headline term. Gold NOT in top-10 — only 'Bead-Based Project Management Methodology' returned (unrelated); a BM25 miss on both control-plane docs.",
+    },
+    {
+      id: 'q17',
+      kind: 'semantic',
+      query: 'do one thing at a time with presence and gratitude to feel less overloaded',
+      relevant: ['qmd://kb-curated/d7e5a1fe-6b9a-5d53-88df-678cd7ad72e3.md'],
+      notes:
+        "Paraphrase of Mindful Focus avoiding the title words. Gold 'Mindful Focus' NOT in top-10 — only a 'Primer' guide (not the gold) returned; genuine miss on the curated concept doc.",
+    },
+    {
+      id: 'q18',
+      kind: 'semantic',
+      query: 'why do I keep filling every quiet moment so I never have to sit still',
+      relevant: ['qmd://kb-curated/fcfb7a3c-c9ad-5925-8c91-5b89a6a90f94.md'],
+      notes:
+        'Everyday-language paraphrase of Fear of Space, no headline keyword. Gold NOT in top-10 (0 results) — BM25 miss.',
+    },
+    {
+      id: 'q19',
+      kind: 'semantic',
+      query: 'overcome procrastination by observing urges and releasing false comforts',
+      relevant: ['qmd://kb-curated/f9a94d2d-8baf-5c5a-9a03-368c5bae8fb9.md'],
+      notes:
+        "Paraphrase of the 'Letting Go' method. Curated gold 'Letting Go' NOT in top-10 — a related blog guide (How I Learned to Stop Procrastinating) hit rank 1 instead, but that is not the labeled gold; miss on the concept doc.",
+    },
+    {
+      id: 'q20',
+      kind: 'semantic',
+      query: 'a green checkmark that passes even when the tool could not run launders trust',
+      relevant: ['qmd://kb-curated/51be40a8-5575-5730-9f9f-6483cb32903a.md'],
+      notes:
+        'Paraphrase of Honest-Gate Culture. Gold NOT in top-10 (0 results) — BM25 miss despite reusing some body wording; token set does not fully co-occur.',
+    },
+    {
+      id: 'q21',
+      kind: 'semantic',
+      query:
+        'each entry contains a cryptographic hash of the previous entry so tampering breaks the chain',
+      relevant: ['qmd://kb-curated/03a1e7c7-9b85-58fb-aa77-08ac74e8486a.md'],
+      notes:
+        "Definition-style paraphrase avoiding the phrase 'hash chain'. Gold 'Hash-Chain Audit Log' HIT at rank 1 (0.97) — succeeds because the paraphrase reuses the doc's own body wording (high term overlap).",
+    },
+    {
+      id: 'q22',
+      kind: 'semantic',
+      query: 'deny access by default unless explicitly approved',
+      relevant: ['qmd://kb-curated/bb527104-0513-5cc7-a203-88ca53e1f28d.md'],
+      notes:
+        "Concept paraphrase of Fail-Closed without the term. Gold 'Fail-Closed' HIT at rank 1 (0.96) — near-verbatim body match; the only doc returned.",
+    },
+    {
+      id: 'q23',
+      kind: 'semantic',
+      query: 'picking one task clearing distractions giving it complete attention',
+      relevant: ['qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md'],
+      notes:
+        "Paraphrase of Single-Tasking avoiding the compound term. Gold 'Single-Tasking' HIT at rank 1 (0.97) — reuses the doc's body phrasing.",
+    },
+    {
+      id: 'q24',
+      kind: 'semantic',
+      query:
+        'separate the writer database pool from the reader so the verification path cannot write',
+      relevant: ['qmd://kb-curated/311c194f-9bd7-534d-9d8a-9c862b3bfbc4.md'],
+      notes:
+        "Paraphrase of Dual-Pool Postgres avoiding 'dual-pool'. Gold HIT at rank 1 (0.97) — strong body-term overlap; only doc returned.",
+    },
+    {
+      id: 'q25',
+      kind: 'semantic',
+      query: 'the fastest path when bootstrapping from zero is a linear series of phases',
+      relevant: ['qmd://kb-curated/4236510f-d643-5994-8ec5-5b81dd09d4b3.md'],
+      notes:
+        'Paraphrase of Sequential Phase Execution avoiding the title. Gold HIT at rank 1 (0.97) — reuses body wording.',
+    },
+    {
+      id: 'q26',
+      kind: 'semantic',
+      query: 'raise alert priority once a failure streak forms',
+      relevant: ['qmd://kb-curated/08909f28-291a-5d1b-a867-030f09f6fc03.md'],
+      notes:
+        'Paraphrase of Consecutive-Failure Escalation avoiding the term. Gold HIT at rank 1 (0.97) — body-phrasing overlap.',
+    },
+    {
+      id: 'q27',
+      kind: 'semantic',
+      query: 'transforms raw corpus into structured semantic knowledge through defined passes',
+      relevant: ['qmd://kb-curated/b1c0e2d7-6fd6-5e65-9cf0-4e94d5bd585e.md'],
+      notes:
+        'Paraphrase of Knowledge Compilation avoiding the term. Gold HIT at rank 1 (0.97) — reuses body wording; blueprint guides also returned.',
+    },
+    {
+      id: 'q28',
+      kind: 'semantic',
+      query: 'MCP servers must not accept tokens that were not issued for themselves',
+      relevant: ['qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md'],
+      notes:
+        "Restatement of the token-passthrough rule without the term. Gold 'Token Passthrough' NOT in top-10 (0 results) — miss even though semantically exact; token co-occurrence fails under strict-AND.",
+    },
+    {
+      id: 'q29',
+      kind: 'semantic',
+      query: 'sort tasks by urgency to reduce stress from an overloaded schedule',
+      relevant: ['qmd://kb-curated/d5344eaa-1afa-5737-8c9e-a7c954814050.md'],
+      notes:
+        "Paraphrase of Triage avoiding the word 'triage'. Curated gold 'Triage' NOT in top-10 — a 'Primer' guide (not the gold) returned instead; miss on the concept doc.",
+    },
+    {
+      id: 'q30',
+      kind: 'semantic',
+      query: 'route cheap simple requests to a free local model and hard ones to a paid cloud API',
+      relevant: ['qmd://kb-curated/c55559d7-e5fe-5f25-bc12-49b733d5b80a.md'],
+      notes:
+        'Paraphrase of the Hybrid AI Stack routing idea, no headline term. Curated gold NOT in top-10 — only an archive open-question doc (out of default scope) returned; miss.',
+    },
+    {
+      id: 'q31',
+      kind: 'semantic',
+      query: 'use real database containers in tests instead of mocks to catch production bugs',
+      relevant: ['qmd://kb-curated/32743115-7333-5076-9143-c997fb662faf.md'],
+      notes:
+        'Paraphrase of Testcontainers-Based Testing avoiding the term. Curated gold NOT in top-10 — a related blog guide returned instead; miss on the concept doc.',
+    },
+    {
+      id: 'q32',
+      kind: 'semantic',
+      query:
+        'give each dashboard panel its own error boundary so one crash does not blank the page',
+      relevant: ['qmd://kb-curated/f32f7ee1-c295-50bd-a837-49e98e4e643a.md'],
+      notes:
+        "Paraphrase of Per-Panel Error Boundaries reusing some body words. Gold NOT in top-10 (0 results) — BM25 miss; the query's token set never fully co-occurs.",
+    },
+    {
+      id: 'q33',
+      kind: 'semantic',
+      query: 'the pipeline executes a misread specification perfectly and ships the wrong product',
+      relevant: [
+        'qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md',
+        'qmd://kb-curated/75620fd4-eb23-5c6b-a57e-f480a5611bb2.md',
+      ],
+      notes:
+        "Paraphrase of Requirements-Level Error Amplification. Guide gold 'The Wrong Product, Built Perfectly' HIT at rank 1 (0.97); the curated concept doc 'Requirements-Level Error Amplification' did NOT appear (partial hit — one of two golds retrieved).",
+    },
+    {
+      id: 'q34',
+      kind: 'semantic',
+      query:
+        'two environment variables must both be set before an expensive or dangerous operation runs',
+      relevant: ['qmd://kb-curated/7e789883-2c59-5b0d-9117-57746de98acc.md'],
+      notes:
+        'Paraphrase of the Double-Gate Pattern avoiding the term. Gold NOT in top-10 (0 results) — BM25 miss.',
+    },
+    {
+      id: 'q35',
+      kind: 'semantic',
+      query: 'search the brain before saving because it only dedupes at promotion not intake',
+      relevant: ['qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md'],
+      notes:
+        'Paraphrase of the search-before-save memory rule reusing body concepts. Gold NOT in top-10 (0 results) — BM25 miss; tokens do not fully co-occur in one doc.',
+    },
+    {
+      id: 'q36',
+      kind: 'semantic',
+      query: 'teammates reach one shared brain over the network instead of each running their own',
+      relevant: ['qmd://kb-curated/03e26e71-27ee-5975-81f3-badbb273894b.md'],
+      notes:
+        'Plain-language paraphrase of team-mode / shared-remote-brain. Gold NOT in top-10 (0 results) — BM25 miss on the team-mode doc.',
+    },
+    {
+      id: 'q37',
+      kind: 'semantic',
+      query:
+        'reducing the available tool set from twenty to four or five based on the current context',
+      relevant: ['qmd://kb-curated/aa69b924-73ca-5f30-92fa-779da6f0dacb.md'],
+      notes:
+        'Paraphrase of Contextual Tool Narrowing reusing body numbers. Gold NOT in top-10 (0 results) — BM25 miss despite high semantic match.',
+    },
+    {
+      id: 'q38',
+      kind: 'semantic',
+      query:
+        'separate the build environment from the runtime environment to reduce the final image size',
+      relevant: ['qmd://kb-curated/016efea4-8115-56df-80b6-2127a07a298f.md'],
+      notes:
+        "Paraphrase of Multi-Stage Docker Build avoiding 'multi-stage'. Gold HIT at rank 1 (0.97) — reuses body wording closely.",
+    },
+    {
+      id: 'q39',
+      kind: 'semantic',
+      query: 'the moat is deterministic governance and receipts not better recall',
+      relevant: ['qmd://kb-decisions/45fcbe44-972f-5a3e-9c7b-00d03dc66beb.md'],
+      notes:
+        'Paraphrase of the Governed-Memory positioning decision. Gold (a kb-decisions doc) NOT in top-10 (0 results) — BM25 miss; also exercises the decisions collection.',
+    },
+    {
+      id: 'q40',
+      kind: 'semantic',
+      query:
+        'each stage returns a new model via model_copy update rather than mutating the original',
+      relevant: ['qmd://kb-curated/f9f16dc2-ad20-5ae2-8e7c-058a87daba66.md'],
+      notes:
+        "Paraphrase of the Immutable Lead Model reusing near-verbatim body wording. Gold NOT in top-10 (0 results) — BM25 miss; 'model_copy' underscore token plus others fail to co-occur.",
+    },
+    {
+      id: 'q41',
+      kind: 'semantic',
+      query: 'member proposes and the server disposes with a remote proxy over the tailnet',
+      relevant: ['qmd://kb-curated/03e26e71-27ee-5975-81f3-badbb273894b.md'],
+      notes:
+        'Paraphrase of team-mode governance (member-proposes/server-disposes). Gold NOT in top-10 (0 results) — BM25 miss.',
+    },
+    {
+      id: 'q42',
+      kind: 'semantic',
+      query: 'the brain does not dedupe at intake only promotion dedupes so search before you save',
+      relevant: ['qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md'],
+      notes:
+        "Alternate paraphrase of the same intake-dedupe rule as q35, closer to the body wording. Gold NOT in top-10 (0 results) — BM25 miss; shows even body-close rewording can fail under strict-AND when a token (e.g. 'intake') pairing is sparse.",
+    },
+  ],
+};

--- a/packages/qmd-adapter/src/eval/index.ts
+++ b/packages/qmd-adapter/src/eval/index.ts
@@ -13,3 +13,7 @@ export type {
   EvalReport,
 } from './eval-types.js';
 export { SEED_EVAL_DATASET } from './datasets/seed-queries.js';
+export { stratify, formatStratifiedReport } from './stratified-report.js';
+export type { StratumMetrics, StratifiedReport } from './stratified-report.js';
+export { qmdRetrievalFn } from './qmd-retrieval.js';
+export { GOVERNED_BRAIN_V1_DATASET } from './datasets/governed-brain-v1.js';

--- a/packages/qmd-adapter/src/eval/qmd-retrieval.ts
+++ b/packages/qmd-adapter/src/eval/qmd-retrieval.ts
@@ -1,0 +1,33 @@
+import type { SearchScope } from '@qmd-team-intent-kb/schema';
+import type { QmdAdapter } from '../adapter.js';
+import type { RetrievalFn } from './eval-types.js';
+
+/**
+ * Adapt a live {@link QmdAdapter} to the eval harness's {@link RetrievalFn}
+ * (bead compile-then-govern-e06.4 / umbrella #27).
+ *
+ * This is the ONE honest retrieval path: it drives the exact same
+ * `adapter.query()` the MCP `brain_search` tool uses in production — scope
+ * enforcement, tenant guard, qmd `search --json`, and `qmd://` citation parsing
+ * all included — and returns the ranked `qmd://` citation ids (the `.file`
+ * field). Because it is the production path, the number the harness computes is
+ * the number `brain_search` actually delivers, not a re-implementation of it.
+ *
+ * `scope` defaults to `'curated'` (curated + decisions + guides — the default
+ * search surface); pass `'all'` to include inbox/archive. `tenantId` MUST match
+ * the tenant the adapter is bound to, or the adapter's fail-closed guard returns
+ * an empty list.
+ */
+export function qmdRetrievalFn(
+  adapter: QmdAdapter,
+  tenantId: string,
+  scope: SearchScope = 'curated',
+): RetrievalFn {
+  return async (query: string, _k: number): Promise<string[]> => {
+    const result = await adapter.query(query, scope, tenantId);
+    if (!result.ok) return [];
+    // qmd already returns hits ranked best-first; the harness applies the top-k
+    // cutoff itself, so we hand back the full ranked citation list.
+    return result.value.map((hit) => hit.file);
+  };
+}

--- a/packages/qmd-adapter/src/eval/stratified-report.ts
+++ b/packages/qmd-adapter/src/eval/stratified-report.ts
@@ -1,0 +1,98 @@
+import { reciprocalRank } from './metrics.js';
+import type { EvalReport, EvalQuery } from './eval-types.js';
+
+/**
+ * Stratified reporting over an {@link EvalReport} (bead compile-then-govern-e06.4 /
+ * umbrella #27).
+ *
+ * ADR 038-AT-DECR does not gate on ONE overall Recall@10 — it gates on where the
+ * recall wall shows up, which is the SEMANTIC (paraphrase / concept) stratum.
+ * BM25 is strong on `lexical` queries (exact terms / names) and silently weak on
+ * `semantic` ones; a healthy overall mean can hide a semantic collapse. So the
+ * real verdict needs the split, not just the aggregate.
+ *
+ * This is a thin, read-only slice over the per-query results {@link runEval}
+ * already computes — it adds no new retrieval, just groups by `kind` and adds
+ * MRR (mean reciprocal rank), the "how high is the first good hit" companion.
+ *
+ * `runEval` intentionally does NOT record `relevant` on each per-query row, so
+ * MRR is recomputed here from the dataset's gold set (keyed by query id) against
+ * the retrieved list already captured in the report.
+ */
+
+/** One stratum's aggregate metrics (or the overall row). */
+export interface StratumMetrics {
+  /** 'lexical' | 'semantic' | 'untagged' | 'overall'. */
+  stratum: string;
+  queryCount: number;
+  meanRecallAtK: number;
+  meanNdcgAtK: number;
+  /** Mean reciprocal rank of the first relevant hit. */
+  mrr: number;
+}
+
+/** The full stratified view: overall + one row per observed `kind`. */
+export interface StratifiedReport {
+  dataset: string;
+  backend: string;
+  k: number;
+  overall: StratumMetrics;
+  byKind: StratumMetrics[];
+}
+
+function mean(nums: readonly number[]): number {
+  return nums.length === 0 ? 0 : nums.reduce((s, n) => s + n, 0) / nums.length;
+}
+
+/**
+ * Build the stratified report. `goldById` maps each query id to its gold-relevant
+ * id set so MRR can be recomputed against the retrieved lists in `report`.
+ */
+export function stratify(report: EvalReport, queries: readonly EvalQuery[]): StratifiedReport {
+  const goldById = new Map<string, ReadonlySet<string>>(
+    queries.map((q) => [q.id, new Set(q.relevant)]),
+  );
+
+  const rows = report.perQuery.map((r) => ({
+    kind: r.kind ?? 'untagged',
+    recall: r.recallAtK,
+    ndcg: r.ndcgAtK,
+    rr: reciprocalRank(r.retrieved, goldById.get(r.id) ?? new Set<string>()),
+  }));
+
+  const summarize = (stratum: string, subset: typeof rows): StratumMetrics => ({
+    stratum,
+    queryCount: subset.length,
+    meanRecallAtK: mean(subset.map((x) => x.recall)),
+    meanNdcgAtK: mean(subset.map((x) => x.ndcg)),
+    mrr: mean(subset.map((x) => x.rr)),
+  });
+
+  const kinds = [...new Set(rows.map((r) => r.kind))].sort();
+  return {
+    dataset: report.dataset,
+    backend: report.backend,
+    k: report.k,
+    overall: summarize('overall', rows),
+    byKind: kinds.map((kind) =>
+      summarize(
+        kind,
+        rows.filter((r) => r.kind === kind),
+      ),
+    ),
+  };
+}
+
+/** Compact, human/CI-readable rendering of a stratified report. */
+export function formatStratifiedReport(sr: StratifiedReport): string {
+  const line = (m: StratumMetrics): string =>
+    `  ${m.stratum.padEnd(9)} n=${String(m.queryCount).padStart(3)}  ` +
+    `Recall@${sr.k}=${m.meanRecallAtK.toFixed(4)}  ` +
+    `nDCG@${sr.k}=${m.meanNdcgAtK.toFixed(4)}  ` +
+    `MRR=${m.mrr.toFixed(4)}`;
+  return [
+    `eval "${sr.dataset}" · backend=${sr.backend} @k=${sr.k}`,
+    line(sr.overall),
+    ...sr.byKind.map(line),
+  ].join('\n');
+}

--- a/scripts/eval-retrieval.ts
+++ b/scripts/eval-retrieval.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/eval-retrieval.ts — the FIRST REAL retrieval number for the Governed
+ * Second Brain (bead compile-then-govern-e06.4 / umbrella #27 / ADR 038-AT-DECR).
+ *
+ * Runs the hand-labeled `governed-brain-v1` query set through the LIVE qmd BM25
+ * index via the production `adapter.query()` path (the same one `brain_search`
+ * uses) and prints Recall@10 + nDCG@10 + MRR, OVERALL and split lexical vs
+ * semantic, then the 0.85-Recall@10 BM25-sufficiency verdict from ADR 038.
+ *
+ * Read-only: it searches an already-built index (default `~/.teamkb`), never
+ * reindexes, never writes to the brain. Run it after the index is fresh
+ * (`pnpm reindex`) so search is warm.
+ *
+ * Usage:
+ *   pnpm eval:retrieval                      # against ~/.teamkb, tenant intent-solutions
+ *   TEAMKB_TENANT=<id> pnpm eval:retrieval   # different tenant
+ *   TEAMKB_BASE_PATH=<dir> pnpm eval:retrieval   # different brain root
+ *   EVAL_SCOPE=all pnpm eval:retrieval       # include inbox/archive (default: curated)
+ *
+ * Exit codes: 0 = ran and reported (regardless of verdict); 2 = qmd unavailable
+ * or the index returned nothing for every query (misconfig — reindex first).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { SearchScope } from '@qmd-team-intent-kb/schema';
+
+import { QmdAdapter } from '../packages/qmd-adapter/src/adapter.js';
+import {
+  runEval,
+  stratify,
+  formatStratifiedReport,
+  qmdRetrievalFn,
+  BM25_SUFFICIENCY_RECALL_THRESHOLD,
+  GOVERNED_BRAIN_V1_DATASET,
+} from '../packages/qmd-adapter/src/eval/index.js';
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  if (!qmdAvailable()) {
+    console.error(
+      'qmd binary not on PATH — cannot run the live retrieval eval. Install qmd first.',
+    );
+    process.exit(2);
+  }
+
+  const tenantId = process.env['TEAMKB_TENANT'] ?? 'intent-solutions';
+  const base = process.env['TEAMKB_BASE_PATH'] ?? join(homedir(), '.teamkb');
+  const exportDir = join(base, 'kb-export');
+  const scope = (process.env['EVAL_SCOPE'] as SearchScope | undefined) ?? 'curated';
+
+  const adapter = new QmdAdapter({ tenantId, exportDir });
+  const retrieve = qmdRetrievalFn(adapter, tenantId, scope);
+
+  const dataset = GOVERNED_BRAIN_V1_DATASET;
+  const report = await runEval(dataset, retrieve, { k: 10, backend: `qmd-bm25 (scope=${scope})` });
+
+  // Guard: a totally empty result set means the index is not built for this
+  // tenant, not that BM25 scored 0. Fail loudly instead of reporting a fake 0.
+  const anyHits = report.perQuery.some((r) => r.retrieved.length > 0);
+  if (!anyHits) {
+    console.error(
+      `Every query returned 0 hits for tenant "${tenantId}" at ${exportDir}. ` +
+        'The qmd index is empty/unbuilt — run `pnpm reindex` first.',
+    );
+    process.exit(2);
+  }
+
+  const sr = stratify(report, dataset.queries);
+
+  console.log(`\n=== Governed Second Brain — retrieval eval (${dataset.name}) ===`);
+  console.log(`corpus: ${exportDir}  tenant: ${tenantId}  queries: ${report.queryCount}\n`);
+  console.log(formatStratifiedReport(sr));
+
+  const overall = sr.overall.meanRecallAtK;
+  const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+  const gate = BM25_SUFFICIENCY_RECALL_THRESHOLD;
+
+  console.log(`\n=== ADR 038-AT-DECR verdict (gate: Recall@10 ≥ ${gate}) ===`);
+  console.log(
+    `overall Recall@10 = ${overall.toFixed(4)} → ${overall >= gate ? 'CLEARS' : 'BELOW'} the gate`,
+  );
+  if (semantic) {
+    console.log(
+      `semantic Recall@10 = ${semantic.meanRecallAtK.toFixed(4)} → ` +
+        `${semantic.meanRecallAtK >= gate ? 'CLEARS' : 'BELOW'} the gate ` +
+        '(the stratum ADR 038 weights the decision on)',
+    );
+  }
+  console.log(
+    overall >= gate
+      ? '\nBM25 is SUFFICIENT — the ~320MB semantic backend (bead 0t9.3) is not yet justified.'
+      : '\nBM25 is INSUFFICIENT on this set — the semantic recall wall is real; the sqlite-vec\n' +
+          'semantic path (bead 0t9.3) is now justified per the ADR signal.',
+  );
+
+  // Machine-readable per-query dump for auditability (which queries BM25 missed).
+  const misses = report.perQuery.filter((r) => r.recallAtK === 0);
+  if (misses.length > 0) {
+    console.log(`\n--- BM25 misses (Recall@10 = 0), ${misses.length} of ${report.queryCount} ---`);
+    for (const m of misses) {
+      console.log(`  [${m.kind ?? 'untagged'}] ${m.id}: "${m.query}"`);
+    }
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## The first real retrieval number

Replaces the self-declared placeholder seed set with a **42-query hand-labeled benchmark over the actual live `~/.teamkb` corpus** (tenant `intent-solutions`), run through the **production `brain_search` BM25 path**, to gate [ADR 038-AT-DECR](../blob/main/000-docs/038-AT-DECR-retrieval-backend-decision-2026-06-18.md)'s 0.85-Recall@10 decision on measured numbers instead of vibes.

Bead `compile-then-govern-e06.4` / umbrella #27.

## Measured (live index, scope=curated, k=10)

| Stratum | n | Recall@10 | nDCG@10 | MRR |
|---|---|---|---|---|
| **overall** | 42 | **0.5595** | 0.5515 | 0.5595 |
| lexical | 14 | **1.0000** | 0.9679 | 0.9643 |
| semantic | 28 | **0.3393** | 0.3433 | 0.3571 |

18 of 42 queries were total misses (Recall@10 = 0) — **all 18 semantic**.

## Verdict vs the 0.85 gate

- Overall Recall@10 = **0.5595 → BELOW 0.85**.
- Semantic Recall@10 = **0.3393 → BELOW 0.85** — the stratum ADR 038 weights the decision on.
- **BM25 is INSUFFICIENT on this set.** Lexical retrieval is effectively perfect (1.0 — BM25 nails exact terms/names), but the semantic recall wall is real. The deferred **sqlite-vec + EmbeddingGemma-300M** path (bead `qmd-team-intent-kb-0t9.3`) is now justified per the ADR signal — on a measured number, not a hunch.

## Honest caveat on interpretation (read before over-reading 0.339)

qmd's default retrieval is **strict-AND FTS5/BM25**: a doc is only returned when it contains *all* query tokens, so most semantic misses return literally **zero rows**, not a low-ranked gold. That makes 0.339 a **floor for this exact backend configuration** — a BM25 variant with OR-fallback / token relaxation would likely score higher on the same labels. The harness correctly measures the shipping `brain_search` path as-is (which is the right thing to gate on), but the "semantic backend justified" conclusion rests partly on the current strict-AND behavior, not solely on BM25-vs-dense in the abstract. Worth noting in the ADR follow-up.

## How the labels were kept honest (no cherry-picking)

- Gold `qmd://` citations are **real corpus docs**, validated present in the live export tree; ids are the exact production id space (`QmdSearchResult.file`).
- Each query was **labeled from the corpus first** (read title + body, decide it answers the query), then live search confirmed the gold exists and recorded its rank.
- **Weighted toward semantic** (28/14) — that's where the wall shows.
- **BM25 misses on valid semantic queries were kept, not discarded or reworded.** The miss is the signal the gate measures.
- Methodology + reproduction: `packages/qmd-adapter/src/eval/datasets/README.md`.

## What's in the diff (additive, non-breaking)

- `eval/datasets/governed-brain-v1.ts` — the 42-query labeled dataset (+ `README.md` methodology).
- `eval/qmd-retrieval.ts` — `RetrievalFn` over the production `adapter.query()` BM25 path (the number is what `brain_search` delivers, not a re-impl).
- `eval/stratified-report.ts` — lexical/semantic split + MRR over the shipped `runEval`.
- `scripts/eval-retrieval.ts` (`pnpm eval:retrieval`) — runs the set against the live index, prints the stratified report + ADR verdict; **read-only**, never reindexes/writes.
- Tests: `eval-retrieval-live.test.ts` (CI reproduction against the live index, skips cleanly if qmd/index absent) + `eval-stratified` + `eval-qmd-retrieval` unit tests (always run) + dataset-integrity assertions.

## Reproduce

\`\`\`bash
pnpm reindex          # warm the live index
pnpm eval:retrieval   # prints the table above + verdict
\`\`\`

## Gates

Full suite **158/158**; typecheck / lint / format all clean. Read-only against `~/.teamkb` (no writes, no reindex).

**Do not merge** — this is the measurement + recommendation for review.

- Jeremy Longshore
intentsolutions.io