### PR TITLE
fix(govern): gate heroku UUID rule + converge PII vocab to raise precision

### DIFF
--- a/packages/claude-runtime/src/__tests__/content-classifier.test.ts
+++ b/packages/claude-runtime/src/__tests__/content-classifier.test.ts
@@ -77,4 +77,47 @@ describe('classifyContent', () => {
     expect(result.hasPii).toBe(true);
     expect(result.hasInternalPaths).toBe(true);
   });
+
+  // --- Part 2: PII vocabulary convergence (bead compile-then-govern-e06.15) ---
+  // classifyContent's PII set now matches the repository-boundary filter, so a
+  // DOB-only / background-check / SSN-keyword leak is classified confidential
+  // pre-boundary (before this fix these passed the classifier and the policy
+  // pipeline that gates on it, caught only at the write choke point).
+  it('returns confidential and hasPii=true for a DOB-only disclosure (converged vocab)', () => {
+    const result = classifyContent('HR note — DOB: 1984-07-02, hired last spring.');
+    expect(result.sensitivityLevel).toBe('confidential');
+    expect(result.hasPii).toBe(true);
+    expect(result.matchedPatterns).toContain('date-of-birth');
+  });
+
+  it('returns confidential for an SSN referenced by keyword (no digits)', () => {
+    const result = classifyContent('Collect the applicant SSN during onboarding.');
+    expect(result.sensitivityLevel).toBe('confidential');
+    expect(result.hasPii).toBe(true);
+    expect(result.matchedPatterns).toContain('ssn-keyword');
+  });
+
+  it('returns confidential for a background-check disclosure', () => {
+    const result = classifyContent('The background-check report came back clean.');
+    expect(result.sensitivityLevel).toBe('confidential');
+    expect(result.hasPii).toBe(true);
+    expect(result.matchedPatterns).toContain('background-check');
+  });
+
+  // --- Part 1: UUID-in-prose no longer over-classified (precision guard) ------
+  // The heroku-api-key rule is UUID-shaped; before the context gate a UUID in
+  // prose was classified `restricted` (a credential). Now it stays `public`.
+  it('classifies a UUID in ordinary prose as public (heroku context gate)', () => {
+    const result = classifyContent('The request id was 3f2504e0-4f89-41d3-9a0c-0305e82c3301.');
+    expect(result.sensitivityLevel).toBe('public');
+    expect(result.hasCredentials).toBe(false);
+    expect(result.matchedPatterns).toHaveLength(0);
+  });
+
+  it('still classifies a real Heroku key in key-context as restricted (recall held)', () => {
+    const result = classifyContent('HEROKU_API_KEY=3f2504e0-4f89-41d3-9a0c-0305e82c3301');
+    expect(result.sensitivityLevel).toBe('restricted');
+    expect(result.hasCredentials).toBe(true);
+    expect(result.matchedPatterns).toContain('heroku-api-key');
+  });
 });

--- a/packages/claude-runtime/src/__tests__/patterns.test.ts
+++ b/packages/claude-runtime/src/__tests__/patterns.test.ts
@@ -51,4 +51,67 @@ describe('PII_PATTERNS', () => {
     expect(ssnPattern).toBeDefined();
     expect(ssnPattern!.regex.test('123-45-6789')).toBe(true);
   });
+
+  // PII vocabulary convergence (bead compile-then-govern-e06.15 · umbrella #27):
+  // the classifier's PII set is widened UP to the repository-boundary filter's
+  // PII_PATTERN — SSN keyword, DOB, and background-check terms — so a DOB-only
+  // leak is caught pre-boundary by the policy pipeline too, not only at the
+  // write choke point. Additive / tightening only.
+  it('includes an SSN keyword pattern (SSN / social security number)', () => {
+    const p = PII_PATTERNS.find((x) => x.id === 'ssn-keyword');
+    expect(p).toBeDefined();
+    expect(p!.regex.test('Employee SSN on file')).toBe(true);
+    expect(p!.regex.test('social security number redacted')).toBe(true);
+  });
+
+  it('includes a date-of-birth pattern (date of birth / DOB: / DOB=)', () => {
+    const p = PII_PATTERNS.find((x) => x.id === 'date-of-birth');
+    expect(p).toBeDefined();
+    expect(p!.regex.test('DOB: 1984-07-02')).toBe(true);
+    expect(p!.regex.test('date of birth on the form')).toBe(true);
+    // A bare "DOB" mention without an assignment stays below the bar (matches
+    // the boundary filter's `\bDOB\b\s*[:=]` shape — no over-broad firing).
+    expect(p!.regex.test('the DOB column header')).toBe(false);
+  });
+
+  it('includes a background-check pattern', () => {
+    const p = PII_PATTERNS.find((x) => x.id === 'background-check');
+    expect(p).toBeDefined();
+    expect(p!.regex.test('background-check passed')).toBe(true);
+    expect(p!.regex.test('background check report attached')).toBe(true);
+  });
+});
+
+describe('heroku-api-key context gate (precision guard)', () => {
+  // The heroku-api-key rule is UUID-shaped, so it is gated behind key-context to
+  // avoid over-flagging a request/trace/bead id in prose (bead
+  // compile-then-govern-e06.15). The pattern still carries the UUID regex; the
+  // scanner (execWithContext) enforces the context. Here we assert the
+  // requiresContext gate exists and matches key-context but not bare prose.
+  const heroku = SECRET_PATTERNS.find((p) => p.id === 'heroku-api-key')!;
+
+  it('still recognises the UUID shape', () => {
+    expect(heroku.regex.test('3f2504e0-4f89-41d3-9a0c-0305e82c3301')).toBe(true);
+  });
+
+  it('carries a requiresContext gate', () => {
+    expect(heroku.requiresContext).toBeInstanceOf(RegExp);
+  });
+
+  it('context gate matches key-context (HEROKU / API / KEY / assignment)', () => {
+    const ctx = heroku.requiresContext!;
+    expect(ctx.test('HEROKU_API_KEY=3f2504e0-4f89-41d3-9a0c-0305e82c3301')).toBe(true);
+    expect(ctx.test('the Heroku API key is ...')).toBe(true);
+    expect(ctx.test('bearer token ...')).toBe(true);
+  });
+
+  it('context gate does NOT match ordinary id prose', () => {
+    const ctx = heroku.requiresContext!;
+    expect(ctx.test('The request id was 3f2504e0-4f89-41d3-9a0c-0305e82c3301 in the trace.')).toBe(
+      false,
+    );
+    expect(ctx.test('Tracked in bead 3f2504e0-4f89-41d3-9a0c-0305e82c3301 for the sprint.')).toBe(
+      false,
+    );
+  });
 });

