### PR TITLE
feat(api): server-side candidate-intake override + provenance receipt (R8)

### DIFF
--- a/apps/api/src/__tests__/candidate-override.test.ts
+++ b/apps/api/src/__tests__/candidate-override.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { buildApp } from '../app.js';
+import { applyIntakeOverrides } from '../services/candidate-service.js';
+import { makeCandidate } from './fixtures.js';
+
+/**
+ * R8 — server-side candidate-intake override (Gate-1 of the 6-engineer review;
+ * bead compile-then-govern-jfv.6.7).
+ *
+ * THE GAP: in team mode the CLIENT builds the entire `MemoryCandidate` and the
+ * server used to `safeParse` and trust it. A member (or a leaked member token)
+ * could assert `trustLevel:'high'`, forge `author`, name a foreign `tenantId`,
+ * and pre-clear `prePolicyFlags.potentialSecret:false` — and intake wrote NO
+ * provenance receipt. These tests prove the server now OWNS those fields and
+ * stamps a receipt + quarantine marker on every proposal.
+ */
+describe('R8 — candidate intake server-side override', () => {
+  // ---- pure override logic (guard-independent) ---------------------------
+  //
+  // The HTTP tenancy guard rejects a SCOPED token's out-of-allowlist tenantId
+  // with 403 before intake runs, so these unit tests exercise the intake binding
+  // directly: they prove that even a forged foreign tenantId reaching the service
+  // is neutralized to the token's own tenant.
+  describe('applyIntakeOverrides', () => {
+    const forged = () =>
+      makeCandidate({
+        trustLevel: 'high',
+        author: { type: 'ai', id: 'governed-brain' },
+        tenantId: 'attacker-tenant',
+        prePolicyFlags: { potentialSecret: false, lowConfidence: true, duplicateSuspect: true },
+        metadata: { filePaths: [], tags: ['x'] },
+      });
+
+    it('forces a MEMBER proposal to server-owned trust / author / tenant / flags / marker', () => {
+      const out = applyIntakeOverrides(forged(), {
+        actor: 'mia',
+        role: 'member',
+        tenants: ['team-secure'],
+      });
+
+      // trustLevel forced to the lowest enum — the asserted 'high' is dropped.
+      expect(out.trustLevel).toBe('untrusted');
+      // author is the token identity, not the client's hardcoded 'governed-brain'.
+      expect(out.author).toEqual({ type: 'human', id: 'mia' });
+      // tenantId bound to the token's sole tenant, overriding the forged 'attacker-tenant'.
+      expect(out.tenantId).toBe('team-secure');
+      // prePolicyFlags reset to server defaults — the client's true flags are dropped.
+      expect(out.prePolicyFlags).toEqual({
+        potentialSecret: false,
+        lowConfidence: false,
+        duplicateSuspect: false,
+      });
+      // quarantine marker stamped for B1.
+      expect(out.metadata.proposedByRole).toBe('member');
+    });
+
+    it('preserves an ADMIN’s asserted trust but still stamps identity, tenant, and marker', () => {
+      const out = applyIntakeOverrides(forged(), {
+        actor: 'adam',
+        role: 'admin',
+        tenants: ['team-secure'],
+      });
+      // admin keeps the asserted level (only member is forced low).
+      expect(out.trustLevel).toBe('high');
+      expect(out.author).toEqual({ type: 'human', id: 'adam' });
+      expect(out.tenantId).toBe('team-secure');
+      expect(out.prePolicyFlags.lowConfidence).toBe(false);
+      expect(out.metadata.proposedByRole).toBe('admin');
+    });
+
+    it('a scoped-multi token keeps the (guard-validated) supplied tenantId', () => {
+      const cand = makeCandidate({ tenantId: 'team-a' });
+      const out = applyIntakeOverrides(cand, {
+        actor: 'mo',
+        role: 'admin',
+        tenants: ['team-a', 'team-b'],
+      });
+      // Multi-tenant scope: the tenancy guard already validated 'team-a' is in the
+      // allowlist, so intake leaves it — it does not guess a single binding.
+      expect(out.tenantId).toBe('team-a');
+    });
+
+    it('an empty context (dev / direct intake) resets only the never-trusted flags', () => {
+      const cand = makeCandidate({
+        trustLevel: 'high',
+        author: { type: 'ai', id: 'claude-x' },
+        tenantId: 'team-x',
+        prePolicyFlags: { potentialSecret: false, lowConfidence: true, duplicateSuspect: true },
+      });
+      const out = applyIntakeOverrides(cand, {});
+      // No token identity → author / trust / tenant left as parsed …
+      expect(out.author).toEqual({ type: 'ai', id: 'claude-x' });
+      expect(out.trustLevel).toBe('high');
+      expect(out.tenantId).toBe('team-x');
+      // … but prePolicyFlags are ALWAYS server-owned, and no marker is stamped.
+      expect(out.prePolicyFlags).toEqual({
+        potentialSecret: false,
+        lowConfidence: false,
+        duplicateSuspect: false,
+      });
+      expect(out.metadata.proposedByRole).toBeUndefined();
+    });
+
+    it('returns a structurally valid MemoryCandidate (re-parsed)', () => {
+      const out = applyIntakeOverrides(forged(), {
+        actor: 'mia',
+        role: 'member',
+        tenants: ['team-secure'],
+      });
+      // Round-trips through the schema without throwing.
+      expect(() => MemoryCandidate.parse(out)).not.toThrow();
+    });
+  });
+
+  // ---- HTTP intake with per-user tokens -----------------------------------
+  describe('POST /api/candidates (authenticated)', () => {
+    const MEMBER = 'mia-member-token';
+    const ADMIN = 'adam-admin-token';
+
+    let db: Database.Database;
+    let app: FastifyInstance;
+    let candidateRepo: CandidateRepository;
+    let auditRepo: AuditRepository;
+
+    beforeEach(async () => {
+      db = createTestDatabase();
+      candidateRepo = new CandidateRepository(db);
+      auditRepo = new AuditRepository(db);
+      app = buildApp({
+        db,
+        silent: true,
+        tokens: [
+          { token: MEMBER, actor: 'mia', role: 'member', tenants: ['team-secure'] },
+          { token: ADMIN, actor: 'adam', role: 'admin', tenants: ['team-secure'] },
+        ],
+      });
+      await app.ready();
+    });
+
+    afterEach(async () => {
+      await app.close();
+      db.close();
+    });
+
+    const auth = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+    it('neutralizes a MEMBER’s forged trust / author / flags and stamps the receipt + marker', async () => {
+      const content = 'Use exponential backoff with jitter on the retry path.';
+      const id = randomUUID();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/candidates',
+        headers: auth(MEMBER),
+        payload: {
+          id,
+          status: 'inbox',
+          source: 'mcp',
+          content,
+          title: 'Retry backoff convention',
+          category: 'convention',
+          // ── all four forged, trust-bearing fields ──
+          trustLevel: 'high',
+          author: { type: 'ai', id: 'governed-brain' },
+          tenantId: 'team-secure',
+          prePolicyFlags: { potentialSecret: false, lowConfidence: true, duplicateSuspect: true },
+          metadata: { filePaths: [], tags: ['retry'] },
+          capturedAt: new Date().toISOString(),
+        },
+      });
+      expect(res.statusCode).toBe(201);
+
+      // The STORED candidate is fully server-owned.
+      const stored = candidateRepo.findById(id);
+      expect(stored).not.toBeNull();
+      expect(stored!.trustLevel).toBe('untrusted'); // server-forced low
+      expect(stored!.author).toEqual({ type: 'human', id: 'mia' }); // token identity
+      expect(stored!.tenantId).toBe('team-secure'); // bound to the token
+      expect(stored!.prePolicyFlags).toEqual({
+        potentialSecret: false,
+        lowConfidence: false,
+        duplicateSuspect: false,
+      }); // recomputed/reset
+      expect(stored!.metadata.proposedByRole).toBe('member'); // quarantine marker
+
+      // An intake receipt was written, anchored to the actor + candidate.
+      const receipts = auditRepo.findByTenantAndAction('team-secure', 'proposed');
+      expect(receipts).toHaveLength(1);
+      const receipt = receipts[0]!;
+      expect(receipt.memoryId).toBe(id);
+      expect(receipt.actor).toEqual({ type: 'human', id: 'mia' });
+      const details = receipt.details as Record<string, unknown>;
+      expect(details['candidateId']).toBe(id);
+      expect(details['contentHash']).toBe(computeContentHash(content));
+      expect(details['tenantId']).toBe('team-secure');
+      expect(details['proposedByRole']).toBe('member');
+    });
+
+    it('rejects a MEMBER naming a FOREIGN tenant (403, tenancy guard) — nothing stored', async () => {
+      const id = randomUUID();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/candidates',
+        headers: auth(MEMBER),
+        payload: makeCandidate({ id, tenantId: 'attacker-tenant' }),
+      });
+      expect(res.statusCode).toBe(403);
+      expect(candidateRepo.findById(id)).toBeNull();
+      expect(auditRepo.findByTenantAndAction('attacker-tenant', 'proposed')).toHaveLength(0);
+    });
+
+    it('an ADMIN keeps its asserted trust, is stamped as author, and marked admin', async () => {
+      const id = randomUUID();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/candidates',
+        headers: auth(ADMIN),
+        payload: makeCandidate({
+          id,
+          tenantId: 'team-secure',
+          trustLevel: 'high',
+          author: { type: 'ai', id: 'governed-brain' },
+        }),
+      });
+      expect(res.statusCode).toBe(201);
+
+      const stored = candidateRepo.findById(id);
+      expect(stored!.trustLevel).toBe('high'); // admin level preserved
+      expect(stored!.author).toEqual({ type: 'human', id: 'adam' }); // stamped
+      expect(stored!.metadata.proposedByRole).toBe('admin'); // marker
+
+      const receipts = auditRepo.findByTenantAndAction('team-secure', 'proposed');
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]!.actor).toEqual({ type: 'human', id: 'adam' });
+    });
+  });
+
+  // ---- dev no-auth path still writes a receipt (back-compat) ---------------
+  describe('POST /api/candidates (dev no-auth)', () => {
+    let db: Database.Database;
+    let app: FastifyInstance;
+    let candidateRepo: CandidateRepository;
+    let auditRepo: AuditRepository;
+
+    beforeEach(async () => {
+      db = createTestDatabase();
+      candidateRepo = new CandidateRepository(db);
+      auditRepo = new AuditRepository(db);
+      app = buildApp({ db, silent: true }); // empty registry → dev admin
+      await app.ready();
+    });
+
+    afterEach(async () => {
+      await app.close();
+      db.close();
+    });
+
+    it('stamps the dev actor + admin marker and writes an intake receipt', async () => {
+      const id = randomUUID();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/candidates',
+        payload: makeCandidate({ id, tenantId: 'team-dev', trustLevel: 'high' }),
+      });
+      expect(res.statusCode).toBe(201);
+
+      const stored = candidateRepo.findById(id);
+      expect(stored!.author).toEqual({ type: 'human', id: 'dev' });
+      expect(stored!.trustLevel).toBe('high'); // dev runs as admin — level kept
+      expect(stored!.metadata.proposedByRole).toBe('admin');
+
+      const receipts = auditRepo.findByTenantAndAction('team-dev', 'proposed');
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]!.actor).toEqual({ type: 'human', id: 'dev' });
+    });
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -126,7 +126,9 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   const batchRepo = new ImportBatchRepository(deps.db);
   const linksRepo = new MemoryLinksRepository(deps.db);
 
