### PR TITLE
feat(api): durable revoke-by-actor + persisted revocation list (R2 / jfv.6.2)

### DIFF
--- a/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
+++ b/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
@@ -14,6 +14,11 @@ exports[`OpenAPI contract > publishes a stable apps/api surface (snapshot) 1`] =
         "post",
       ],
     },
+    "/api/auth/revoke-actor": {
+      "methods": [
+        "post",
+      ],
+    },
     "/api/candidates": {
       "methods": [
         "get",

--- a/apps/api/src/__tests__/auth-revoke.test.ts
+++ b/apps/api/src/__tests__/auth-revoke.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type Database from 'better-sqlite3';
 import { createTestDatabase } from '@qmd-team-intent-kb/store';
 import { buildApp } from '../app.js';
+import type { RevokedActorEntry } from '../auth/token-registry.js';
 
 /**
  * Live token revocation — POST /api/auth/revoke (EPIC 0, compile-then-govern-c5k).
@@ -100,6 +104,147 @@ describe('live token revocation — POST /api/auth/revoke', () => {
       method: 'POST',
       url: '/api/auth/revoke',
       payload: { token: VICTIM },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+/**
+ * Durable revoke-by-actor — POST /api/auth/revoke-actor (R2 review gate, jfv.6.2).
+ *
+ * The realistic incident after E1 hashed tokens at rest: an admin holds NO
+ * plaintext bearer secret, so revoke-by-value is impossible ("Tim's laptop was
+ * stolen"). Revoke-by-actor needs only the audit identity, cuts off ALL of that
+ * actor's tokens, and persists the ban to a durable file so it survives a
+ * restart. The tests prove: (1) an admin revokes all of an actor's tokens and
+ * gets the count, and those tokens are then 401; (2) it is admin-only (write
+ * gate covers /api/auth); (3) an unknown actor is 0-but-200; (4) the ban is
+ * written to the durable file; (5) a fresh boot pointed at that file keeps the
+ * actor revoked.
+ */
+describe('durable revoke-by-actor — POST /api/auth/revoke-actor', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let dir: string;
+  let revokedFile: string;
+
+  const ADMIN = 'admin-token-abc';
+  const MEMBER = 'member-token-xyz';
+  // Tim carries two tokens; revoking the identity must kill both.
+  const TIM_A = 'tim-laptop-token';
+  const TIM_B = 'tim-desktop-token';
+
+  const TOKENS = [
+    { token: ADMIN, actor: 'jeremy', role: 'admin' as const },
+    { token: MEMBER, actor: 'pablo', role: 'member' as const },
+    { token: TIM_A, actor: 'tim', role: 'member' as const },
+    { token: TIM_B, actor: 'tim', role: 'member' as const },
+  ];
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'teamkb-revoke-actor-'));
+    revokedFile = join(dir, 'revoked-actors.json');
+    db = createTestDatabase();
+    app = buildApp({ db, silent: true, tokens: TOKENS, revokedFile });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function revokeActor(actorToken: string, body: Record<string, unknown>) {
+    return app.inject({
+      method: 'POST',
+      url: '/api/auth/revoke-actor',
+      headers: { Authorization: `Bearer ${actorToken}` },
+      payload: body,
+    });
+  }
+
+  function reads(token: string) {
+    return app.inject({
+      method: 'GET',
+      url: '/api/memories?tenantId=team-alpha',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  it('an admin revokes ALL of an actor’s tokens — returns the count, both are then 401', async () => {
+    // Both of Tim's tokens work before revocation.
+    expect((await reads(TIM_A)).statusCode).not.toBe(401);
+    expect((await reads(TIM_B)).statusCode).not.toBe(401);
+
+    const res = await revokeActor(ADMIN, { actor: 'tim', reason: 'laptop stolen' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ revoked: 2 });
+
+    // Both tokens are cut off immediately, no restart.
+    expect((await reads(TIM_A)).statusCode).toBe(401);
+    expect((await reads(TIM_B)).statusCode).toBe(401);
+    // Other actors are untouched.
+    expect((await reads(MEMBER)).statusCode).not.toBe(401);
+  });
+
+  it('persists the ban to the durable revocation file (survives a restart)', async () => {
+    await revokeActor(ADMIN, { actor: 'tim', reason: 'laptop stolen' });
+    expect(existsSync(revokedFile)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(revokedFile, 'utf8')) as RevokedActorEntry[];
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0]!.actor).toBe('tim');
+    expect(onDisk[0]!.reason).toBe('laptop stolen');
+    expect(typeof onDisk[0]!.revokedAt).toBe('string');
+
+    // A fresh app pointed at the same file (a restart) keeps Tim revoked.
+    const db2 = createTestDatabase();
+    const app2 = buildApp({ db: db2, silent: true, tokens: TOKENS, revokedFile });
+    await app2.ready();
+    try {
+      const after = await app2.inject({
+        method: 'GET',
+        url: '/api/memories?tenantId=team-alpha',
+        headers: { Authorization: `Bearer ${TIM_A}` },
+      });
+      expect(after.statusCode).toBe(401);
+      // A non-revoked actor still works after the "restart".
+      const ok = await app2.inject({
+        method: 'GET',
+        url: '/api/memories?tenantId=team-alpha',
+        headers: { Authorization: `Bearer ${MEMBER}` },
+      });
+      expect(ok.statusCode).not.toBe(401);
+    } finally {
+      await app2.close();
+      db2.close();
+    }
+  });
+
+  it('revoke-by-actor is admin-only — a member is blocked with 403', async () => {
+    const res = await revokeActor(MEMBER, { actor: 'tim' });
+    expect(res.statusCode).toBe(403);
+    // Nothing was revoked and nothing was persisted.
+    expect((await reads(TIM_A)).statusCode).not.toBe(401);
+    expect(existsSync(revokedFile)).toBe(false);
+  });
+
+  it('revoking an unknown actor returns { revoked: 0 } and still 200', async () => {
+    const res = await revokeActor(ADMIN, { actor: 'nobody' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ revoked: 0 });
+  });
+
+  it('a missing / non-string actor body is a 400', async () => {
+    expect((await revokeActor(ADMIN, {})).statusCode).toBe(400);
+    expect((await revokeActor(ADMIN, { actor: 123 })).statusCode).toBe(400);
+  });
+
+  it('revoke-by-actor requires authentication (no token → 401)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/revoke-actor',
+      payload: { actor: 'tim' },
     });
     expect(res.statusCode).toBe(401);
   });