--- a/packages/claude-runtime/src/__tests__/redactor.test.ts
+++ b/packages/claude-runtime/src/__tests__/redactor.test.ts
@@ -33,4 +33,33 @@ describe('redactSecrets', () => {
     expect(result).toContain('[REDACTED:aws-key]');
     expect(result).toContain('[REDACTED:connection-string]');
   });
+
+  // Context gate consistency with scanForSecrets (bead compile-then-govern-e06.15).
+  it('does NOT redact a bare UUID in prose (heroku context gate)', () => {
+    const content = 'The request id was 3f2504e0-4f89-41d3-9a0c-0305e82c3301 in the trace.';
+    // No key-context → the heroku rule is suppressed, so the UUID is left intact
+    // (matching the scanner, which no longer flags it).
+    expect(redactSecrets(content)).toBe(content);
+  });
+
+  it('STILL redacts a real Heroku key in key-context (recall held)', () => {
+    // The key MUST be gone (recall held). Note: in a `HEROKU_API_KEY=` string the
+    // broader `env-secret` (`API_KEY=…`) rule runs first and redacts the whole
+    // assignment, so the value is removed under that id — the context-gated
+    // heroku rule is a backstop, not the only path. Either way, no leak.
+    const content = 'HEROKU_API_KEY=3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+    const result = redactSecrets(content);
+    expect(result).not.toContain('3f2504e0-4f89-41d3-9a0c-0305e82c3301');
+    expect(result).toContain('[REDACTED:');
+  });
+
+  it('redacts the Heroku key via the context-gated rule when no other rule fires', () => {
+    // Reference the key with heroku/api-key WORDS (not an `API_KEY=` assignment),
+    // so the env-secret rule does not pre-empt it — proving the context-gated
+    // heroku rule itself fires and redacts when its context is present.
+    const content = 'Heroku api key value: 3f2504e0-4f89-41d3-9a0c-0305e82c3301 rotate soon';
+    const result = redactSecrets(content);
+    expect(result).toContain('[REDACTED:heroku-api-key]');
+    expect(result).not.toContain('3f2504e0-4f89-41d3-9a0c-0305e82c3301');
+  });
 });

--- a/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
+++ b/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
@@ -315,6 +315,37 @@ describe('scanForSecrets — heroku UUID context gate (precision up, recall held
     expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(false);
   });
 
+  it('flags a base64-wrapped Heroku key when the ORIGINAL content has context (recall held)', () => {
+    // Gemini finding: the decoded blob is just the raw UUID and carries no
+    // context keywords, so the context gate must be evaluated against the
+    // ORIGINAL content (threaded via scanFlat's contextText). A real wrapped
+    // Heroku key surrounded by `heroku api key` context must still be caught.
+    const wrapped = Buffer.from(UUID, 'utf8').toString('base64');
+    const content = `The Heroku API key blob is ${wrapped} — decode at runtime.`;
+    expect(
+      scanForSecrets(content).some((m) => m.patternId === 'base64-wrapped:heroku-api-key'),
+    ).toBe(true);
+  });
+
+  it('flags a hex-wrapped Heroku key when the original content has context (recall held)', () => {
+    const wrapped = Buffer.from(UUID, 'utf8').toString('hex');
+    const content = `heroku token hexval ${wrapped} rotate soon`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'hex-wrapped:heroku-api-key')).toBe(
+      true,
+    );
+  });
+
+  it('does NOT flag a base64-wrapped bare UUID with NO context (precision held)', () => {
+    // A UUID that merely happens to be base64-wrapped in prose with no key
+    // context stays suppressed — the decode pass does not resurrect the
+    // over-block the gate removed.
+    const wrapped = Buffer.from(UUID, 'utf8').toString('base64');
+    const content = `The request id blob is ${wrapped} in the trace log.`;
+    expect(
+      scanForSecrets(content).some((m) => m.patternId === 'base64-wrapped:heroku-api-key'),
+    ).toBe(false);
+  });
+
   it('resets lastIndex on a global/sticky requiresContext regex (determinism)', () => {
     // A custom context-gated pattern whose CONTEXT regex carries the global flag.
     // Without resetting `requiresContext.lastIndex` between scans, `.test()`

--- a/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
+++ b/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
@@ -314,4 +314,33 @@ describe('scanForSecrets — heroku UUID context gate (precision up, recall held
     const content = `trace segment one\n${UUID}\nsegment two ends here`;
     expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(false);
   });
+
+  it('resets lastIndex on a global/sticky requiresContext regex (determinism)', () => {
+    // A custom context-gated pattern whose CONTEXT regex carries the global flag.
+    // Without resetting `requiresContext.lastIndex` between scans, `.test()`
+    // would advance lastIndex and make the gate nondeterministic — the second
+    // scan could wrongly suppress a hit the first counted. Scanning twice must
+    // yield identical results, and the gate must both fire (context present) and
+    // suppress (context absent) correctly.
+    const gated: SecretPattern = {
+      id: 'custom-gated',
+      name: 'Custom Context-Gated Token',
+      regex: /GATED-[A-Z0-9]{6}/,
+      description: 'a custom pattern gated behind a global-flag context regex',
+      requiresContext: /\bkeyctx\b/g, // NOTE the global flag
+    };
+
+    const withCtx = 'keyctx present: GATED-ABC123 in scope';
+    const first = scanForSecrets(withCtx, [gated]);
+    const second = scanForSecrets(withCtx, [gated]);
+    expect(first).toEqual(second);
+    expect(first.some((m) => m.patternId === 'custom-gated')).toBe(true);
+
+    // Same token, no context word → suppressed, and stable across scans.
+    const noCtx = 'no context here: GATED-ABC123 in scope';
+    const a = scanForSecrets(noCtx, [gated]);
+    const b = scanForSecrets(noCtx, [gated]);
+    expect(a).toEqual(b);
+    expect(a.some((m) => m.patternId === 'custom-gated')).toBe(false);
+  });
 });

--- a/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
+++ b/packages/claude-runtime/src/__tests__/secret-scanner.test.ts
@@ -265,3 +265,53 @@ describe('scanForSecrets — global/sticky custom pattern determinism (evasion h
     expect(first).toEqual(second);
   });
 });
