### PR TITLE
feat(api): accept pre-hashed scrypt tokens at rest (E1 / jfv.5.1)

### DIFF
--- a/apps/api/src/__tests__/token-registry.test.ts
+++ b/apps/api/src/__tests__/token-registry.test.ts
@@ -84,6 +84,50 @@ describe('InMemoryTokenRegistry', () => {
     expect(reg.resolve('plaintext-leak-canary')).toEqual({ actor: 'a', role: 'admin' });
   });
 
+  // ---- pre-hashed at-rest tokens (E1 — no plaintext bearer secret on disk) --
+
+  it('accepts an already-hashed `scrypt$salt$hash` token and resolves the plaintext', () => {
+    // The on-disk record stores hashToken(secret) — NOT the secret. The holder
+    // still presents the plaintext; it verifies against the stored salt+hash.
+    const stored = hashToken('member-secret');
+    expect(stored).not.toContain('member-secret'); // nothing plaintext at rest
+    const reg = new InMemoryTokenRegistry([{ token: stored, actor: 'ezekiel', role: 'member' }]);
+    expect(reg.resolve('member-secret')).toEqual({ actor: 'ezekiel', role: 'member' });
+    expect(reg.resolve('wrong-secret')).toBeUndefined();
+    expect(reg.resolve(stored)).toBeUndefined(); // the hash itself is not a valid bearer token
+  });
+
+  it('mixes pre-hashed and plaintext records in one registry (both resolve)', () => {
+    const reg = new InMemoryTokenRegistry([
+      { token: hashToken('hashed-secret'), actor: 'tim', role: 'member' },
+      { token: 'plain-secret', actor: 'jeremy', role: 'admin' },
+    ]);
+    expect(reg.resolve('hashed-secret')).toEqual({ actor: 'tim', role: 'member' });
+    expect(reg.resolve('plain-secret')).toEqual({ actor: 'jeremy', role: 'admin' });
+  });
+
+  it('preserves tenant + expiry on a pre-hashed record', () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const reg = new InMemoryTokenRegistry([
+      {
+        token: hashToken('scoped-secret'),
+        actor: 'a',
+        role: 'admin',
+        tenants: ['t1'],
+        expiresAt: future,
+      },
+    ]);
+    expect(reg.resolve('scoped-secret')).toEqual({ actor: 'a', role: 'admin', tenants: ['t1'] });
+  });
+
+  it('treats a plaintext token that merely looks like `scrypt$...` as plaintext (fail-safe)', () => {
+    // Non-hex segments make it an invalid stored hash, so it is hashed as a
+    // plaintext secret rather than mistaken for a valid at-rest hash.
+    const looksHashed = 'scrypt$not-hex$also-not-hex';
+    const reg = new InMemoryTokenRegistry([{ token: looksHashed, actor: 'a', role: 'admin' }]);
+    expect(reg.resolve(looksHashed)).toEqual({ actor: 'a', role: 'admin' });
+  });
+
   // ---- expiry (EPIC 0, compile-then-govern-c5k) --------------------------
 
   it('resolves a not-yet-expired token', () => {

--- a/apps/api/src/auth/token-registry.ts
+++ b/apps/api/src/auth/token-registry.ts
@@ -25,11 +25,15 @@ export interface TokenIdentity {
 /**
  * A token and the identity it grants.
  *
- * The on-disk `tokens.json` carries the bearer secret in the `token` field for
- * operator convenience (you write the secret you hand out). At load time the
- * registry **derives a salted scrypt hash and discards the plaintext** — see
- * {@link hashToken} / {@link InMemoryTokenRegistry}. The plaintext never lives
- * in process memory past construction, so a heap dump cannot leak live tokens.
+ * The on-disk `tokens.json` `token` field carries EITHER a plaintext bearer
+ * secret (operator convenience — you write the secret you hand out) OR an
+ * already-salted `scrypt$salt$hash` produced by {@link hashToken}. The
+ * pre-hashed form is the at-rest default: it keeps **no plaintext bearer secret
+ * on disk** (nor in any backup of `~/.teamkb`). Either way, at load the registry
+ * ends up holding only a salted scrypt hash — a plaintext value is hashed and
+ * discarded, a pre-hashed value is used verbatim — so the plaintext never lives
+ * in process memory past construction and a heap dump cannot leak live tokens.
+ * See {@link InMemoryTokenRegistry}.
  */
 export interface TokenRecord extends TokenIdentity {
   token: string;
@@ -123,14 +127,21 @@ export class InMemoryTokenRegistry implements TokenRegistry {
   private readonly records: HashedRecord[];
 
   /**
-   * @param records  Plaintext token records (the on-disk shape). The constructor
-   *                 hashes each secret and discards the plaintext immediately.
+   * @param records  Token records (the on-disk shape). Each `token` is either a
+   *                 plaintext bearer secret or an already-salted
+   *                 `scrypt$salt$hash`. The constructor keeps only a salted hash
+   *                 and discards any plaintext immediately.
    */
   constructor(records: readonly TokenRecord[]) {
     this.records = records.map((rec) => {
-      // hashToken always emits a well-formed `scrypt$salt$hash`, so parse never
-      // fails here; assert non-undefined to keep the field types narrow.
-      const parsed = parseStoredHash(hashToken(rec.token));
+      // A `token` may already be a salted `scrypt$salt$hash` (the at-rest form,
+      // so no plaintext bearer secret sits on disk) — use it verbatim so the
+      // stored salt verifies the presented plaintext. Otherwise treat it as a
+      // plaintext secret and hash it now. `??` short-circuits, so a pre-hashed
+      // record never pays a second scrypt. A plaintext value that merely looks
+      // like `scrypt$...` (non-hex segments) fails parseStoredHash and falls
+      // through to hashToken — fail-safe, never treated as a valid stored hash.
+      const parsed = parseStoredHash(rec.token) ?? parseStoredHash(hashToken(rec.token));
       if (parsed === undefined) {
         throw new Error('internal: hashToken produced an unparseable hash');
       }


### PR DESCRIPTION
## What
`InMemoryTokenRegistry` now accepts an already-salted `scrypt$salt$hash` in a token record's `token` field and uses it verbatim, so `~/.teamkb/tokens.json` can store **hashes, not plaintext bearer secrets**. Plaintext records still work (operator convenience); a plaintext that merely looks like `scrypt$…` with non-hex segments fails `parseStoredHash` and is safely hashed as plaintext. `??` short-circuits so a pre-hashed record never pays a second scrypt.

## Why
The registry hashed *in memory* but re-hashed whatever was on disk, forcing plaintext at rest — every backup of `~/.teamkb` (borg / daily `teamkb-backup.sh` / R2) leaked live tokens. This closes that at-rest gap and unblocks minting hashed per-user tokens for all six leaders.

## Tests
+4 registry tests (pre-hashed resolves plaintext + rejects wrong/the-hash-itself; mixed pre-hashed+plaintext; tenant/expiry preserved; scrypt-lookalike fail-safe). **32/32** registry, **288/288** api, typecheck clean.

## Paired operational step (not in this diff)
Re-seed `~/.teamkb/tokens.json` to 6 hashed records (existing 4 hashed in place — their tokens keep working — plus ezekiel/tim), restart the service, verify. Tracked in the issue.

Refs #226

- Jeremy Longshore
intentsolutions.io