--- a/apps/api/src/__tests__/token-registry.test.ts
+++ b/apps/api/src/__tests__/token-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
@@ -10,7 +10,11 @@ import {
   InMemoryTokenRegistry,
   loadTokenRecords,
   hashToken,
+  buildTokenRegistry,
+  loadRevokedActors,
+  appendRevokedActor,
   type TokenRecord,
+  type RevokedActorEntry,
 } from '../auth/token-registry.js';
 
 describe('InMemoryTokenRegistry', () => {
@@ -165,6 +169,50 @@ describe('InMemoryTokenRegistry', () => {
     const reg = new InMemoryTokenRegistry([{ token: 'live', actor: 'a', role: 'admin' }]);
     expect(reg.revoke('never-existed')).toBe(false);
   });
+
+  // ---- revoke-by-actor (durable incident response — jfv.6.2) --------------
+
+  it('revokeByActor revokes ALL of one actor’s records and returns the count', () => {
+    // Tim carries two tokens (laptop + workstation); revoking the identity must
+    // cut off both at once and report the count.
+    const reg = new InMemoryTokenRegistry([
+      { token: 'tim-laptop', actor: 'tim', role: 'member' },
+      { token: 'tim-workstation', actor: 'tim', role: 'member' },
+      { token: 'other', actor: 'jeremy', role: 'admin' },
+    ]);
+    expect(reg.revokeByActor('tim')).toBe(2);
+    // Both of Tim's tokens are dead; the other actor is untouched.
+    expect(reg.resolve('tim-laptop')).toBeUndefined();
+    expect(reg.resolve('tim-workstation')).toBeUndefined();
+    expect(reg.resolve('other')).toEqual({ actor: 'jeremy', role: 'admin' });
+  });
+
+  it('a revoked actor does NOT resolve after revokeByActor', () => {
+    const reg = new InMemoryTokenRegistry([{ token: 'tim-token', actor: 'tim', role: 'member' }]);
+    expect(reg.resolve('tim-token')).toEqual({ actor: 'tim', role: 'member' });
+    reg.revokeByActor('tim');
+    expect(reg.resolve('tim-token')).toBeUndefined();
+  });
+
+  it('revokeByActor returns 0 for an unknown actor (still safe, no throw)', () => {
+    const reg = new InMemoryTokenRegistry([{ token: 'live', actor: 'jeremy', role: 'admin' }]);
+    expect(reg.revokeByActor('nobody')).toBe(0);
+    expect(reg.resolve('live')).toEqual({ actor: 'jeremy', role: 'admin' });
+  });
+
+  it('applies a boot-time revoked-actors list at construction (survives restart)', () => {
+    // Simulate a restart: the same records reload, but the actor is on the
+    // durable revocation list, so their token starts life revoked.
+    const reg = new InMemoryTokenRegistry(
+      [
+        { token: 'tim-token', actor: 'tim', role: 'member' },
+        { token: 'jeremy-token', actor: 'jeremy', role: 'admin' },
+      ],
+      ['tim'],
+    );
+    expect(reg.resolve('tim-token')).toBeUndefined(); // banned at boot
+    expect(reg.resolve('jeremy-token')).toEqual({ actor: 'jeremy', role: 'admin' });
+  });
 });
 
 describe('loadTokenRecords', () => {
@@ -265,6 +313,78 @@ describe('loadTokenRecords', () => {
       { token: 'typo', actor: 'a', role: 'admin', expiresAt: 'not-a-date' },
     ]);
     expect(loadTokenRecords({ tokensJson: json })).toHaveLength(0);
+  });
+});
+
+describe('durable revocation list (revoke-by-actor persistence — jfv.6.2)', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'teamkb-revoked-'));
+    file = join(dir, 'revoked-actors.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loadRevokedActors returns [] for an undefined path or a missing file', () => {
+    expect(loadRevokedActors(undefined)).toEqual([]);
+    expect(loadRevokedActors(file)).toEqual([]); // file not created yet
+  });
+
+  it('loadRevokedActors reads the distinct set of revoked actors', () => {
+    const entries: RevokedActorEntry[] = [
+      { actor: 'tim', revokedAt: '2026-07-09T00:00:00.000Z', reason: 'laptop stolen' },
+      { actor: 'tim', revokedAt: '2026-07-09T01:00:00.000Z' }, // duplicate → collapsed
+      { actor: 'ope', revokedAt: '2026-07-09T02:00:00.000Z' },
+    ];
+    writeFileSync(file, JSON.stringify(entries));
+    expect(loadRevokedActors(file).sort()).toEqual(['ope', 'tim']);
+  });
+
+  it('loadRevokedActors fails OPEN on an unparseable file (returns [], does not throw)', () => {
+    writeFileSync(file, 'this is not json{');
+    expect(loadRevokedActors(file)).toEqual([]);
+  });
+
+  it('appendRevokedActor writes an entry (append-only) and is readable back', () => {
+    const first = appendRevokedActor(file, 'tim', 'laptop stolen');
+    expect(first.actor).toBe('tim');
+    expect(first.reason).toBe('laptop stolen');
+    expect(typeof first.revokedAt).toBe('string');
+
+    // A second append keeps the first (append-only), not overwrites it.
+    appendRevokedActor(file, 'ope');
+    const onDisk = JSON.parse(readFileSync(file, 'utf8')) as RevokedActorEntry[];
+    expect(onDisk).toHaveLength(2);
+    expect(onDisk.map((e) => e.actor)).toEqual(['tim', 'ope']);
+    expect(loadRevokedActors(file).sort()).toEqual(['ope', 'tim']);
+  });
+
+  it('appendRevokedActor heals a corrupt existing file forward (does not lose the new revoke)', () => {
+    writeFileSync(file, 'garbage-not-json');
+    appendRevokedActor(file, 'tim');
+    const onDisk = JSON.parse(readFileSync(file, 'utf8')) as RevokedActorEntry[];
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0]!.actor).toBe('tim');
+  });
+
+  it('buildTokenRegistry applies a persisted revocation at boot (the R2 restart guarantee)', () => {
+    // Persist a ban, then build a fresh registry pointed at that file — exactly
+    // what happens on a service restart. The banned actor's token must NOT
+    // resolve; an unbanned actor's token must.
+    appendRevokedActor(file, 'tim', 'laptop stolen');
+    const reg = buildTokenRegistry({
+      records: [
+        { token: 'tim-token', actor: 'tim', role: 'member' },
+        { token: 'jeremy-token', actor: 'jeremy', role: 'admin' },
+      ],
+      revokedFile: file,
+    });
+    expect(reg.resolve('tim-token')).toBeUndefined();
+    expect(reg.resolve('jeremy-token')).toEqual({ actor: 'jeremy', role: 'admin' });
   });
 });
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,7 +31,7 @@ import { registerApiKeyAuth } from './middleware/api-key-auth.js';
 import { registerWriteGate } from './middleware/write-gate.js';
 import { registerTenancyGuard } from './middleware/tenancy-guard.js';
 import { registerInputSanitizer } from './middleware/input-sanitizer.js';