+
+/**
+ * Heroku-key UUID context gate (bead compile-then-govern-e06.15 · umbrella #27).
+ *
+ * The `heroku-api-key` rule is a bare-UUID regex, so before this fix ANY UUID in
+ * prose (a request/trace/bead id) was flagged as a live credential —
+ * over-blocking a benign memory (the e06.3 eval's `neg-uuid-in-prose-01` false
+ * positive). The fix gates the rule behind key-context. These tests pin BOTH
+ * directions: precision UP (a bare UUID in prose is NOT flagged) and recall HELD
+ * (a real Heroku key in a key-context IS still flagged). The gate NEVER weakens
+ * a context-free rule — only the ambiguous UUID pattern is gated.
+ */
+describe('scanForSecrets — heroku UUID context gate (precision up, recall held)', () => {
+  const UUID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+
+  it('does NOT flag a bare UUID in ordinary prose (precision guard)', () => {
+    const content = `The request id was ${UUID} in the trace.`;
+    const matches = scanForSecrets(content);
+    expect(matches.some((m) => m.patternId === 'heroku-api-key')).toBe(false);
+    // And nothing ELSE should fire on this benign prose either.
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does NOT flag a UUID used as a bead id in prose', () => {
+    const content = `Tracked in bead ${UUID} for the sprint retro.`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(false);
+  });
+
+  it('STILL flags a real Heroku key in a HEROKU_API_KEY= assignment (recall held)', () => {
+    const content = `HEROKU_API_KEY=${UUID}`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(true);
+  });
+
+  it('STILL flags a Heroku key referenced with heroku / api key words (recall held)', () => {
+    const content = `Rotate the Heroku API key ${UUID} after the incident.`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(true);
+  });
+
+  it('flags a Heroku key split across a newline when context is present (collapse pass)', () => {
+    // The newline-collapsed pre-pass must also honour the context gate: with a
+    // key-context word present, the UUID (even reassembled) is a real hit.
+    const content = `HEROKU_API_KEY set to\n${UUID}\nin the dyno config`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(true);
+  });
+
+  it('does NOT flag a UUID split across a newline with NO key-context', () => {
+    const content = `trace segment one\n${UUID}\nsegment two ends here`;
+    expect(scanForSecrets(content).some((m) => m.patternId === 'heroku-api-key')).toBe(false);
+  });
+});

--- a/packages/claude-runtime/src/secrets/patterns.ts
+++ b/packages/claude-runtime/src/secrets/patterns.ts
@@ -78,7 +78,24 @@ export const SECRET_PATTERNS: SecretPattern[] = [
     id: 'heroku-api-key',
     name: 'Heroku API Key',
     regex: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
-    description: 'Heroku API key (UUID format)',
+    description: 'Heroku API key (UUID format), only in key-context',
+    // A Heroku API key is UUID-shaped, but so is a request id, a trace id, or a
+    // bead id in ordinary prose. Firing on any bare UUID over-blocks benign
+    // memories (the e06.3 eval's `neg-uuid-in-prose-01` false positive dragged
+    // secret-scanner + content-classifier precision below 1.0). Gate the rule
+    // behind key-context: only flag a UUID as a credential when a `heroku` /
+    // `api` / `key` / `token` keyword, or an assignment/secret env var, is
+    // present in the same scan window. A REAL Heroku key still fires (it is set
+    // via `HEROKU_API_KEY=` or referenced with those words); a naked UUID in
+    // prose does not. Precision up, recall held (bead compile-then-govern-e06.15).
+    //
+    // Keyword boundaries are separator-based `(?:^|[^a-z0-9])…(?:[^a-z0-9]|$)`
+    // rather than `\b`, so an underscored env-var token (`HEROKU_API_KEY`, where
+    // `\bkey\b` would fail because `_` is a word char) still satisfies the gate.
+    // The final alternative matches an env-var-style assignment (`FOO=` / `FOO:`).
+    // Linear-time (no nested quantifiers) — ReDoS-safe.
+    requiresContext:
+      /(?:^|[^a-z0-9])(?:heroku|api[-_ ]?key|api|key|token|secret|credential|bearer)(?:[^a-z0-9]|$)|[A-Za-z][A-Za-z0-9_]*\s*[:=]/i,
   },
   {
     id: 'mysql-connection-string',
@@ -113,5 +130,33 @@ export const PII_PATTERNS: SecretPattern[] = [
     name: 'SSN-like Pattern',
     regex: /\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b/,
     description: 'Social Security Number pattern (XXX-XX-XXXX)',
+  },
+  // The three patterns below converge this classifier's PII vocabulary UP to the
+  // repository-boundary disclosure filter's PII_PATTERN
+  // (@qmd-team-intent-kb/common). The boundary filter caught SSN keyword, DOB,
+  // and background-check terms; classifyContent did not, so a DOB-only leak
+  // passed the policy pipeline (which gates on classifyContent) and was caught
+  // only at the write boundary — the two vocabularies had drifted, and the
+  // classifier was the weaker one (the e06.3 eval's `pii-inline-dob-01`
+  // documented gap). Adding these TIGHTENS detection (the safe direction) so the
+  // policy pipeline rejects DOB / background-check / SSN-keyword PII pre-boundary
+  // too. Bounded character classes only — linear time, no ReDoS surface.
+  {
+    id: 'ssn-keyword',
+    name: 'SSN Keyword',
+    regex: /\bSSN\b|social security (?:number|no)/i,
+    description: 'Social Security Number referenced by keyword (SSN / social security number)',
+  },
+  {
+    id: 'date-of-birth',
+    name: 'Date of Birth',
+    regex: /date of birth|\bDOB\b\s*[:=]/i,
+    description: 'Date-of-birth disclosure (date of birth / DOB: / DOB=)',
+  },
+  {
+    id: 'background-check',
+    name: 'Background Check Data',
+    regex: /background[- ]check (?:result|report|passed|failed)/i,
+    description: 'Background-check result/report disclosure',
   },
 ];

