### PR TITLE
feat(deploy): immutable tag-pinned release deploy for the brain API (R6)

### DIFF
--- a/000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md
+++ b/000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md
@@ -1,0 +1,152 @@
+# Runbook — immutable, versioned deploys for the governed brain API
+
+| Field         | Value                                                                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Code**      | `041-OD-OPSM`                                                                                                                                 |
+| **Type**      | Operations runbook                                                                                                                            |
+| **Date**      | 2026-07-09                                                                                                                                    |
+| **Service**   | `teamkb-brain-api.service` (systemd **--user**, on the tailnet team-server)                                                                   |
+| **Bead**      | `compile-then-govern-jfv.6.6` (R6 / Gate-0 from the 6-engineer review)                                                                        |
+| **Floor**     | tag **`v0.8.0`** @ `a2143be` — first tag containing E1 pre-hashed tokens                                                                      |
+| **Companion** | `040-OD-OPSM` (the service, tokens, tailnet bind, client team-mode) — still valid; **§2 "after a code change" is superseded by this runbook** |
+
+## Why this exists (the R6 problem)
+
+Before R6 the live API ran **from Jeremy's mutable working checkout**:
+
+```ini
+WorkingDirectory=/home/jeremy/000-projects/qmd-team-intent-kb
+ExecStart=/usr/bin/node apps/api/dist/main.js
+```
+
+That is unsafe for a live service:
+
+1. Any `git checkout` / rebuild in that repo **mutates the running service's code**.
+2. A crash-restart can relaunch from a **torn or feature-branch `dist/`**.
+3. There is **no immutable rollback target** — the build that served Jun 25 – Jul 9 was overwritten
+   in place. Worse, rolling the working checkout back **past the release floor `a2143be` (E1)**
+   rebuilds the pre-E1 registry, which **double-hashes `~/.teamkb/tokens.json` and locks out all six
+   users** (the registry would scrypt-hash the already-`scrypt$…` strings a second time).
+
+The database is external (`~/.teamkb/teamkb.db`), so the fix is purely about the **code artifact**:
+serve from an **immutable, tag-pinned release directory** behind an atomic `current` symlink.
+
+## The layout
+
+```
+~/.local/opt/teamkb-api/
+├── current -> releases/v0.8.0          # atomic pointer; the unit's WorkingDirectory
+├── releases/
+│   └── v0.8.0/                         # self-contained: source + node_modules + dist (no .git)
+│       └── apps/api/dist/main.js       # what ExecStart runs (relative to WorkingDirectory)
+└── DEPLOYS.log                         # append-only: <utc> tag= sha= actor= note=
+```
+
+Each `releases/<tag>` is produced by `git archive <tag>` (no `.git`, immutable) + `pnpm install
+--frozen-lockfile` + `pnpm -r build`, built with **`/usr/bin/node`** so `better-sqlite3`'s native
+ABI matches the node the unit runs. Releases are **never rebuilt in place** — a new tag is a new
+directory, and rollback is a symlink flip.
+
+## The release floor — the ONE rule
+
+> **Never point `current` at a ref that does not contain `a2143be` (E1 pre-hashed tokens).**
+
+The deploy script enforces this (`git merge-base --is-ancestor a2143be <tag>` → hard abort) and
+re-checks it against the built artifact (`grep parseStoredHash …/dist/auth/token-registry.js`). The
+tag **`v0.8.0`** is the floor: it is the first tag that contains E1. Deploying anything below it
+double-hashes `~/.teamkb/tokens.json` and locks out every teammate.
+
+## Deploy
+
+```bash
+cd ~/000-projects/qmd-team-intent-kb
+scripts/deploy-brain-api.sh v0.8.0        # or any later tag that contains a2143be
+```
+
+What it does, in order (all `set -euo pipefail`, idempotent, safe):
+
+1. `git fetch --tags` in the source repo.
+2. **Floor check** — abort unless the tag contains `a2143be`.
+3. **Build** a fresh `releases/<tag>` (archive → `pnpm install` → `pnpm -r build`). If the dir already
+   exists and passes preflight, it is **reused** (re-running the same tag is a safe no-op re-point).
+4. **Lockout preflight** — `grep parseStoredHash …/dist/auth/token-registry.js`, else abort.
+5. **Smoke** — see below.
+6. **Flip** `current -> releases/<tag>`, then `systemctl --user daemon-reload && restart`.
+7. **Post-restart health gate** — if the new build is unhealthy it **auto-rolls back** the symlink,
+   restarts, and exits non-zero (the service is never left down).
+8. Append a line to `DEPLOYS.log` and **prune** to the newest 5 release dirs (never the live one).
+
+### What the smoke proves (and what it can't)
+
+Token records in `~/.teamkb/tokens.json` are **scrypt hashes** (E1). A hashed token can't be
+exercised without its plaintext, which only the holder has. So the deploy smoke proves the **auth
+gate and liveness**, not each token:
+
+- `GET /api/health` → **200** (service up, DB opened) — `/api/health` is auth-exempt by design.
+- unauthenticated `POST /api/search` → **401** (the bearer gate is on).
+- the same two checks again **after** the restart, on the new build.
+
+A real teammate's authed query returning `qmd://`-cited hits is the **final human confirmation** — do
+one after cutover (see `040-OD-OPSM` §6).
+
+## Rollback — seconds, no rebuild
+
+Any prior `releases/<tag>` is a complete, ready-to-run build. To roll back:
+
+```bash
+ln -sfn releases/<prior-tag> ~/.local/opt/teamkb-api/current
+systemctl --user daemon-reload
+systemctl --user restart teamkb-brain-api.service
+# smoke:
+HOST=$(systemctl --user show teamkb-brain-api.service -p Environment --value | tr ' ' '\n' | sed -n 's/^TEAMKB_API_HOST=//p')
+curl -s -o /dev/null -w 'health %{http_code}\n' "http://$HOST:3847/api/health"        # → 200
+```
+
+The deploy script does exactly this automatically if a post-restart smoke fails. **Constraint:** the
+rollback target must still contain the floor `a2143be` — every retained release does, because the
+floor guard blocks anything below it from ever becoming a release.
+
+## ONE-TIME cutover (operator — do this once)
+
+The release infra is **already staged** (`releases/v0.8.0` built + preflighted, `current` symlinked).
+The only remaining change is to repoint the unit's `WorkingDirectory` at the `current` symlink — a
+**one-line edit**; everything else in the unit (all `Environment=` lines, `ExecStart`, `Restart`,
+`[Install]`) stays **byte-for-byte identical**. `ExecStart` remains `/usr/bin/node apps/api/dist/main.js`
+because that path is relative to `WorkingDirectory`, which now resolves through `current`.
+
+```bash
+UNIT=~/.config/systemd/user/teamkb-brain-api.service
+
+# 1. Back up the current unit
+cp "$UNIT" "$UNIT.bak-$(date -u +%Y%m%d)"
+
+# 2. Repoint WorkingDirectory (only this line changes)
+#    from: WorkingDirectory=/home/jeremy/000-projects/qmd-team-intent-kb
+#    to:   WorkingDirectory=/home/jeremy/.local/opt/teamkb-api/current
+sed -i 's#^WorkingDirectory=.*#WorkingDirectory=/home/jeremy/.local/opt/teamkb-api/current#' "$UNIT"
+
+# 3. Apply + verify
+systemctl --user daemon-reload
+systemctl --user restart teamkb-brain-api.service
+systemctl --user show teamkb-brain-api.service -p WorkingDirectory   # → .../teamkb-api/current
+
+# 4. Smoke
+HOST=$(systemctl --user show teamkb-brain-api.service -p Environment --value | tr ' ' '\n' | sed -n 's/^TEAMKB_API_HOST=//p')
+curl -s -o /dev/null -w 'health %{http_code}\n' "http://$HOST:3847/api/health"                                   # → 200
+curl -s -o /dev/null -w 'unauth %{http_code}\n' -X POST "http://$HOST:3847/api/search" \
+  -H 'content-type: application/json' -d '{"query":"x"}'                                                          # → 401
+```
+
+After this one-time edit, **all future deploys are `scripts/deploy-brain-api.sh <tag>`** — the working
+checkout is never again the live service. To undo the cutover itself, restore the `.bak-…` unit,
+`daemon-reload`, restart.
+
+## Notes
+
+- **Host / bind / tokens** are unchanged — see `040-OD-OPSM`. This runbook only changes _where the
+  code artifact comes from_.
+- **Disk:** each `releases/<tag>` is ~1 GB (full workspace `node_modules`, mostly pnpm-store
+  hardlinks); the script keeps the newest 5.
+- **Env overrides** (defaults shown): `TEAMKB_SRC_REPO=$HOME/000-projects/qmd-team-intent-kb`,
+  `TEAMKB_API_OPT=$HOME/.local/opt/teamkb-api`, `TEAMKB_API_UNIT=teamkb-brain-api.service`,
+  `TEAMKB_API_NODE=/usr/bin/node`, `TEAMKB_KEEP=5`, `TEAMKB_FLOOR_SHA=a2143be`.