-import { InMemoryTokenRegistry, loadTokenRecords } from './auth/token-registry.js';
+import { buildTokenRegistry } from './auth/token-registry.js';
 import type { TokenRecord } from './auth/token-registry.js';
 import { registerOpenApi } from './openapi.js';
 
@@ -67,6 +67,14 @@ export interface AppDependencies {
    */
   bindHost?: string;
   /**
+   * Path to the durable revocation list (default env `TEAMKB_REVOKED_FILE`,
+   * else — set by `main.ts` — `~/.teamkb/revoked-actors.json`). Actors listed
+   * here are revoked at boot, and `POST /api/auth/revoke-actor` appends to it so
+   * a revoke-by-actor survives a restart. Left unset in tests → in-memory only,
+   * no file is touched.
+   */
+  revokedFile?: string;
+  /**
    * Optional qmd query port. When provided, search runs through qmd so every
    * hit carries a `qmd://` citation. When omitted, search falls back to SQLite
    * text-match over the curated store.
@@ -86,14 +94,16 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   const app = Fastify({ logger: !deps.silent, bodyLimit });
 
   registerRateLimiter(app, deps.rateLimitMax ?? 100, deps.rateLimitWindowMs ?? 60000);
-  const tokenRegistry = new InMemoryTokenRegistry(
-    loadTokenRecords({
-      records: deps.tokens,
-      apiKey: deps.apiKey,
-      tokensJson: process.env['TEAMKB_TOKENS'],
-      tokensFile: process.env['TEAMKB_TOKENS_FILE'],
-    }),
-  );
+  // The durable revocation list: actors banned here are revoked at boot, and
+  // POST /api/auth/revoke-actor appends to it so a revoke survives a restart.
+  const revokedFile = deps.revokedFile ?? process.env['TEAMKB_REVOKED_FILE'];
+  const tokenRegistry = buildTokenRegistry({
+    records: deps.tokens,
+    apiKey: deps.apiKey,
+    tokensJson: process.env['TEAMKB_TOKENS'],
+    tokensFile: process.env['TEAMKB_TOKENS_FILE'],
+    revokedFile,
+  });
   // Pass the bind host so the no-auth dev path is refused off-loopback — an
   // unauthenticated admin-stamping brain must never be reachable off-host.
   registerApiKeyAuth(app, tokenRegistry, { bindHost: deps.bindHost ?? '127.0.0.1' });
@@ -144,7 +154,8 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     registerImportRoutes(scope, importService);
     registerGraphRoutes(scope, linksRepo, memoryRepo);
     // Live token revocation — admin-only, cuts a token off without a restart.
-    registerAuthRoutes(scope, tokenRegistry);
+    // The revoked-file path lets revoke-by-actor persist durably.
+    registerAuthRoutes(scope, tokenRegistry, revokedFile);
   });
 
   return app;

--- a/apps/api/src/auth/token-registry.ts
+++ b/apps/api/src/auth/token-registry.ts
@@ -1,5 +1,6 @@
 import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 /** What a token grants. `admin` may write/promote; `member` is read-only. */
 export type TokenRole = 'admin' | 'member';
@@ -58,6 +59,19 @@ export interface TokenRegistry {
    * re-read on next restart, where the operator should also drop the record).
    */
   revoke(token: string): boolean;
+  /**
+   * Durable-incident revocation by IDENTITY, not by secret. Marks EVERY live
+   * record whose `identity.actor` matches as revoked, in-process and immediate.
+   * Returns the number of records revoked.
+   *
+   * This is the revoke path that still works AFTER tokens are hashed at rest
+   * (E1): an admin holds no plaintext bearer secret, so {@link revoke} by value
+   * is impossible for the realistic "an actor's laptop was stolen" case.
+   * Revoking by actor needs no secret — only the audit identity the token
+   * already carries. Pair it with {@link appendRevokedActor} to make the
+   * revocation survive a restart (the boot loader re-applies the list).
+   */
+  revokeByActor(actor: string): number;
 }
 
 /** Constant-time buffer compare (equal-length-safe). */