--- a/packages/claude-runtime/src/secrets/redactor.ts
+++ b/packages/claude-runtime/src/secrets/redactor.ts
@@ -8,6 +8,15 @@ export function redactSecrets(
 ): string {
   let result = content;
   for (const pattern of patterns) {
+    // Honor a pattern's context gate so the redactor stays consistent with
+    // scanForSecrets (bead compile-then-govern-e06.15): a context-gated pattern
+    // (e.g. heroku-api-key, a bare-UUID regex) only redacts when the required
+    // key-context is present in the content — otherwise a benign UUID in prose
+    // would be needlessly redacted, disagreeing with the scanner that no longer
+    // flags it. Over-redaction is the safe direction, but the two must agree.
+    if (pattern.requiresContext && !pattern.requiresContext.test(result)) {
+      continue;
+    }
     result = result.replace(
       new RegExp(pattern.regex.source, pattern.regex.flags + 'g'),
       `[REDACTED:${pattern.id}]`,

--- a/packages/claude-runtime/src/secrets/secret-scanner.ts
+++ b/packages/claude-runtime/src/secrets/secret-scanner.ts
@@ -35,6 +35,39 @@ const HEX_CANDIDATE_RE = /[A-Fa-f0-9]{24,}/g;
  * `line`/`column` are relative to `originText` (the caller supplies how to map
  * a hit back to a source location — best-effort for the derived views).
  */
+/**
+ * Run one pattern against `text` and return its first match, honoring the
+ * pattern's optional context gate. Centralises two invariants for every scan
+ * pass (per-line, collapsed, decoded):
+ *
+ *   1. Determinism — a global/sticky regex carries `lastIndex` across `.exec()`
+ *      calls, which would make matching nondeterministic across invocations, so
+ *      reset it (and the context regex) before use.
+ *   2. Context gate — when `pattern.requiresContext` is set, the value matching
+ *      is not sufficient: the SAME scan window must also satisfy the context
+ *      regex, else the hit is suppressed. This lets an ambiguous value (a bare
+ *      UUID) only count as a credential when key-context is nearby, raising
+ *      precision without weakening any context-free rule.
+ *
+ * Returns the RegExpExecArray for a counted hit, or `null` when the pattern does
+ * not match or its context gate is not satisfied.
+ */
+function execWithContext(pattern: SecretPattern, text: string): RegExpExecArray | null {
+  if (pattern.regex.global || pattern.regex.sticky) {
+    pattern.regex.lastIndex = 0;
+  }
+  const match = pattern.regex.exec(text);
+  if (!match) return null;
+  if (pattern.requiresContext) {
+    if (pattern.requiresContext.global || pattern.requiresContext.sticky) {
+      pattern.requiresContext.lastIndex = 0;
+    }
+    // Suppress the hit unless the surrounding window also carries key-context.
+    if (!pattern.requiresContext.test(text)) return null;
+  }
+  return match;
+}
+
 function scanFlat(
   text: string,
   patterns: SecretPattern[],
@@ -43,13 +76,7 @@ function scanFlat(
   patternIdOverride?: (patternId: string) => string,
 ): void {
   for (const pattern of patterns) {
-    // A global/sticky regex carries `lastIndex` across `.exec()` calls, which
-    // would make matching nondeterministic across separate scan invocations.
-    // Reset it so scanFlat stays pure regardless of a custom pattern's flags.
-    if (pattern.regex.global || pattern.regex.sticky) {
-      pattern.regex.lastIndex = 0;
-    }
-    const match = pattern.regex.exec(text);
+    const match = execWithContext(pattern, text);
     if (match) {
       const { line, column } = locate(match.index, match[0].length);
       matches.push({
@@ -248,17 +275,15 @@ export function scanForSecrets(
   const matches: SecretMatch[] = [];
   const lines = content.split('\n');
 
-  // Pass 1 — the original per-line scan (UNCHANGED; the split/encoded passes are
-  // additive backstops layered on top, never a replacement).
+  // Pass 1 — the original per-line scan (behaviour unchanged for context-free
+  // patterns; the split/encoded passes are additive backstops layered on top,
+  // never a replacement). `execWithContext` centralises the determinism reset
+  // AND the optional per-pattern context gate — a context-gated pattern (e.g.
+  // heroku-api-key) only counts when key-context is present on the SAME line.
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx]!;
     for (const pattern of patterns) {
-      // Same determinism guard as scanFlat: a global/sticky custom pattern
-      // would otherwise carry `lastIndex` across lines and skip matches.
-      if (pattern.regex.global || pattern.regex.sticky) {
-        pattern.regex.lastIndex = 0;
-      }
-      const match = pattern.regex.exec(line);
+      const match = execWithContext(pattern, line);
       if (match) {
         matches.push({
           patternId: pattern.id,

--- a/packages/claude-runtime/src/secrets/secret-scanner.ts
+++ b/packages/claude-runtime/src/secrets/secret-scanner.ts
@@ -44,15 +44,28 @@ const HEX_CANDIDATE_RE = /[A-Fa-f0-9]{24,}/g;
  *      calls, which would make matching nondeterministic across invocations, so
  *      reset it (and the context regex) before use.
  *   2. Context gate — when `pattern.requiresContext` is set, the value matching
- *      is not sufficient: the SAME scan window must also satisfy the context
- *      regex, else the hit is suppressed. This lets an ambiguous value (a bare
- *      UUID) only count as a credential when key-context is nearby, raising
- *      precision without weakening any context-free rule.
+ *      is not sufficient: a context window must ALSO satisfy the context regex,
+ *      else the hit is suppressed. This lets an ambiguous value (a bare UUID)
+ *      only count as a credential when key-context is nearby, raising precision
+ *      without weakening any context-free rule.
+ *
+ * The context window is `contextText` when supplied, else `text`. This matters
+ * for the decode-and-rescan pass: the DECODED blob (`text`) is just the raw
+ * value (e.g. a bare UUID) with no surrounding keywords, so the context gate
+ * must be evaluated against the ORIGINAL content the blob came from
+ * (`contextText`) — otherwise a real base64/hex-wrapped Heroku key surrounded by
+ * `heroku` / `api key` context would be silently missed (Gemini finding, e06.15).
+ * For the per-line and collapsed passes the value and its context live in the
+ * same string, so `contextText` is omitted and the window is `text` itself.
  *
  * Returns the RegExpExecArray for a counted hit, or `null` when the pattern does
  * not match or its context gate is not satisfied.
  */
-function execWithContext(pattern: SecretPattern, text: string): RegExpExecArray | null {
+function execWithContext(
+  pattern: SecretPattern,
+  text: string,
+  contextText?: string,
+): RegExpExecArray | null {
   if (pattern.regex.global || pattern.regex.sticky) {
     pattern.regex.lastIndex = 0;
   }
@@ -62,8 +75,11 @@ function execWithContext(pattern: SecretPattern, text: string): RegExpExecArray 
     if (pattern.requiresContext.global || pattern.requiresContext.sticky) {
       pattern.requiresContext.lastIndex = 0;
     }
-    // Suppress the hit unless the surrounding window also carries key-context.
-    if (!pattern.requiresContext.test(text)) return null;
+    // Evaluate the gate against the context window (the original content for a
+    // decoded blob; the text itself otherwise). Suppress unless it carries
+    // key-context.
+    const window = contextText ?? text;
+    if (!pattern.requiresContext.test(window)) return null;
   }
   return match;
 }
@@ -74,9 +90,13 @@ function scanFlat(
   matches: SecretMatch[],
   locate: (matchIndex: number, matchLength: number) => { line: number; column: number },
   patternIdOverride?: (patternId: string) => string,
+  contextText?: string,
 ): void {
   for (const pattern of patterns) {
-    const match = execWithContext(pattern, text);
+    // `contextText` (when supplied) is the window a context-gated pattern's gate
+    // is evaluated against — used by the decode pass so a wrapped value is gated
+    // on the ORIGINAL content, not just the context-free decoded blob.
+    const match = execWithContext(pattern, text, contextText);
     if (match) {
       const { line, column } = locate(match.index, match[0].length);
       matches.push({
@@ -179,6 +199,11 @@ function scanEncodedWrapped(
         const wrappedId = `${prefix}:${patternId}`;
         return wrappedId;
       },
+      // The decoded blob is just the raw value; a context-gated pattern must be
+      // evaluated against the ORIGINAL content (where `heroku` / `api key`
+      // keywords live), else a real wrapped Heroku key is silently missed
+      // (Gemini finding, e06.15). Value regex still runs on `decoded`.
+      content,
     );
     // Dedup guard: track the wrapped prefix so the same blob is not re-scanned.
     seenWrapped.add(raw);

--- a/packages/claude-runtime/src/types.ts
+++ b/packages/claude-runtime/src/types.ts
@@ -31,6 +31,19 @@ export interface SecretPattern {
   name: string;
   regex: RegExp;
   description: string;
+  /**
+   * Optional context gate. When present, `regex` matching a value is NOT enough:
+   * the SAME scan window (the line / collapsed view / decoded blob the value was
+   * found in) must ALSO match `requiresContext` for the hit to count. Used to
+   * disambiguate a structurally-ambiguous value (e.g. a bare UUID, which is a
+   * Heroku API key only when a `heroku` / `api` / `key` / `token` keyword or an
+   * assignment is nearby) so the scanner does not over-flag ordinary prose.
+   *
+   * This RAISES precision without lowering recall for the specific pattern: a
+   * real key in a key-context still fires; a bare id in prose does not. It never
+   * relaxes any OTHER pattern — every context-free rule keeps firing unchanged.
+   */
+  requiresContext?: RegExp;
 }
 
 /** A match found by the secret scanner */

--- a/packages/eval-surface/src/__tests__/govern-decision.test.ts
+++ b/packages/eval-surface/src/__tests__/govern-decision.test.ts
@@ -52,21 +52,43 @@ describe('evaluateGovernDecision — shipped v1 set', () => {
     expect(boundary!.precision).toBe(1);
   });
 
-  it('the ONLY false positives are the documented UUID over-block (heroku-key regex)', () => {
-    // Real precision finding (see README §5): the `heroku-api-key` rule is a bare
-    // UUID regex, so a UUID in prose (neg-uuid-in-prose-01) is over-flagged by
-    // scanForSecrets / classifyContent, dragging those three checks below 1.0.
-    // This is surfaced, not hidden — but it must stay bounded to exactly that one
-    // benign case (FP ≤ 1 per check), so a NEW over-block regression is caught.
+  it('has ZERO false positives on EVERY check — precision 1.0 (e06.15 UUID over-block closed)', () => {
+    // Before e06.15 the `heroku-api-key` rule was a bare UUID regex, so a UUID in
+    // prose (`neg-uuid-in-prose-01`) over-fired scanForSecrets / classifyContent
+    // / policy-pipeline (FP=1 each, precision ~0.92–0.94). The rule is now
+    // context-gated, so that benign case no longer fires: precision returns to
+    // 1.0 on all four checks. This is the PRECISION-UP assertion — any NEW
+    // over-block regression (a benign case firing a check) flips it.
     const rep = report(evaluateGovernDecision());
     for (const m of rep.perCheck) {
-      expect(m.falsePositives).toBeLessThanOrEqual(1);
+      expect(m.falsePositives).toBe(0);
+      expect(m.precision).toBe(1);
     }
-    // The three content checks lose precision only via that single case.
-    const contentChecks = rep.perCheck.filter((m) => m.check !== 'boundary-disclosure');
-    for (const m of contentChecks) {
-      expect(m.precision).toBeGreaterThan(0.85);
-    }
+  });
+
+  it('holds recall on the real Heroku key in key-context (context gate did not drop detection)', () => {
+    // The recall-hold counterpart to the precision fix: `sec-inline-heroku-01`
+    // (a real Heroku key in `HEROKU_API_KEY=` context) must STILL be caught by
+    // the in-content checks. If the context gate over-suppressed, this case would
+    // become an undocumented FN and flip the eval red.
+    const rep = report(evaluateGovernDecision());
+    const heroFn = rep.falseNegatives.filter(
+      (f) => f.caseId === 'sec-inline-heroku-01' && f.check !== 'boundary-disclosure',
+    );
+    expect(heroFn).toHaveLength(0);
+  });
+
+  it('catches the DOB-only PII leak on the classifier + policy pipeline (converged vocab)', () => {
+    // Part 2 of e06.15: claude-runtime's PII vocab is converged UP to the
+    // boundary filter's, so `pii-inline-dob-01` is no longer a documented miss on
+    // policy-pipeline / content-classifier — it is caught (a TP), not an FN.
+    const rep = report(evaluateGovernDecision());
+    const dobFn = rep.falseNegatives.filter(
+      (f) =>
+        f.caseId === 'pii-inline-dob-01' &&
+        (f.check === 'policy-pipeline' || f.check === 'content-classifier'),
+    );
+    expect(dobFn).toHaveLength(0);
   });
 
   it('catches inline secrets on the line-based secret scanner (recall > 0)', () => {

--- a/packages/eval-surface/src/govern-decision/dataset/v1/README.md
+++ b/packages/eval-surface/src/govern-decision/dataset/v1/README.md
@@ -1,8 +1,9 @@
 # govern-decision adversarial labeled set — v1
 
-**Version:** `1.1.0` · **Cases:** 32 (22 positive · 10 negative) ·
+**Version:** `1.2.0` · **Cases:** 33 (23 positive · 10 negative) ·
 **Bead:** `compile-then-govern-e06.3` (set) / `compile-then-govern-e06.14`
-(v1.1.0 relabel) · **Risk:** `010-AT-RISK` R5 / R10 ·
+(v1.1.0 relabel) / `compile-then-govern-e06.15` (v1.2.0 precision fix) ·
+**Risk:** `010-AT-RISK` R5 / R10 ·
 **Umbrella:** `intent-solutions-io/governed-second-brain#27`
 
 This is the versioned, labeled adversarial set that measures the **efficacy** of
@@ -55,31 +56,35 @@ label drifts (an undocumented false-negative). So the dataset and the code
 cannot silently disagree: a relabel that hides a real miss is caught by the CI
 gate, and a code regression that breaks a real catch is caught the same way.
 
-## Measured results (v1.1.0, e06.14 — after the split/base64 fix)
+## Measured results (v1.2.0, e06.15 — after the UUID precision + PII-vocab fix)
 
-Reporting score = mean per-check F1 = **0.8188** (was 0.7333 at v1.0.0). Gate =
+Reporting score = mean per-check F1 = **0.8526** (was 0.8188 at v1.1.0). Gate =
 **zero undocumented false-negatives** → PASS.
 
-| check                 | precision  | recall (v1.0.0 → v1.1.0) | F1     | TP  | FP  | FN  | TN  |
-| --------------------- | ---------- | ------------------------ | ------ | --- | --- | --- | --- |
-| `policy-pipeline`     | 0.9333     | 0.5789 → **0.7368**      | 0.8235 | 14  | 1   | 5   | 9   |
-| `secret-scanner`      | 0.9231     | 0.5625 → **0.7500**      | 0.8276 | 12  | 1   | 4   | 9   |
-| `content-classifier`  | 0.9444     | 0.6364 → **0.7727**      | 0.8500 | 17  | 1   | 5   | 9   |
-| `boundary-disclosure` | **1.0000** | 0.6316 (unchanged)       | 0.7742 | 12  | 0   | 7   | 10  |
+| check                 | precision (v1.1.0 → v1.2.0) | recall (v1.1.0 → v1.2.0) | F1     | TP  | FP  | FN  | TN  |
+| --------------------- | --------------------------- | ------------------------ | ------ | --- | --- | --- | --- |
+| `policy-pipeline`     | 0.9333 → **1.0000**         | 0.7368 → **0.8000**      | 0.8889 | 16  | 0   | 4   | 10  |
+| `secret-scanner`      | 0.9231 → **1.0000**         | 0.7500 → **0.7647**      | 0.8667 | 13  | 0   | 4   | 10  |
+| `content-classifier`  | 0.9444 → **1.0000**         | 0.7727 → **0.8261**      | 0.9048 | 19  | 0   | 4   | 10  |
+| `boundary-disclosure` | **1.0000** (held)           | 0.6316 → 0.6000          | 0.7500 | 12  | 0   | 8   | 10  |
 
-The **secret-scanner recall rose 0.56 → 0.75** because the two evasions that
-defeated the line-by-line scan — a key split across a newline, and a
-base64/hex-wrapped token — are now closed by a newline-collapsed pre-pass and a
-bounded decode-and-rescan in `scanForSecrets` (see gaps 1 & 2 below, now
-**CLOSED**). The cascade lifts the policy-pipeline and content-classifier too
-(both consume `scanForSecrets` / `classifyContent`). Precision held (no new
-false positives — a benign base64 data-URI image is NOT flagged, guarded by a
-printable-decode check). The remaining ~0.63–0.77 recall is the point of the
-eval, not a bug: the still-missed positives are the metadata/tenant-spoof and
-boundary-vocabulary gaps documented below. The scoping rule is that a check only
-counts toward a case's recall when the case names it in `expectCaughtBy` or
-`knownFalseNegativeOf` — so e.g. the secret-scanner is not penalised for
-"missing" an SSN (SSNs are PII, not secrets).
+**Precision rose to 1.0 on all three in-content checks** because the
+`heroku-api-key` rule — a bare UUID regex that flagged any UUID in prose as a
+credential (`neg-uuid-in-prose-01`, the single false positive at v1.1.0) — is now
+**context-gated** (gap 5 below, now **CLOSED**): a UUID counts as a Heroku key
+only when key-context (`heroku` / `api key` / `token` / an assignment) is present.
+**Recall held / rose**: a new `sec-inline-heroku-01` positive (a real Heroku key
+in `HEROKU_API_KEY=` context) proves the gate did not drop real-key detection,
+and the DOB-only leak (`pii-inline-dob-01`) is now caught by policy-pipeline +
+content-classifier after the PII-vocabulary convergence (gap 3, DOB line, now
+**CLOSED**). The `boundary-disclosure` raw recall dips only because two new
+positives (`sec-inline-heroku-01`) sit on its pre-existing "no Heroku/UUID/
+generic-assign rule" documented gap — not a regression (its precision stays 1.0).
+The remaining recall is the point of the eval, not a bug: the still-missed
+positives are the metadata/tenant-spoof and boundary-vocabulary gaps documented
+below. The scoping rule is that a check only counts toward a case's recall when
+the case names it in `expectCaughtBy` or `knownFalseNegativeOf` — so e.g. the
+secret-scanner is not penalised for "missing" an SSN (SSNs are PII, not secrets).
 
 ## Documented gaps this set proves (real findings — follow-up bead candidates)
 
@@ -109,10 +114,14 @@ was fixed by weakening a rule.**
    - Boundary filter misses: DB connection strings (`sec-inline-connstr-01`),
      generic `KEY=value` env assignments (`sec-inline-envassign-01`), and
      hex-encoded keys (`sec-hex-aws-01`) — all caught by the line scanner.
-   - The claude-runtime classifier misses **DOB** (`pii-inline-dob-01`): its PII
-     set is EMAIL / PHONE / SSN only, while the boundary filter's PII pattern
-     includes `date of birth` / `DOB:`. So a DOB-only leak passes the policy
-     pipeline but is caught at the repository boundary.
+   - The claude-runtime classifier missed **DOB** (`pii-inline-dob-01`) — its PII
+     set was EMAIL / PHONE / SSN only, while the boundary filter's PII pattern
+     includes `date of birth` / `DOB:`. **CLOSED (e06.15):** the classifier's PII
+     vocabulary is converged UP to the boundary filter's (added `date-of-birth`,
+     `ssn-keyword`, `background-check`), so a DOB-only leak is now caught by
+     policy-pipeline + content-classifier too, not only at the repository
+     boundary. (The DB-connstr / generic-assign / hex-key line-scanner-only cases
+     above are still boundary-filter misses — a separate convergence follow-up.)
    - The boundary filter misses **email** (`pii-inline-email-01`) by design
      (email is often legitimate); the classifier flags it.
      Fix candidate: converge the two vocabularies (or document the split as
@@ -127,12 +136,17 @@ was fixed by weakening a rule.**
    **R10 fix** in this PR extends the API intake early-check to that surface so
    it is caught at the boundary too (not just the deeper repository backstop).
 
-5. **PRECISION finding — the `heroku-api-key` rule is a bare UUID regex.** A
-   plain UUID in prose (`neg-uuid-in-prose-01`) is flagged as a credential by
-   `scanForSecrets` / `classifyContent`, so those checks lose precision
-   (0.90 / 0.93) and the policy pipeline over-rejects a benign note. The
-   boundary filter (no UUID rule) stays at precision 1.0. Fix candidate: gate
-   the UUID rule behind a key-context keyword, or drop it.
+5. **PRECISION finding — the `heroku-api-key` rule was a bare UUID regex —
+   CLOSED (e06.15).** A plain UUID in prose (`neg-uuid-in-prose-01`) was flagged
+   as a credential by `scanForSecrets` / `classifyContent`, so those checks lost
+   precision (0.92 / 0.94) and the policy pipeline over-rejected a benign note.
+   **Fixed:** the UUID rule is now gated behind key-context — a UUID counts as a
+   Heroku key only when a `heroku` / `api key` / `token` keyword or an
+   assignment (`HEROKU_API_KEY=`) is present in the same scan window (the new
+   `SecretPattern.requiresContext` field, enforced by `scanForSecrets`). Precision
+   returns to 1.0 on all three in-content checks; the recall-hold is proven by the
+   new `sec-inline-heroku-01` positive (a real key in key-context is still caught).
+   The gate weakens no other rule — every context-free pattern fires unchanged.
 
 ## Bumping the set
 

--- a/packages/eval-surface/src/govern-decision/dataset/v1/index.ts
+++ b/packages/eval-surface/src/govern-decision/dataset/v1/index.ts
@@ -27,6 +27,16 @@ import type { GovernCase } from '../../types.js';
 /**
  * Semantic version of THIS labeled set. Bump on any case add/remove/relabel.
  *
+ * 1.2.0 (e06.15 · umbrella #27) — the govern PRECISION LEAK the e06.3 eval
+ * surfaced is closed. (1) The `heroku-api-key` rule (a bare UUID regex) is now
+ * context-gated in claude-runtime, so `neg-uuid-in-prose-01` (a UUID in prose)
+ * no longer false-positives — secret-scanner / content-classifier /
+ * policy-pipeline precision returns to 1.0. A new `sec-inline-heroku-01`
+ * positive (a real Heroku key in `HEROKU_API_KEY=` context) proves the gate held
+ * recall — a real key is still caught. (2) claude-runtime's classifyContent PII
+ * vocabulary is converged UP to the boundary filter's, so `pii-inline-dob-01` (a
+ * DOB-only leak) is now caught by policy-pipeline + content-classifier too — it
+ * was `knownFalseNegativeOf` both.
  * 1.1.0 (e06.14 · umbrella #27) — the split-across-newline and base64-wrapped
  * secret evasions the e06.3 eval measured are now CLOSED in claude-runtime's
  * scanForSecrets (newline-collapsed pre-pass + bounded decode-and-rescan), so
@@ -37,7 +47,7 @@ import type { GovernCase } from '../../types.js';
  * miss on the split/base64 cases — a separate follow-up (converge the filters).
  * 1.0.0 — initial adversarial set (see README).
  */
-export const DATASET_VERSION = '1.1.0';
+export const DATASET_VERSION = '1.2.0';
 
 /* -------------------------------------------------------------------------- */
 /* Fixture material — realistic-shaped but non-live secrets.                   */
@@ -59,6 +69,9 @@ const JWT_SHAPE =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpEb2UifQ.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
 /** An SSN-shaped string. */
 const SSN_SHAPE = '123-45-6789';
+/** A UUID-shaped string. Heroku API keys are UUIDs; so are request/trace/bead
+ *  ids — the ambiguity the e06.15 context gate resolves. Random, not a live key. */
+const UUID_SHAPE = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
 
 /** base64 of the OpenAI-shaped key — the encoded-token evasion. */
 const OPENAI_B64 = Buffer.from(OPENAI_SHAPE, 'utf8').toString('base64');
@@ -165,6 +178,23 @@ export const GOVERN_CASES: readonly GovernCase[] = [
     expectCaughtBy: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
     knownFalseNegativeOf: ['boundary-disclosure'],
   },
+  {
+    id: 'sec-inline-heroku-01',
+    description: 'Real Heroku API key (UUID) in HEROKU_API_KEY= context (recall-hold probe)',
+    sensitiveClass: 'secret',
+    surface: 'inline',
+    // The RECALL-HOLD counterpart to the `neg-uuid-in-prose-01` precision probe.
+    // The heroku-api-key rule is now context-gated (e06.15): a bare UUID in prose
+    // is NOT flagged, but a UUID in a `HEROKU_API_KEY=` assignment (or with
+    // heroku/api-key/token words) STILL is. This case proves the gate did not
+    // silently drop real-key detection — the env-secret regex ALSO fires here,
+    // but the heroku rule firing in key-context is what the recall-hold asserts.
+    // The boundary filter's SECRET_PATTERNS have no Heroku/UUID rule, so it is a
+    // documented miss there — the same shape as the other generic-assign cases.
+    candidate: { content: `Set HEROKU_API_KEY=${UUID_SHAPE} in the dyno config.` },
+    expectCaughtBy: ['policy-pipeline', 'secret-scanner', 'content-classifier'],
+    knownFalseNegativeOf: ['boundary-disclosure'],
+  },
 
   /* --------- SECRETS · split across two lines (the CISO's fear) ------------ */
   {
@@ -263,15 +293,15 @@ export const GOVERN_CASES: readonly GovernCase[] = [
     sensitiveClass: 'pii',
     surface: 'inline',
     candidate: { content: 'HR note — DOB: 1984-07-02, hired last spring.' },
-    // DOCUMENTED GAP (real finding, follow-up bead candidate): the boundary
-    // disclosure filter's PII_PATTERN includes `date of birth` / `DOB:`, but
-    // claude-runtime's classifyContent PII set is EMAIL / PHONE / SSN only — no
-    // DOB — so a DOB-only leak passes the policy pipeline (which gates on
-    // classifyContent) and is caught only at the repository boundary. The two
-    // PII vocabularies have drifted; the classifier is the weaker one. Surfaced
-    // here, not hidden by loosening a rule.
-    expectCaughtBy: ['boundary-disclosure'],
-    knownFalseNegativeOf: ['policy-pipeline', 'content-classifier'],
+    // CLOSED (e06.15): the previously-documented PII-vocabulary drift is fixed.
+    // claude-runtime's classifyContent PII set is now converged UP to the
+    // boundary filter's PII_PATTERN (added `date-of-birth`, `ssn-keyword`,
+    // `background-check`), so a DOB-only leak is now classified `confidential`
+    // and the policy pipeline REJECTS it pre-boundary — not caught only at the
+    // repository boundary. All three checks fire; was
+    // `knownFalseNegativeOf: ['policy-pipeline', 'content-classifier']`.
+    // Relabelled under DATASET_VERSION 1.2.0.
+    expectCaughtBy: ['policy-pipeline', 'content-classifier', 'boundary-disclosure'],
   },
   {
     id: 'pii-inline-email-01',
@@ -428,12 +458,15 @@ export const GOVERN_CASES: readonly GovernCase[] = [
     sensitiveClass: 'none',
     surface: 'benign',
     candidate: {
-      content: 'The request id was 3f2504e0-4f89-41d3-9a0c-0305e82c3301 in the trace.',
+      content: `The request id was ${UUID_SHAPE} in the trace.`,
     },
-    // NOTE: this is a deliberate PRECISION probe. The heroku-api-key rule is a
-    // bare UUID regex, so classify/secret-scanner treat any UUID as a secret.
-    // We expect NO check to fire; if one does it is a FALSE POSITIVE and drags
-    // that check's precision — surfaced, not hidden. (Documented in README.)
+    // PRECISION probe — NOW CLOSED (e06.15). The heroku-api-key rule was a bare
+    // UUID regex, so classify/secret-scanner over-flagged any UUID in prose as a
+    // credential (this case was the FALSE POSITIVE dragging secret-scanner /
+    // content-classifier / policy-pipeline precision below 1.0). The rule is now
+    // context-gated: a UUID counts as a Heroku key only with key-context nearby.
+    // This prose has none, so NO check fires — precision returns to 1.0. The
+    // recall-hold counterpart is `sec-inline-heroku-01` (same UUID, key-context).
     expectCaughtBy: [],
   },
   {


### PR DESCRIPTION
## What & why

The `e06.3` govern-decision eval surfaced a **precision leak** in the
deterministic policy pipeline (below the spool — no model calls in the fix).
This closes it in both parts, raising precision **without lowering recall** —
the hard constraint for a secret scanner.

### Part 1 — the `heroku-api-key` bare-UUID over-block (primary)

`heroku-api-key` was a bare UUID regex, so **any** UUID in ordinary prose (a
request id, a trace id, a bead id) was flagged as a live credential by
`scanForSecrets` / `classifyContent`, making the policy pipeline **over-REJECT a
benign memory**. The eval's `neg-uuid-in-prose-01` proves it (secret-scanner
0.92, content-classifier 0.94 — the boundary filter, with no UUID rule, stayed
1.0). This is a false-positive / over-block, not a leak.

**Fix — gate the UUID rule behind key-context, not drop it.** A new optional
`SecretPattern.requiresContext` field: a UUID counts as a Heroku key **only when**
a `heroku` / `api key` / `token` keyword or an assignment (`HEROKU_API_KEY=`) is
present in the same scan window. Enforced uniformly across all three scan passes
(per-line, newline-collapsed, base64/hex decode) via a single `execWithContext`
helper, and honored by `redactSecrets` so the redactor and scanner agree. Keyword
boundaries are separator-based (not `\b`) so an underscored env-var token
(`HEROKU_API_KEY`) still satisfies the gate. Linear-time / ReDoS-safe.

### Part 2 — PII vocabulary divergence (folded in)

`classifyContent`'s PII vocab (email / phone / SSN) was **narrower** than the
boundary filter's, so a **DOB-only** disclosure (`pii-inline-dob-01`) passed the
classifier and the policy pipeline that gates on it, caught only at the write
boundary. **Fix — converge the classifier PII vocab UP** to the boundary filter's
set: add `date-of-birth`, `ssn-keyword`, `background-check`. Additive / tightening
only — the safe direction.

## Measured eval (dataset `v1.1.0` → `v1.2.0`, `govern:ci`)

| check | precision (before → after) | recall (before → after) |
|---|---|---|
| `policy-pipeline` | 0.9333 → **1.0000** | 0.7368 → **0.8000** |
| `secret-scanner` | 0.9231 → **1.0000** | 0.7500 → **0.7647** |
| `content-classifier` | 0.9444 → **1.0000** | 0.7727 → **0.8261** |
| `boundary-disclosure` | 1.0000 → **1.0000** (held) | 0.6316 → 0.6000 |

- **Precision up to 1.0** on all three in-content checks (the UUID over-block is
  gone). `boundary-disclosure` stayed 1.0.
- **Recall held / rose.** `neg-uuid-in-prose-01` now PASSES (not flagged). A **new
  `sec-inline-heroku-01` positive** (a real Heroku key in `HEROKU_API_KEY=`
  context) proves the gate did not drop real-key detection — it is still caught.
  DOB is now caught by policy-pipeline + content-classifier. The `boundary` raw
  recall dips only because the two new positives sit on its pre-existing
  "no Heroku/UUID rule" documented gap — **not a regression** (precision 1.0,
  zero undocumented false-negatives, gate green).

## Gates

Full suite (1942 tests, 163 files) · typecheck · lint · prettier · depcruise ·
crap · `harness-pin` · `provenance:ci` · `govern:ci` — all green. No app code, no
model calls; the deterministic-below-the-spool invariant is preserved.

Beads: compile-then-govern-e06.15
Refs intent-solutions-io/governed-second-brain#27

- Jeremy Longshore
intentsolutions.io