-  const candidateService = new CandidateService(candidateRepo);
+  // The candidate service takes the audit repo so every accepted intake writes a
+  // `proposed` provenance receipt (R8, compile-then-govern-jfv.6.7).
+  const candidateService = new CandidateService(candidateRepo, auditRepo);
   const memoryService = new MemoryService(memoryRepo, auditRepo);
   const policyService = new PolicyService(policyRepo);
   const healthService = new HealthService(deps.db);

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -28,7 +28,14 @@ export function registerCandidateRoutes(
     },
     async (request, reply) => {
       try {
-        const candidate = service.intake(request.body);
+        // Thread the bearer-token identity into intake so the server — not the
+        // client — owns author / trustLevel / tenantId / prePolicyFlags and the
+        // quarantine marker (R8, compile-then-govern-jfv.6.7).
+        const candidate = service.intake(request.body, {
+          actor: request.actor,
+          role: request.role,
+          tenants: request.tenants,
+        });
         return reply.status(201).send(candidate);
       } catch (err) {
         if (err instanceof ApiError) {

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -1,34 +1,155 @@
-import type { CandidateRepository } from '@qmd-team-intent-kb/store';
-import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { AuditRepository, CandidateRepository } from '@qmd-team-intent-kb/store';
+import { AuditEvent, MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import {
   computeContentHash,
+  deriveAuditEventId,
   scanDisclosureFields,
   collectFreeTextFields,
 } from '@qmd-team-intent-kb/common';
+import type { TokenRole } from '../auth/token-registry.js';
 import { badRequest, notFound, unprocessable } from '../errors.js';
+
+/**
+ * The bearer-token identity of the caller proposing a candidate. Resolved by the
+ * auth middleware onto the request (`request.actor` / `request.role` /
+ * `request.tenants`) and threaded into {@link CandidateService.intake} so the
+ * intake path can OVERRIDE the client-supplied trust-bearing fields server-side
+ * (R8, bead compile-then-govern-jfv.6.7).
+ *
+ * All fields are optional: dev no-auth intake and the direct-service unit tests
+ * pass an empty context, in which case the identity-derived overrides are no-ops
+ * (author/trust/tenant are left as parsed) but the never-trusted-from-client
+ * fields (prePolicyFlags) are still reset server-side.
+ */
+export interface IntakeActorContext {
+  /** Audit actor the bearer token belongs to (undefined in dev no-auth). */
+  actor?: string;
+  /** Role the token grants. A `member`'s asserted trust is never honored. */
+  role?: TokenRole;
+  /** Tenant allowlist bound to the token (undefined/empty = unscoped). */
+  tenants?: readonly string[];
+}
+
+/**
+ * Apply the R8 server-side intake overrides to a *parsed* candidate — the single
+ * place the brain refuses to trust a team-mode client for the trust-bearing
+ * fields (bead compile-then-govern-jfv.6.7).
+ *
+ * In team mode the CLIENT builds the entire `MemoryCandidate` and the server used
+ * to `safeParse` it and trust it verbatim. That let a member (or a leaked member
+ * token) assert `trustLevel:'high'`, forge `author`, name an arbitrary
+ * `tenantId`, and pre-clear `prePolicyFlags.potentialSecret:false`. Each override
+ * below re-derives one of those fields from the SERVER's token identity instead:
+ *
+ *  1. **author** ← the token identity (`{ type:'human', id: actor }`). Preserves
+ *     real provenance and neutralizes the client's hardcoded `governed-brain`
+ *     author, so proposals are no longer byte-identical in authorship.
+ *  2. **trustLevel** ← forced to the lowest level (`untrusted`) for a `member`.
+ *     `source-trust-rule` reads `candidate.trustLevel` verbatim, so an un-forced
+ *     `high` would clear a min-trust gate a member should never clear. An
+ *     admin/unknown role keeps its asserted level.
+ *  3. **tenantId** ← bound to the token's tenant when the token is scoped to
+ *     exactly one tenant. (For a scoped multi-tenant token the tenancy guard has
+ *     already validated the supplied tenantId is in-allowlist; an unscoped token
+ *     — the single-tenant team default — keeps the supplied value.) Defense in
+ *     depth beside the tenancy guard, which independently rejects a scoped
+ *     token's out-of-allowlist tenantId with 403 before intake runs.
+ *  4. **prePolicyFlags** ← reset to server defaults (all false). These are
+ *     advisory capture-time hints; the durable secret backstop is the disclosure
+ *     gate (rejects at 422 pre-insert) and the deterministic policy pipeline's
+ *     `secret_detection` rule (re-scans content at promotion, never reading this
+ *     flag). A client's self-asserted `potentialSecret:false` must never be
+ *     trusted, so the whole struct is server-owned.
+ *  5. **metadata.proposedByRole** ← stamped with the proposer's role so a future
+ *     auto-govern step (B1) can quarantine member-authored proposals behind admin
+ *     review. Marker only — the quarantine ENFORCEMENT is B1's job.
+ *
+ * The result is re-parsed through `MemoryCandidate` so the overridden object is
+ * guaranteed structurally valid (including the new `proposedByRole` enum).
+ */
+export function applyIntakeOverrides(
+  candidate: MemoryCandidate,
+  ctx: IntakeActorContext,
+): MemoryCandidate {
+  // (1) author ← token identity. Only when the caller is authenticated; dev
+  // no-auth / direct-unit intake (no actor) leaves the parsed author untouched.
+  const author =
+    ctx.actor !== undefined && ctx.actor.length > 0
+      ? { type: 'human' as const, id: ctx.actor }
+      : candidate.author;
+
+  // (2) trustLevel ← a member's asserted trust is never honored; force lowest.
+  const trustLevel = ctx.role === 'member' ? 'untrusted' : candidate.trustLevel;
+
+  // (3) tenantId ← bind to the token's sole tenant when scoped-single; otherwise
+  // keep the (guard-validated / unscoped) value.
+  const tenantId =
+    ctx.tenants !== undefined && ctx.tenants.length === 1 ? ctx.tenants[0]! : candidate.tenantId;
+
+  // (4) prePolicyFlags ← never trust client-set values; reset to server defaults.
+  const prePolicyFlags = { potentialSecret: false, lowConfidence: false, duplicateSuspect: false };
+
+  // (5) metadata.proposedByRole ← quarantine marker for B1, stamped from the role.
+  const metadata =
+    ctx.role !== undefined
+      ? { ...candidate.metadata, proposedByRole: ctx.role }
+      : candidate.metadata;
+
+  return MemoryCandidate.parse({
+    ...candidate,
+    author,
+    trustLevel,
+    tenantId,
+    prePolicyFlags,
+    metadata,
+  });
+}
 
 /**
  * Service layer for memory candidate intake and retrieval.
  * Validates all inputs with Zod before writing to the repository.
  */
 export class CandidateService {
-  constructor(private readonly repo: CandidateRepository) {}
+  /**
+   * @param repo       The candidate store (required).
+   * @param auditRepo  The append-only audit store. When present, every accepted
+   *                   intake writes a `proposed` provenance receipt (R8). Optional
+   *                   so the direct-service unit tests can construct a service
+   *                   without an audit sink; the HTTP app always wires it.
+   */
+  constructor(
+    private readonly repo: CandidateRepository,
+    private readonly auditRepo?: AuditRepository,
+  ) {}
 
   /**
-   * Validate and intake a new memory candidate.
-   * Computes the content hash and inserts the record.
+   * Validate, server-side-override, and intake a new memory candidate.
+   * Computes the content hash, inserts the record, and writes a provenance
+   * receipt.
+   *
+   * @param data  The raw (client-supplied) candidate payload.
+   * @param ctx   The bearer-token identity of the caller. Drives the R8 overrides
+   *              (author / trustLevel / tenantId / prePolicyFlags / proposedByRole).
+   *              Defaults to an empty context (dev no-auth / direct-unit intake),
+   *              where only the never-client-trusted fields are reset.
    *
    * @throws a 400 ApiError on invalid (mis-shaped) input.
    * @throws a 422 ApiError when the content violates the no-compensation /
    *   no-PII disclosure rule — the candidate is rejected before it can enter
    *   the inbox (bead `3iu.1`).
    */
-  intake(data: unknown): MemoryCandidate {
+  intake(data: unknown, ctx: IntakeActorContext = {}): MemoryCandidate {
     const parsed = MemoryCandidate.safeParse(data);
     if (!parsed.success) {
       throw badRequest(`Invalid candidate: ${parsed.error.message}`);
     }
-    const candidate = parsed.data;
+
+    // R8 (bead compile-then-govern-jfv.6.7): never trust the team-mode client for
+    // the trust-bearing fields. Re-derive author / trustLevel / tenantId /
+    // prePolicyFlags from the SERVER token identity and stamp the quarantine
+    // marker BEFORE the disclosure gate + insert, so what is scanned and stored is
+    // exactly the server-owned candidate.
+    const candidate = applyIntakeOverrides(parsed.data, ctx);
 
     // Disclosure gate: enforce the no-compensation / no-PII / no-secret rule at
     // the boundary so the API returns a clean 422 (the same gate is also enforced
@@ -36,23 +157,11 @@ export class CandidateService {
     // CandidateRepository.insert). The matched value is never echoed back
     // (PII non-leak).
     //
-    // R10 fix (010-AT-RISK · bead compile-then-govern-e06.3): the early-check
-    // scanned only a HAND-MAINTAINED subset (content/title/tags, later a few
-    // metadata fields), so a secret or PII hidden in any un-enumerated free-text
-    // surface slipped THIS boundary and only tripped the deeper repository choke
-    // point — a worse error surface, and a real leak the moment any path skips
-    // that backstop. The last-enumerated list still MISSED `tenantId` and the
-    // `author` free-text (`author.name`, `author.id`), both of which the backstop
-    // (`assertDisclosureClean`) and the govern-decision eval already scan — a
-    // known bypass.
-    //
-    // The fix (Gemini review, HIGH): derive the scanned set STRUCTURALLY via
-    // `collectFreeTextFields(candidate)` — the exact same walker the repository
-    // backstop uses. This scans every persisted free-text surface (content,
-    // title, tenantId, every tag, all ContentMetadata free-text, and the author
-    // free-text), skipping only enum-constrained fields by name. The early gate
-    // now covers EXACTLY the same fields as the backstop, so no un-enumerated
-    // free-text column can bypass it, and future schema additions are covered
+    // R10 fix (010-AT-RISK · bead compile-then-govern-e06.3): the scanned set is
+    // derived STRUCTURALLY via `collectFreeTextFields(candidate)` — the exact same
+    // walker the repository backstop uses — so every persisted free-text surface
+    // (content, title, tenantId, every tag, all ContentMetadata free-text, and the
+    // author free-text) is scanned and future schema additions are covered
     // automatically with no manual list to drift.
     const violation = scanDisclosureFields(collectFreeTextFields(candidate));
     if (violation !== null) {
@@ -69,7 +178,50 @@ export class CandidateService {
 
     const contentHash = computeContentHash(candidate.content);
     this.repo.insert(candidate, contentHash);
+
+    // R8 intake receipt: every accepted proposal gets a provenance receipt from
+    // byte one — actor + candidateId + contentHash + tenantId — so proposals are
+    // never anonymous and B1 has an auditable record before any promotion.
+    this.writeIntakeReceipt(candidate, contentHash, ctx);
+
     return candidate;
+  }
+
+  /**
+   * Write the append-only `proposed` audit event for an accepted candidate (R8).
+   * No-op when no audit sink is wired (direct-service unit tests). Reuses the
+   * existing {@link AuditEvent} shape + repo (not a parallel log); `memoryId`
+   * carries the candidate's UUID and the id is content-derived so a re-proposed
+   * identical candidate yields a reproducible receipt id across clones.
+   */
+  private writeIntakeReceipt(
+    candidate: MemoryCandidate,
+    contentHash: string,
+    ctx: IntakeActorContext,
+  ): void {
+    if (this.auditRepo === undefined) return;
+    const at = new Date().toISOString();
+    const actor =
+      ctx.actor !== undefined && ctx.actor.length > 0
+        ? { type: 'human' as const, id: ctx.actor }
+        : { type: 'system' as const, id: 'intake' };
+    const event = AuditEvent.parse({
+      id: deriveAuditEventId(candidate.id, 'proposed'),
+      action: 'proposed',
+      memoryId: candidate.id,
+      tenantId: candidate.tenantId,
+      actor,
+      reason: 'Candidate proposed to the governed inbox',
+      details: {
+        candidateId: candidate.id,
+        contentHash,
+        tenantId: candidate.tenantId,
+        proposedByRole: ctx.role ?? 'unknown',
+        at,
+      },
+      timestamp: at,
+    });
+    this.auditRepo.insert(event);
   }
 
   /**

--- a/packages/schema/src/__tests__/audit-event.test.ts
+++ b/packages/schema/src/__tests__/audit-event.test.ts
@@ -18,6 +18,7 @@ describe('AuditEvent', () => {
       'deleted',
       'searched',
       'exported',
+      'proposed',
     ] as const;
     for (const action of actions) {
       const result = AuditEvent.parse(makeAuditEvent({ action }));

--- a/packages/schema/src/__tests__/enums.test.ts
+++ b/packages/schema/src/__tests__/enums.test.ts
@@ -129,6 +129,7 @@ describe('AuditAction', () => {
     'searched',
     'exported',
     'eval-result',
+    'proposed',
   ];
   it.each(actions)('accepts "%s"', (val) => {
     expect(AuditAction.parse(val)).toBe(val);

--- a/packages/schema/src/common.ts
+++ b/packages/schema/src/common.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AuthorType, Confidence, Sensitivity } from './enums.js';
+import { AuthorType, Confidence, ProposerRole, Sensitivity } from './enums.js';
 
 /** UUID v4 string */
 export const Uuid = z.string().uuid();
@@ -53,5 +53,17 @@ export const ContentMetadata = z.object({
   confidence: Confidence.optional(),
   sensitivity: Sensitivity.optional(),
   tags: z.array(Tag).default([]),
+  /**
+   * The role of the token that proposed this candidate, stamped server-side at
+   * intake (R8, bead compile-then-govern-jfv.6.7). Never client-supplied — the
+   * intake path overwrites it from the bearer-token identity so a member cannot
+   * masquerade as an admin-authored proposal. A closed enum (`admin` | `member`),
+   * so the disclosure scanner and the enum-membership backstop treat it as
+   * closed-vocabulary. Optional/absent on legacy records and non-token (dev)
+   * intake; present on every token-authenticated proposal. Flows through
+   * promotion onto the curated memory so a later auto-govern step (B1) can
+   * quarantine member-authored content behind admin review.
+   */
+  proposedByRole: ProposerRole.optional(),
 });
 export type ContentMetadata = z.infer<typeof ContentMetadata>;

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -52,8 +52,25 @@ export const AuditAction = z.enum([
   // Evidence Bundle emission on a curation/promotion cycle (IEP unification
   // thesis, DR-010 Q3). Added for the eval-surface emit path (bead tr08.15/.17/.19).
   'eval-result',
+  // Candidate-intake receipt — a proposal enters the pre-governance inbox (R8,
+  // bead compile-then-govern-jfv.6.7). Written at intake so every candidate has a
+  // provenance receipt (actor + contentHash + tenant) from byte one, before any
+  // promotion. `memoryId` on this row is the candidate's UUID.
+  'proposed',
 ]);
 export type AuditAction = z.infer<typeof AuditAction>;
+
+/**
+ * The role of the token that PROPOSED a candidate (R8, bead
+ * compile-then-govern-jfv.6.7). Stamped server-side at intake onto
+ * {@link ContentMetadata.proposedByRole} so a downstream auto-govern step (B1)
+ * can quarantine member-authored proposals behind admin review rather than
+ * auto-promoting them. Mirrors the API token roles (`admin` | `member`); kept in
+ * the schema package so it is a durable, persisted vocabulary, not an API-only
+ * type. A closed enum so it is treated as closed-vocabulary (never free text).
+ */
+export const ProposerRole = z.enum(['admin', 'member']);
+export type ProposerRole = z.infer<typeof ProposerRole>;
 
 export const Confidence = z.enum(['high', 'medium', 'low']);
 export type Confidence = z.infer<typeof Confidence>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -8,6 +8,7 @@ export {
   PolicyRuleType,
   PolicyRuleAction,
   AuditAction,
+  ProposerRole,
   Confidence,
   Sensitivity,
   AuthorType,


### PR DESCRIPTION
## What

Server-side override at candidate intake so the brain no longer trusts the
team-mode client for the trust-bearing fields, plus a provenance receipt on
every proposal. Implements **R8 / Gate-1** from the 6-engineer review
(bead `compile-then-govern-jfv.6.7`).

In team mode the client (`governed-second-brain-plugin` `remote-server.ts`)
builds the entire `MemoryCandidate` and the API used to `safeParse` and trust
it verbatim. A member — or a leaked member token — could send:

- `trustLevel:'high'` (which `source-trust-rule` reads verbatim, clearing a
  min-trust gate),
- a forged `author` (the hardcoded `{type:'ai', id:'governed-brain'}`, so all
  six leaders' proposals were byte-identical in authorship),
- an arbitrary `tenantId`,
- `prePolicyFlags.potentialSecret:false`,

and the candidate-intake path wrote **no** audit event — proposals had no
provenance/receipt. This becomes P0 the moment B1 (auto-govern) ships.

## Why & decision rationale

The model proposes; the deterministic system owns durable state and control.
Letting the client set trust/identity/tenant is a direct violation at the
intake boundary. The server now re-derives each field from the **bearer-token
identity** instead of trusting the body.

- **Override in the service, keyed off the token identity** (chosen) — the
  identity already exists on the request (`request.actor/role/tenants`), so
  the fix is a pure function over the parsed candidate; testable in isolation.
- *Alternative — reject any candidate that asserts a non-default trust/author*
  (rejected): brittle and hostile to legitimate clients; the plugin always
  sends a full body, so we'd reject every real proposal. Overriding is
  transparent and forward-compatible.
- *Alternative — trim the client body to a minimal DTO* (rejected): a larger
  contract change across the plugin + API for no extra safety; the server
  override already neutralizes every field regardless of what the client sends.
- **prePolicyFlags: reset to server defaults** (chosen over recompute) — these
  flags are advisory capture-time hints; the durable secret backstop is the
  disclosure gate (422 pre-insert) and the policy pipeline's `secret_detection`
  rule (re-scans content at promotion, never reading this flag). So the honest
  move is to make the struct server-owned, not to trust a client's self-cleared
  `potentialSecret:false`.

## Layer(s) touched

- **Spool boundary (govern-adjacent intake)** — `apps/api` candidate service +
  route.
- **Store schema vocabulary** — `packages/schema` (additive enum values +
  one optional field).
- **Receipts/audit** — writes a new `proposed` event through the existing
  append-only `AuditRepository`.

**No cross-layer invariant changed.** This *hardens* the spool boundary and is
defense-in-depth beside the tenancy guard. Specifically:
- *Tenant isolation* — strengthened, not altered (the tenancy guard still
  independently 403s a scoped token's foreign tenant before intake).
- *Append-only hash-chained receipts* — respected (receipt written only via
  `AuditRepository.insert`).
- *Insert-only `candidates`* — respected (intake still inserts; no update/delete).
- *No model below the spool* — respected (pure deterministic overrides).

## How it works

- `applyIntakeOverrides(candidate, ctx)` (new, exported pure fn in
  `apps/api/src/services/candidate-service.ts`) re-derives, then re-parses:
  1. `author` ← `{type:'human', id: ctx.actor}` when authenticated;
  2. `trustLevel` ← forced `'untrusted'` for a `member` (admin keeps its level —
     lowest enum per `TrustLevel`);
  3. `tenantId` ← the token's sole tenant when scoped-single (a scoped-multi
     token's tenantId is already guard-validated; unscoped keeps the value);
  4. `prePolicyFlags` ← reset to all-`false`;
  5. `metadata.proposedByRole` ← `ctx.role` (the quarantine marker for B1).
- `CandidateService.intake(data, ctx)` applies the overrides **before** the
  disclosure gate + insert, then writes the receipt.
- `writeIntakeReceipt(...)` appends a `proposed` `AuditEvent`
  `{ actor, memoryId=candidateId, tenantId, details:{ candidateId, contentHash,
  tenantId, proposedByRole, at } }` via the injected `AuditRepository`
  (content-derived id → reproducible across clones).
- `routes/candidates.ts` threads `{actor, role, tenants}` from the request;
  `app.ts` injects the `auditRepo`.
- Schema: `AuditAction` gains `'proposed'`; new `ProposerRole` enum; new
  optional `ContentMetadata.proposedByRole` (stored in the existing
  `metadata_json` blob — no DDL).

## Verification & evidence

- [x] **Unit/integration test run** — new suite
  `apps/api/src/__tests__/candidate-override.test.ts` (**9/9**): member forgery
  neutralized (trust→`untrusted`, author→actor, tenant bound, flags reset,
  marker `member`, receipt written); foreign tenant → 403 + nothing stored;
  admin keeps asserted trust + marker `admin`; dev no-auth writes a receipt;
  pure `applyIntakeOverrides` incl. forged-tenant binding, scoped-multi, and
  empty-context cases.
- [x] Full **`apps/api`** suite green after the change; broader run
  **1976/1976** across api + schema + store + common + policy-engine + curator +
  the rest of the workspace (`pnpm test`).
- [x] **`pnpm typecheck`** (tsc -b) clean · **`pnpm lint`** (eslint .) clean ·
  **`pnpm format:check`** clean.
- [x] **Coverage gate** (`pnpm test:coverage`) passes: statements 88.95%,
  branches 81.56%, functions 88.93%, lines 89.74% (all above thresholds).

## Risk assessment

| Question | Answer |
|---|---|
| What could this break? | Nothing beyond the intake path — a client that *relied on* its forged trust/author/tenant/flags being honored now has them overridden. That is the intended tightening. |
| Backward compatible? | Yes. Schema additions are additive/optional; legacy candidates without `proposedByRole` parse unchanged. Dev no-auth + existing tenancy/candidate/promote tests all still pass. |
| User-facing or internal? | Internal control-plane (team-mode brain API); no end-user UI. |
| Public API/contract change? | Request contract unchanged (same body accepted). Response now reflects server-owned fields + `metadata.proposedByRole`. OpenAPI component/route/tag inventory unchanged (contract snapshot stable). |

## Operational impact

- New environment variables? **None.**
- Schema migrations? **None** — `proposedByRole` lives in the existing
  `metadata_json` blob; `audit_events.action` has no CHECK/FK, so `proposed`
  needs no DDL.
- New dependencies? **None.**
- Cost implications? **None.**
- New permissions/secrets? **None.**
- Deployment order? **None** — no data migration; deploy code as-is. (Existing
  `candidates` rows simply have no `proposedByRole`; new proposals carry it.)

## Follow-up & deferred

- **B1 (auto-govern remote inbox)** will *enforce* the quarantine: this PR
  ships only the `proposedByRole` marker; B1 gates member-authored candidates
  behind admin review rather than auto-promoting them (bead
  `compile-then-govern-jfv.6.7` scope note → B1 track).
- No new beads required — no work was intentionally cut from R8's scope.

## Governance links

- PR standard: `governed-second-brain` `000-docs/013-OD-STND`.
- Architecture / spool-boundary + insert-only `candidates`:
  `000-docs/005-AT-ARCH`.
- Bead: `compile-then-govern-jfv.6.7` (R8 / Gate-1, 6-engineer review).

## Refs / Beads

Refs bead `compile-then-govern-jfv.6.7`.

- Jeremy Longshore
intentsolutions.io