@@ -127,12 +141,18 @@ export class InMemoryTokenRegistry implements TokenRegistry {
   private readonly records: HashedRecord[];
 
   /**
-   * @param records  Token records (the on-disk shape). Each `token` is either a
-   *                 plaintext bearer secret or an already-salted
-   *                 `scrypt$salt$hash`. The constructor keeps only a salted hash
-   *                 and discards any plaintext immediately.
+   * @param records        Token records (the on-disk shape). Each `token` is
+   *                        either a plaintext bearer secret or an already-salted
+   *                        `scrypt$salt$hash`. The constructor keeps only a
+   *                        salted hash and discards any plaintext immediately.
+   * @param revokedActors  Actors from the durable revocation list. Any record
+   *                        whose `actor` is listed starts life revoked, so a
+   *                        revoked actor STAYS revoked across a restart (the
+   *                        file is re-read every boot). Prefer the
+   *                        {@link buildTokenRegistry} factory, which wires this
+   *                        from the revocation file for you.
    */
-  constructor(records: readonly TokenRecord[]) {
+  constructor(records: readonly TokenRecord[], revokedActors: readonly string[] = []) {
     this.records = records.map((rec) => {
       // A `token` may already be a salted `scrypt$salt$hash` (the at-rest form,
       // so no plaintext bearer secret sits on disk) — use it verbatim so the
@@ -160,6 +180,19 @@ export class InMemoryTokenRegistry implements TokenRegistry {
         revoked: false,
       };
     });
+
+    // Apply the durable, boot-time revocation list: any actor banned in the
+    // persisted file starts revoked. Applied AFTER the records are built so it
+    // also catches a token freshly issued to an already-banned actor — a ban is
+    // on the identity, not on one specific secret.
+    if (revokedActors.length > 0) {
+      const banned = new Set(revokedActors);
+      for (const rec of this.records) {
+        if (banned.has(rec.identity.actor)) {
+          rec.revoked = true;
+        }
+      }
+    }
   }
 
   isEmpty(): boolean {
@@ -193,6 +226,23 @@ export class InMemoryTokenRegistry implements TokenRegistry {
       }
     }
     return revokedAny;
+  }
+
+  revokeByActor(actor: string): number {
+    // Revoke by identity — no secret needed. This works after E1 hashed tokens
+    // at rest (an admin has no plaintext to pass to revoke()) and cuts off ALL
+    // of one actor's live tokens at once (e.g. a stolen laptop with a session).
+    // Constant-time comparison is irrelevant here: `actor` is a public audit
+    // identity, not a secret, so a plain string equals is correct.
+    let count = 0;
+    for (const rec of this.records) {
+      if (rec.revoked) continue;
+      if (rec.identity.actor === actor) {
+        rec.revoked = true;
+        count += 1;
+      }
+    }
+    return count;
   }
 }
 