--- a/scripts/deploy-brain-api.sh
+++ b/scripts/deploy-brain-api.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# deploy-brain-api.sh — immutable, versioned deploy for the governed brain API.
+#
+# R6 / Gate-0 (6-engineer review). The live `teamkb-brain-api.service` must run
+# from an IMMUTABLE, tag-pinned release directory — never from a mutable working
+# checkout. This script deploys a git TAG into
+#   $TEAMKB_API_OPT/releases/<tag>/          (self-contained: source + node_modules + dist)
+# flips the atomic
+#   $TEAMKB_API_OPT/current -> releases/<tag>
+# symlink, and restarts the systemd --user unit whose WorkingDirectory is that
+# `current` symlink. Rollback is a symlink flip back to any prior release + a
+# restart (seconds, no rebuild).
+#
+# SAFETY CONTRACT
+#   * Never deploys a ref that does not contain the release floor (E1 pre-hashed
+#     tokens, default commit a2143be). A pre-E1 build double-hashes
+#     ~/.teamkb/tokens.json and LOCKS OUT ALL USERS — so this is a hard abort.
+#   * Never leaves the service down. If the post-restart smoke fails, it restores
+#     the previous release, restarts, and exits non-zero.
+#   * Never rebuilds a release dir that is already good — reuse is idempotent, so
+#     re-running with the same tag is a safe no-op re-point + restart.
+#
+# The per-token smoke NOTE: token records in ~/.teamkb/tokens.json are scrypt
+# hashes (E1). A hashed token cannot be exercised without the plaintext, which
+# only its holder has. So the deploy smoke proves the AUTH GATE and LIVENESS, not
+# each token: (1) GET /api/health -> 200 (service up, DB opened); (2) an
+# unauthenticated POST /api/search -> 401 (the bearer gate is on); (3) the same
+# two checks again after the restart on the new build. A real teammate's authed
+# query is the final human confirmation (see the runbook).
+#
+# Usage:
+#   scripts/deploy-brain-api.sh <tag>          # e.g. scripts/deploy-brain-api.sh v0.8.0
+#
+# Environment overrides (sane defaults; NO ~/.claude paths):
+#   TEAMKB_SRC_REPO   git repo to fetch/archive from   (default: $HOME/000-projects/qmd-team-intent-kb)
+#   TEAMKB_API_OPT    immutable release root           (default: $HOME/.local/opt/teamkb-api)
+#   TEAMKB_API_UNIT   systemd --user unit name         (default: teamkb-brain-api.service)
+#   TEAMKB_API_NODE   node binary; ABI must match unit (default: /usr/bin/node)
+#   TEAMKB_KEEP       release dirs to retain on prune  (default: 5)
+#   TEAMKB_FLOOR_SHA  floor commit that must be an      (default: a2143be)
+#                     ancestor of the tag (E1)
+#
+set -euo pipefail
+
+# --- config -----------------------------------------------------------------
+SRC="${TEAMKB_SRC_REPO:-$HOME/000-projects/qmd-team-intent-kb}"
+OPT="${TEAMKB_API_OPT:-$HOME/.local/opt/teamkb-api}"
+UNIT="${TEAMKB_API_UNIT:-teamkb-brain-api.service}"
+NODE="${TEAMKB_API_NODE:-/usr/bin/node}"
+KEEP="${TEAMKB_KEEP:-5}"
+FLOOR="${TEAMKB_FLOOR_SHA:-a2143be}"
+RELEASES="$OPT/releases"
+
+# --- state (used by the EXIT trap) ------------------------------------------
+TAG=""
+SHA=""
+PREV=""
+STAGING=""
+OLD_ASIDE=""
+FLIPPED=0
+DEPLOY_OK=0
+
+# --- helpers ----------------------------------------------------------------
+log()  { printf '%s  [deploy] %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
+die()  { log "ERROR: $*"; exit 1; }
+
+deploylog() {
+  printf '%s  tag=%s  sha=%s  actor=%s  note=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${TAG:-?}" "${SHA:-?}" "${USER:-$(id -un)}" "$*" \
+    >> "$OPT/DEPLOYS.log"
+}
+
+# Resolve the API base URL from the live unit's own Environment (no hardcoded IP).
+api_base() {
+  local envs host port
+  envs="$(systemctl --user show "$UNIT" --property=Environment --value 2>/dev/null || true)"
+  host="$(printf '%s' "$envs" | tr ' ' '\n' | sed -n 's/^TEAMKB_API_HOST=//p' | head -1)"
+  port="$(printf '%s' "$envs" | tr ' ' '\n' | sed -n 's/^TEAMKB_API_PORT=//p' | head -1)"
+  if [ -z "$host" ] && command -v tailscale >/dev/null 2>&1; then
+    host="$(tailscale ip -4 2>/dev/null | head -1)"
+  fi
+  [ -n "$port" ] || port="3847"
+  [ -n "$host" ] || return 1
+  printf 'http://%s:%s' "$host" "$port"
+}
+
+# Poll GET /api/health until 200 (service up) or timeout.
+health_ok() {
+  local base code
+  base="$(api_base)" || { log "cannot resolve API endpoint for health check"; return 1; }
+  for _ in $(seq 1 20); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "$base/api/health" 2>/dev/null || echo 000)"
+    [ "$code" = "200" ] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+# Full smoke: health 200 AND unauthenticated POST /api/search 401 (auth gate on).
+smoke_check() {
+  local base code
+  base="$(api_base)" || { log "smoke: cannot resolve API endpoint"; return 1; }
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$base/api/health" 2>/dev/null || echo 000)"
+  [ "$code" = "200" ] || { log "smoke: health expected 200, got $code ($base/api/health)"; return 1; }
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+          -X POST "$base/api/search" -H 'content-type: application/json' \
+          -d '{"query":"deploy-smoke"}' 2>/dev/null || echo 000)"
+  [ "$code" = "401" ] || { log "smoke: unauth POST /api/search expected 401, got $code (AUTH GATE OFF?!)"; return 1; }
+  log "smoke OK: health 200, unauth /api/search 401 ($base)"
+  return 0
+}
+
+# Lockout preflight: the built token-registry MUST accept pre-hashed scrypt tokens.
+lockout_preflight() {
+  local dir="$1"
+  grep -q parseStoredHash "$dir/apps/api/dist/auth/token-registry.js" 2>/dev/null \
+    || die "LOCKOUT PREFLIGHT FAILED: parseStoredHash absent in $dir — a pre-E1 build would double-hash ~/.teamkb/tokens.json and lock out ALL users. Refusing to deploy."
+}
+
+rollback() {
+  log "rolling back the current symlink"
+  if [ -n "$PREV" ]; then
+    ln -sfn "$PREV" "$OPT/current" || true
+    log "current -> $PREV (restored)"
+  else
+    log "no previous release recorded — cannot restore symlink; restarting current as-is"
+  fi
+  systemctl --user daemon-reload || true
+  systemctl --user restart "$UNIT" || true
+  if health_ok; then
+    log "rollback restart is healthy"
+  else
+    log "WARN: service still UNHEALTHY after rollback — MANUAL INTERVENTION NEEDED (journalctl --user -u $UNIT -n 80)"
+  fi
+  deploylog "ROLLBACK to ${PREV:-none} (post-restart smoke failed)"
+}
+
+cleanup_on_exit() {
+  local rc=$?
+  trap - EXIT
+  if [ "$FLIPPED" = 1 ] && [ "$DEPLOY_OK" != 1 ]; then
+    log "deploy failed after symlink flip (rc=$rc)"
+    rollback
+  fi
+  if [ -n "$STAGING" ] && [ -d "$STAGING" ]; then rm -rf "$STAGING"; fi
+  exit "$rc"
+}
+trap cleanup_on_exit EXIT
+
+# Reuse a good release dir, else build a fresh one via `git archive` (self-contained).
+build_release() {
+  local dir="$RELEASES/$TAG"
+  if [ -d "$dir" ] && [ -f "$dir/apps/api/dist/main.js" ] \
+     && grep -q parseStoredHash "$dir/apps/api/dist/auth/token-registry.js" 2>/dev/null; then
+    log "release $TAG already built and passes preflight — reusing (idempotent)"
+    return 0
+  fi
+  command -v pnpm >/dev/null 2>&1 || die "pnpm not found on PATH"
+  [ -x "$NODE" ] || die "node binary not executable: $NODE"
+  log "building release $TAG from $SRC @ $SHA (node: $NODE)"
+  mkdir -p "$RELEASES"
+  STAGING="$(mktemp -d "$RELEASES/.stage-XXXXXX")"
+  git -C "$SRC" archive "$TAG" | tar -x -C "$STAGING"
+  (
+    cd "$STAGING"
+    nodebin_dir="$(dirname "$NODE")"
+    export PATH="$nodebin_dir:$PATH"         # pin the node whose ABI the unit uses
+    export HUSKY=0                           # no .git in an archive extract
+    pnpm install --frozen-lockfile
+    pnpm -r build
+  )
+  [ -f "$STAGING/apps/api/dist/main.js" ] || die "build produced no apps/api/dist/main.js"
+  lockout_preflight "$STAGING"
+  if [ -e "$dir" ]; then
+    OLD_ASIDE="$dir.old.$$"
+    mv "$dir" "$OLD_ASIDE"       # only reached for a broken existing dir (never the live target)
+  fi
+  mv "$STAGING" "$dir"
+  STAGING=""
+  log "release built: $dir"
+}
+
+# Keep the newest $KEEP release dirs; never remove the live target or the just-deployed one.
+prune_releases() {
+  local curtarget name n=0 d
+  curtarget="$(readlink "$OPT/current" 2>/dev/null || true)"
+  curtarget="${curtarget#releases/}"
+  # newest-first by mtime; tag dirs never contain spaces/newlines
+  while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    name="$(basename "$d")"
+    case "$name" in .*) continue ;; esac      # skip staging dirs
+    n=$((n + 1))
+    [ "$n" -le "$KEEP" ] && continue
+    [ "$name" = "$curtarget" ] && continue
+    [ "$name" = "$TAG" ] && continue
+    log "pruning old release: $name"
+    rm -rf "$d"
+  done < <(find "$RELEASES" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | cut -d' ' -f2-)
+}
+
+# --- main -------------------------------------------------------------------
+[ $# -eq 1 ] || die "usage: $(basename "$0") <tag>   (e.g. v0.8.0)"
+TAG="$1"
+[ -d "$SRC/.git" ] || die "source repo not found: $SRC (set TEAMKB_SRC_REPO)"
+
+log "fetching tags from origin"
+git -C "$SRC" fetch --tags --force origin >/dev/null 2>&1 || die "git fetch failed in $SRC"
+
+SHA="$(git -C "$SRC" rev-list -n1 "$TAG" 2>/dev/null || true)"
+[ -n "$SHA" ] || die "tag not found: $TAG"
+
+log "verifying release floor ($FLOOR) is an ancestor of $TAG ($SHA)"
+git -C "$SRC" merge-base --is-ancestor "$FLOOR" "$TAG" \
+  || die "REFUSING: $TAG does not contain the release floor $FLOOR (E1 pre-hashed tokens). Deploying it would double-hash tokens.json and lock out all users."
+
+build_release
+lockout_preflight "$RELEASES/$TAG"
+
+# Pre-flip smoke against the currently-live service (informational — we still
+# deploy even if the old build is already unhealthy; the hard gate is post-restart).
+if smoke_check; then log "pre-flip: live service healthy"; else log "pre-flip: live service NOT fully healthy (continuing — post-restart smoke is the gate)"; fi
+
+PREV="$(readlink "$OPT/current" 2>/dev/null || true)"
+log "flipping current: ${PREV:-<none>} -> releases/$TAG"
+ln -sfn "releases/$TAG" "$OPT/current"
+FLIPPED=1
+
+log "daemon-reload + restart $UNIT"
+systemctl --user daemon-reload
+systemctl --user restart "$UNIT"
+
+log "waiting for post-restart health"
+health_ok || die "post-restart health check failed (service did not return 200 on /api/health)"
+smoke_check || die "post-restart smoke failed"
+
+# Success — service confirmed healthy on the new build.
+DEPLOY_OK=1
+deploylog "DEPLOYED (current -> releases/$TAG)"
+log "deploy OK: $UNIT now running releases/$TAG (sha $SHA)"
+
+prune_releases
+if [ -n "$OLD_ASIDE" ] && [ -d "$OLD_ASIDE" ]; then rm -rf "$OLD_ASIDE"; fi
+
+log "done."


### PR DESCRIPTION
## What
Add `scripts/deploy-brain-api.sh` + `000-docs/041-OD-OPSM` so `teamkb-brain-api.service` deploys from an **immutable, tag-pinned release directory** (`~/.local/opt/teamkb-api/releases/<tag>`, self-contained: source + `node_modules` + `dist`, no `.git`) behind an atomic `current` symlink — instead of running from the mutable working checkout. This PR is **shell + docs only**; it does **not** edit the live unit or restart the service.

## Why & decision rationale
The live API runs with `WorkingDirectory=/home/jeremy/000-projects/qmd-team-intent-kb` and `ExecStart=/usr/bin/node apps/api/dist/main.js`. That means (a) any `git checkout`/rebuild in that repo mutates the running service, (b) a crash-restart can relaunch from a torn/feature-branch `dist/`, and (c) there is **no immutable rollback target** — the build that served Jun 25–Jul 9 was overwritten in place. Worse, rolling that checkout back **past E1 (`a2143be`)** rebuilds the pre-E1 registry, which double-hashes `~/.teamkb/tokens.json` and **locks out all six users**.

- **Chose** immutable `git archive` release dirs + an atomic `current` symlink **over** (1) rebuilding in place — *rejected*: no rollback target; and (2) `git worktree`-based releases — *rejected*: not self-contained, the tree depends on the parent repo's `.git`. The DB is external (`~/.teamkb/teamkb.db`), so only the **code artifact** needs pinning.

## Layer(s) touched
API-auth / operational tooling + docs. **No cross-layer invariant changed.**

## How it works
`deploy-brain-api.sh <tag>`: fetch → **floor guard** (`git merge-base --is-ancestor a2143be <tag>`, abort otherwise) → build a fresh `releases/<tag>` (`git archive` + `pnpm install --frozen-lockfile` + `pnpm -r build`, pinned to `/usr/bin/node` so `better-sqlite3`'s native ABI matches the unit) → **lockout preflight** (`grep parseStoredHash …/dist/auth/token-registry.js`) → smoke → flip `current` → `daemon-reload` + restart → post-restart health gate (**auto-rollback** the symlink + restart on failure) → append `DEPLOYS.log` → prune to newest 5. `set -euo pipefail`, idempotent (reuses a good release dir), never leaves the service down. No `~/.claude` paths; all locations are env-overridable.

Load-bearing files: `scripts/deploy-brain-api.sh`, `000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md`.

## Verification & evidence
- [x] **Static:** `shellcheck` clean (0 findings); `bash -n` OK; usage-abort + floor-guard logic exercised.
- [x] **Release built (staged, not live):** `releases/v0.8.0` built with `/usr/bin/node` v22.21.0; `better-sqlite3` `.node` load-tested + `@qmd-team-intent-kb/store` ESM dist imports OK.
- [x] **Lockout preflight:** `parseStoredHash` present in the built `apps/api/dist/auth/token-registry.js`.
- [x] **Smoke logic** validated against the running service: `GET /api/health` → 200, unauthenticated `POST /api/search` → 401.
- [x] **Docs:** markdownlint 0 errors, prettier-formatted; frontmatter validator N/A (table-header runbook, same shape as the passing `040-OD-OPSM`).

## Risk assessment
- **What could break?** Nothing at merge — this adds a script + doc; no code path or the live unit is touched. The runtime change happens only when the operator performs the documented one-time cutover.
- **Backward compatible?** Yes — the current working-checkout deploy keeps working until cutover.
- **User-facing?** Internal ops only.
- **Public API/contract change?** No.

## Operational impact
- **Deploy:** `scripts/deploy-brain-api.sh <tag>` (post-cutover).
- **One-time operator cutover (reserved for the human):** back up the unit, then repoint **only** `WorkingDirectory=/home/jeremy/.local/opt/teamkb-api/current` (every `Environment=`, `ExecStart`, `Restart`, `[Install]` line stays byte-identical), `daemon-reload`, restart, smoke. Full steps in `041-OD-OPSM` §cutover.
- **Disk:** ~1 GB per retained release (mostly pnpm-store hardlinks), capped at 5.
- New env/secrets/migrations: none. Release floor tag `v0.8.0` (`a2143be`) pushed to origin.

## Follow-up & deferred
- The one-time `WorkingDirectory` cutover is an operator action (documented), intentionally **not** in this PR.
- Migrating the brain to a dedicated tailnet VM remains tracked under `compile-then-govern-650.6` (unchanged by this PR).

## Governance links
- Companion runbook `000-docs/040-OD-OPSM` (service/tokens/tailnet bind — still valid; its "after a code change" step is superseded here).
- Commit/PR convention: `governed-second-brain/000-docs/013-OD-STND`.

## Refs / Beads
Refs Beads: compile-then-govern-jfv.6.6 (R6 / Gate-0, 6-engineer review)

- Jeremy Longshore
intentsolutions.io