@@ -307,4 +357,127 @@ function parseTenants(raw: unknown): string[] | undefined {
 function parseExpiry(raw: unknown): string | undefined {
   if (typeof raw !== 'string' || raw.length === 0) return undefined;
   return raw;
+}
+
+// --- Durable revocation list (revoke-by-actor, survives restart) -----------
+//
+// A token record already supports `expiresAt` for time-boxed retirement (see
+// TokenRecord / loadTokenRecords, both of which enforce it) — an operator caps
+// a token's life by adding `"expiresAt": "2026-12-31T00:00:00Z"` to its record
+// in tokens.json. That covers PLANNED retirement. The revocation list below
+// covers UNPLANNED, immediate incident response by actor ("Tim's laptop was
+// stolen") in a world where tokens are hashed at rest and no plaintext exists
+// to revoke by value.
+
+/**
+ * One entry in the durable revocation list. Append-only: an entry is never
+ * removed (un-revoking is re-issuing a fresh token, not editing this file), so
+ * the file doubles as a small, human-readable revocation audit trail.
+ */
+export interface RevokedActorEntry {
+  /** The audit actor whose tokens are cut off. */
+  actor: string;
+  /** When the revocation was recorded (ISO-8601). */
+  revokedAt: string;
+  /** Optional operator note ("laptop stolen", "left the team"). */
+  reason?: string;
+}
+
+/**
+ * Read the durable revocation list and return the DISTINCT set of revoked
+ * actors. The file is a JSON array of {@link RevokedActorEntry}.
+ *
+ * Fail-open-safe: a missing file (the normal first-run case) yields `[]`
+ * silently; a present-but-unparseable file yields `[]` but LOGS a warning. A
+ * revocation file is a safety add-on, not the primary auth gate — a corrupt
+ * file must never stop the brain from booting, but the operator should know it
+ * was ignored (a silently-dropped ban list is a security footgun).
+ */
+export function loadRevokedActors(path: string | undefined): string[] {
+  if (path === undefined || path === '') return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return []; // no file yet = nothing revoked
+  }
+  try {
+    const data: unknown = JSON.parse(raw);
+    if (!Array.isArray(data)) throw new Error('revocation file is not a JSON array');
+    const actors = new Set<string>();
+    for (const item of data) {
+      if (!item || typeof item !== 'object') continue;
+      const actor = (item as Record<string, unknown>)['actor'];
+      if (typeof actor === 'string' && actor.length > 0) actors.add(actor);
+    }
+    return [...actors];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[teamkb-api] WARN: ignoring unparseable revocation file ${path}: ${msg}\n`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Append one revocation to the durable list and return the entry written.
+ *
+ * Append-only semantics: the existing entries are read, the new one is pushed,
+ * and the whole array is rewritten (so a concurrent reader always parses valid
+ * JSON — never a torn half-write). A missing parent dir is created; a
+ * missing-or-corrupt existing file is treated as an empty list so the append
+ * still succeeds and heals a corrupt file forward without dropping the new
+ * revocation. The file is written mode 0600 (it lists actor identities + free
+ * -text reasons — no secrets, but no reason to be world-readable either).
+ */
+export function appendRevokedActor(
+  path: string,
+  actor: string,
+  reason?: string,
+): RevokedActorEntry {
+  const entry: RevokedActorEntry = { actor, revokedAt: new Date().toISOString() };
+  if (reason !== undefined && reason !== '') entry.reason = reason;
+
+  let existing: RevokedActorEntry[] = [];
+  const raw = readFileSafe(path);
+  if (raw !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        existing = parsed.filter(
+          (e): e is RevokedActorEntry =>
+            !!e && typeof e === 'object' && typeof (e as { actor?: unknown }).actor === 'string',
+        );
+      }
+    } catch {
+      existing = []; // corrupt existing file → heal forward, don't lose this revoke
+    }
+  }
+  existing.push(entry);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`, { mode: 0o600 });
+  return entry;
+}
+
+/** Options for {@link buildTokenRegistry}: token sources + the revocation list. */
+export interface RegistryBuildOptions extends TokenSourceOptions {
+  /**
+   * Path to the durable revocation list (env `TEAMKB_REVOKED_FILE`, default
+   * `~/.teamkb/revoked-actors.json`). Actors listed here are revoked at boot.
+   */
+  revokedFile?: string;
+}
+
+/**
+ * Build a registry from the token sources AND apply the durable revocation
+ * list — the single construction path that guarantees a revoked actor stays
+ * revoked across a restart. `buildApp` uses this instead of
+ * `new InMemoryTokenRegistry(...)` directly so the boot-time file read is never
+ * forgotten.
+ */
+export function buildTokenRegistry(opts: RegistryBuildOptions): InMemoryTokenRegistry {
+  const records = loadTokenRecords(opts);
+  const revoked = loadRevokedActors(opts.revokedFile);
+  return new InMemoryTokenRegistry(records, revoked);
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,6 +18,7 @@
  *   TEAMKB_DB_PATH      — SQLite path (default ~/.teamkb/data/teamkb.db)
  *   TEAMKB_TENANT_ID    — tenant scope for qmd isolation (default intent-solutions)
  *   TEAMKB_EXPORT_DIR   — git-exporter output dir qmd indexes (default ~/.teamkb/kb-export)
+ *   TEAMKB_REVOKED_FILE — durable revoke-by-actor list (default ~/.teamkb/revoked-actors.json)
  */
 import { resolve } from 'node:path';
 import { createDatabase } from '@qmd-team-intent-kb/store';
@@ -64,10 +65,15 @@ async function main(): Promise<void> {
     process.stderr.write(`[teamkb-api] auth: ${tokens.length} token(s) loaded — ${roles}\n`);
   }
 
+  // Durable revoke-by-actor list — default under the brain base so a stolen
+  // laptop can be revoked by identity and the ban survives a restart.
+  const revokedFile =
+    process.env['TEAMKB_REVOKED_FILE'] ?? resolveTeamKbPath('revoked-actors.json');
+
   // Pass the real bind host so the no-auth dev path is refused off-loopback:
   // an empty registry on a tailnet/0.0.0.0 bind throws at boot rather than
   // serving every request as role=admin. Loopback stays the default.
-  const app = buildApp({ db, tokens, qmdAdapter, bindHost: config.host });
+  const app = buildApp({ db, tokens, qmdAdapter, bindHost: config.host, revokedFile });
   await app.ready();
 
   const shutdown = async (signal: string): Promise<void> => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,27 +1,42 @@
 import type { FastifyInstance } from 'fastify';
-import type { TokenRegistry } from '../auth/token-registry.js';
+import { appendRevokedActor, type TokenRegistry } from '../auth/token-registry.js';
 
 /**
- * Live token-revocation route — EPIC 0 hardening (compile-then-govern-c5k).
+ * Token-revocation routes — EPIC 0 hardening (compile-then-govern-c5k) plus the
+ * durable revoke-by-actor added for the R2 review gate (jfv.6.2).
  *
- * Before this, the only way to revoke a bearer token was edit `tokens.json` and
- * restart the process. That is a slow, disruptive incident response: a leaked
- * token stays live until the next restart. This endpoint lets an admin cut a
- * token off IN-PROCESS, immediately, with no restart.
+ * Two ways to cut a token off without editing `tokens.json` and restarting:
  *
- * `POST /api/auth/revoke` — body `{ "token": "<the-secret-to-revoke>" }`.
- * Admin-only (enforced by the write gate, which gates `/api/auth/*` mutations).
- * Returns `{ revoked: true }` if a live record matched, `{ revoked: false }`
- * otherwise. Revocation is permanent for the life of the process; the operator
- * should also drop the record from `tokens.json` so a restart does not revive it.
+ * 1. `POST /api/auth/revoke` — by VALUE. Body `{ "token": "<secret>" }`. The
+ *    caller must hold the plaintext secret. In-memory only (lost on restart).
+ * 2. `POST /api/auth/revoke-actor` — by IDENTITY. Body `{ "actor": "<actor>" }`.
+ *    Needs NO secret, so it works after E1 hashed tokens at rest (an admin holds
+ *    no plaintext to pass to route #1). This is the revoke path for the real
+ *    incident — "Tim's laptop was stolen" — and it is DURABLE: the actor is
+ *    appended to the revocation list (`TEAMKB_REVOKED_FILE`, default
+ *    `~/.teamkb/revoked-actors.json`) so the boot loader re-applies it and the
+ *    actor stays revoked across a restart.
  *
- * Note: the request body carries the plaintext secret. That is unavoidable for a
- * revoke-by-value endpoint and is acceptable because (a) the call itself is
- * admin-authenticated over the same loopback/tailnet channel as every other
- * write, and (b) the registry compares it against the stored salted hash and
- * never persists it.
+ * Both are admin-only, enforced by the write gate (which gates `/api/auth/*`
+ * mutations) — no per-route role check needed here.
+ *
+ * Note on route #1: the request body carries the plaintext secret. That is
+ * unavoidable for a revoke-by-value endpoint and is acceptable because (a) the
+ * call itself is admin-authenticated over the same loopback/tailnet channel as
+ * every other write, and (b) the registry compares it against the stored salted
+ * hash and never persists it.
+ *
+ * @param registry     the token registry to revoke against (in-memory, immediate)
+ * @param revokedFile  path to the durable revocation list; when set,
+ *                     revoke-by-actor appends to it so the ban survives a
+ *                     restart. When unset (dev/tests), revocation is in-memory
+ *                     only and no file is touched.
  */
-export function registerAuthRoutes(app: FastifyInstance, registry: TokenRegistry): void {
+export function registerAuthRoutes(
+  app: FastifyInstance,
+  registry: TokenRegistry,
+  revokedFile?: string,
+): void {
   app.post(
     '/api/auth/revoke',
     {
@@ -44,6 +59,55 @@ export function registerAuthRoutes(app: FastifyInstance, registry: TokenRegistry
         });
       }
       const revoked = registry.revoke(token);
+      return reply.send({ revoked });
+    },
+  );
+
+  app.post(
+    '/api/auth/revoke-actor',
+    {
+      schema: {
+        tags: ['auth'],
+        summary: 'Revoke ALL of an actor’s tokens durably (by identity) — admin only',
+        description:
+          'Cuts off every live token belonging to `actor`, in-process and ' +
+          'immediately, and appends the actor to the durable revocation list so ' +
+          'the ban survives a restart. Needs no plaintext secret — the revoke ' +
+          'path for hashed-at-rest tokens (a stolen laptop). Admin-only. Returns ' +
+          '`{ revoked: <count> }` — the number of live records cut off.',
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as { actor?: unknown; reason?: unknown } | undefined;
+      const actor = body?.actor;
+      if (typeof actor !== 'string' || actor.length === 0) {
+        return reply.code(400).send({
+          error: 'actor is required',
+          message: 'Supply the actor to revoke in the request body: { "actor": "..." }.',
+        });
+      }
+      const reason =
+        typeof body?.reason === 'string' && body.reason.length > 0 ? body.reason : undefined;
+
+      // In-memory first (immediate effect), then persist (durable across
+      // restart). Persist even when the count is 0: a ban is on the identity,
+      // so an actor with no CURRENTLY-loaded token still gets banned for any
+      // future token — the whole point of a durable, identity-scoped list.
+      const revoked = registry.revokeByActor(actor);
+      if (revokedFile !== undefined && revokedFile !== '') {
+        try {
+          appendRevokedActor(revokedFile, actor, reason);
+        } catch (err) {
+          // The in-memory revocation already took effect; a failed persist must
+          // not fail the request. Log so the operator knows the ban is not yet
+          // durable and can retry / fix the path.
+          const msg = err instanceof Error ? err.message : String(err);
+          request.log.error(
+            { err: msg, revokedFile },
+            'revoke-actor: in-memory revoke succeeded but persisting to the revocation file failed',
+          );
+        }
+      }
       return reply.send({ revoked });
     },
   );


### PR DESCRIPTION
## What

Adds **durable revoke-by-actor** to the brain API. Two new registry capabilities plus one admin endpoint:

- `InMemoryTokenRegistry.revokeByActor(actor)` — marks **every** live record whose `identity.actor` matches as revoked (in-memory, immediate) and returns the count.
- A **persisted revocation list** — a JSON file at `TEAMKB_REVOKED_FILE` (default `~/.teamkb/revoked-actors.json`), an append-only array of `{ actor, revokedAt, reason? }`, read at boot so a revoked actor **stays revoked across a restart**, and appended to at runtime by the endpoint.
- `POST /api/auth/revoke-actor` — admin-only, body `{ actor, reason? }` → `{ revoked: <count> }`. Revokes in-memory **and** persists. The existing revoke-by-token route (`POST /api/auth/revoke`) is kept for back-compat.

## Why & decision rationale

All live brain tokens carry `expiresAt: null`, and the only revoke path was **in-memory** (`InMemoryTokenRegistry.revoke`) — lost on restart. Since **E1 hashed tokens at rest** (#227), an admin holds **no plaintext bearer secret**, so revoke-by-value is impossible for the realistic incident: *"Tim's laptop was stolen."* Revoke needs to work from the **audit identity** the token already carries, and it needs to be **durable**.

**Chose a separate append-only revocation-list file over rewriting `tokens.json`** because append-only is safer than mutating the source token file (no risk of corrupting the credential store on a revoke) and it doubles as a **revocation audit trail**. Alternative considered — flipping a `revoked`/`expiresAt` field inside each `tokens.json` record — rejected: it mutates the source-of-truth token file on every incident and loses the "who/when/why" history that a ban list preserves for free.

## Layer(s) touched

**Below the spool — govern-adjacent API auth only** (`qmd-team-intent-kb/apps/api`: token registry, auth routes, app wiring). **No cross-layer invariant changed** — no touch to content-stable spool UUIDs, append-only hash-chained receipts, tenant isolation, insert-only `candidates`, or promotion. Tenant + expiry fields on token records are preserved (covered by existing tests).

## How it works

- `apps/api/src/auth/token-registry.ts` — `revokeByActor` (identity match, no secret / no constant-time needed — `actor` is public); `loadRevokedActors(path)` (fail-open-safe: missing file → `[]` silently, corrupt file → `[]` + logged warning, never blocks boot); `appendRevokedActor(path, actor, reason?)` (reads-appends-rewrites the whole array so a reader never sees a torn write; creates the dir; heals a corrupt file forward; mode `0600`); `buildTokenRegistry(opts)` — the single construction path that loads records **and** applies the revocation list, plus a new optional `revokedActors` constructor arg that marks matching records revoked at boot.
- `apps/api/src/app.ts` — `buildApp` now resolves `revokedFile` (dep or `TEAMKB_REVOKED_FILE`), builds via `buildTokenRegistry`, and passes the path to `registerAuthRoutes`.
- `apps/api/src/routes/auth.ts` — the `POST /api/auth/revoke-actor` handler (admin gating is inherited from the write gate, which already treats `/api/auth/*` mutations as admin-only — no per-route role check).
- `apps/api/src/main.ts` — defaults the path to `~/.teamkb/revoked-actors.json` via `resolveTeamKbPath`.

## Verification & evidence

- [x] **Unit/integration tests** — **+16 tests**, all green:
  - `token-registry.test.ts` **42/42** — `revokeByActor` revokes all of one actor's records + returns the count; a revoked actor no longer resolves; unknown actor → 0; boot-time constructor application; `loadRevokedActors` (distinct set / missing → `[]` / unparseable → `[]` fail-open); `appendRevokedActor` (append-only + heals corrupt); `buildTokenRegistry` applies a persisted ban at boot.
  - `auth-revoke.test.ts` **11/11** — admin revokes an actor's **two** tokens → `{ revoked: 2 }` and both are then 401; **persists to the file and a fresh app (simulated restart) keeps the actor revoked**; member → **403**; unknown actor → `{ revoked: 0 }` + 200; missing/non-string actor → 400; no token → 401.
- [x] **Full suite** — `apps/api` **304/304**; whole repo **1966/1966** (163 files).
- [x] **Gates** — `typecheck` clean · `eslint` clean · `prettier --check` clean · `depcruise` (architecture) exit 0 · `crap` (complexity) OK · OpenAPI contract snapshot updated (one added path: `/api/auth/revoke-actor`).

## Risk assessment

- **What could break?** Nothing beyond the touched auth module. Boot adds one best-effort file read (fail-open-safe — a missing/corrupt file logs and continues). The endpoint is new; the existing revoke-by-token route is unchanged.
- **Backward compatible?** Yes. `revokedFile` is optional (unset in tests → in-memory only, no file touched); plaintext + pre-hashed token records still load; expiry unchanged.
- **User-facing or internal?** Internal — tailnet-bound admin API auth. No end-user surface.
- **Public API / contract change?** Adds one endpoint (`POST /api/auth/revoke-actor`); no change to any existing route or schema. Contract snapshot re-blessed.

## Operational impact

- **New env var:** `TEAMKB_REVOKED_FILE` (optional; default `~/.teamkb/revoked-actors.json`).
- **New state file:** `~/.teamkb/revoked-actors.json` — created on first revoke, mode `0600`, no secrets (actor identities + reasons). **No schema migration.**
- **New dependencies:** none. **Cost:** none. **New permissions/secrets:** none.
- **Deploy order:** code-only, no paired data step. The file is created lazily on first `revoke-actor`; it is **not** in the current backup Tier list — a follow-up may add it, but losing it only forgets bans (fail-open), it does not lose brain data.

## Follow-up & deferred

- Setting `expiresAt` on the **live** tokens is an operational step handled separately (out of scope here) — expiry is already supported + enforced by the registry; this PR only documents it.
- Not-emailing/handing-out the admin token is operational, handled separately.
- Possible follow-ups (not filed as blocking): include `revoked-actors.json` in the backup Tier list; token expiry/rotation automation. Tracked under the remediation epic `compile-then-govern-jfv.6`.

## Governance links

- Commit/branch/PR standard `governed-second-brain/000-docs/013-OD-STND`.
- E1 hash-at-rest predecessor: #227 (why an admin has no plaintext to revoke by value).
- Remediation epic `compile-then-govern-jfv.6` (R2 review gate).

## Refs

Refs #227 · Beads: compile-then-govern-jfv.6.2

- Jeremy Longshore
intentsolutions.io
