### PR TITLE
feat(curator): wrap promote() writes in one transaction — atomic receipts (R9 / jfv.6.9)

### DIFF
--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -247,6 +247,82 @@ describe('promote', () => {
     expect(supersededEvent?.tenantId).toBe(TENANT);
   });
 
+  // ── R9: promote() is atomic (all-or-nothing) ────────────────────────────────
+  // The whole write block runs in ONE `db.transaction(...).immediate()`, so a
+  // crash partway (the cron `timeout 1800`, or a SIGTERM) can NEVER leave a
+  // promoted memory without its 'promoted' receipt — a durable row without a
+  // receipt would violate the product's append-only-receipts promise and never
+  // self-heal. We simulate the crash by making the 'promoted' audit insert throw
+  // AFTER the memory row is already inserted (the exact orphan window).
+  it('atomicity: a crash before the promoted receipt rolls the memory back — no orphan', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memoryId = deriveMemoryId(candidate.id, contentHash);
+
+    const realInsert = auditRepo.insert.bind(auditRepo);
+    vi.spyOn(auditRepo, 'insert').mockImplementation((event) => {
+      if (event.action === 'promoted') {
+        throw new Error('simulated crash before the promoted receipt');
+      }
+      return realInsert(event);
+    });
+
+    expect(() =>
+      promote(
+        { candidate, contentHash, pipelineResult: makePipelineResult() },
+        memoryRepo,
+        auditRepo,
+      ),
+    ).toThrow(/simulated crash before the promoted receipt/);
+
+    // NEITHER the memory NOR any partial audit event survives.
+    expect(memoryRepo.findById(memoryId)).toBeNull();
+    expect(memoryRepo.count()).toBe(0);
+    expect(auditRepo.findByMemory(memoryId)).toHaveLength(0);
+  });
+
+  it('atomicity: a crash in a supersession promote also rolls back the earlier superseded event + old-memory update', () => {
+    const old = makeCuratedMemory({ title: 'Error handling guide', category: 'convention' });
+    memoryRepo.insert(old);
+
+    const candidate = makeCandidate({ title: 'Error handling guide v4', category: 'convention' });
+    const contentHash = computeContentHash(candidate.content);
+    const memoryId = deriveMemoryId(candidate.id, contentHash);
+    const supersession = {
+      supersededMemoryId: old.id,
+      supersededTitle: old.title,
+      similarity: 0.9,
+    };
+
+    const realInsert = auditRepo.insert.bind(auditRepo);
+    vi.spyOn(auditRepo, 'insert').mockImplementation((event) => {
+      if (event.action === 'promoted') {
+        throw new Error('simulated crash before the promoted receipt');
+      }
+      return realInsert(event);
+    });
+
+    expect(() =>
+      promote(
+        { candidate, contentHash, pipelineResult: makePipelineResult(), supersession },
+        memoryRepo,
+        auditRepo,
+      ),
+    ).toThrow(/simulated crash before the promoted receipt/);
+
+    // The new memory never lands.
+    expect(memoryRepo.findById(memoryId)).toBeNull();
+    // The old memory's active→superseded update — written EARLIER in the same
+    // transaction — is undone: it is still 'active' with no supersession link.
+    const oldAfter = memoryRepo.findById(old.id);
+    expect(oldAfter?.lifecycle).toBe('active');
+    expect(oldAfter?.supersession).toBeUndefined();
+    // The 'superseded' audit event (also written before the throw) is rolled back.
+    expect(auditRepo.findByMemory(old.id).some((e) => e.action === 'superseded')).toBe(false);
+    // Only the original memory remains — nothing partial.
+    expect(memoryRepo.count()).toBe(1);
+  });
+
   it('dry run does not insert memory into store', () => {
     const candidate = makeCandidate();
     const contentHash = computeContentHash(candidate.content);

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -139,144 +139,160 @@ export function promote(
   });
 
   if (!dryRun) {
-    if (input.supersession !== undefined) {
-      const oldMemory = memoryRepo.findById(input.supersession.supersededMemoryId);
-      if (oldMemory !== null) {
-        const updatedOld = CuratedMemorySchema.parse({
-          ...oldMemory,
-          lifecycle: 'superseded',
-          supersession: {
-            supersededBy: memoryId,
-            reason: `Title similarity: ${input.supersession.similarity.toFixed(2)}`,
-            linkedAt: now,
-          },
-          updatedAt: now,
-        });
-        memoryRepo.update(updatedOld);
-      }
-
-      auditRepo.insert(
-        AuditEventSchema.parse({
-          // Content-derived (bead 8da.5): identity is the superseded memory +
-          // the 'superseded' action + the superseding memory id as discriminator,
-          // so two clones supersede-by-the-same-memory mint the same audit id and
-          // hence the same v2 entry_hash at the same chain position.
-          id: deriveAuditEventId(input.supersession.supersededMemoryId, 'superseded', memoryId),
-          action: 'superseded',
-          memoryId: input.supersession.supersededMemoryId,
-          tenantId: input.candidate.tenantId,
-          actor: { type: 'system', id: 'curator' },
-          reason: `Superseded by ${memoryId}`,
-          details: {
-            newMemoryId: memoryId,
-            similarity: input.supersession.similarity,
-          },
-          timestamp: now,
-        }),
-      );
-    }
-
-    memoryRepo.insert(memory);
-
-    if (input.supersession !== undefined && linksRepo) {
-      linksRepo.insert({
-        // Content-derived (bead 8da.5): a graph edge's identity is its
-        // (source, target, type) triple, stable across clones for the same
-        // logical promotion. Not part of the audit chain, but kept deterministic
-        // so the whole promotion is byte-reproducible across clones.
-        id: deriveLinkId(memoryId, input.supersession.supersededMemoryId, 'supersedes'),
-        sourceMemoryId: memoryId,
-        targetMemoryId: input.supersession.supersededMemoryId,
-        linkType: 'supersedes',
-        weight: input.supersession.similarity,
-        createdBy: 'curator',
-        source: 'curator',
-        importBatchId: null,
-        createdAt: now,
-      });
-    }
-
-    // Extract wiki-links from content and create relates_to edges
-    if (linksRepo) {
-      const wikiLinks = extractWikiLinks(input.candidate.content);
-      for (const wl of wikiLinks) {
-        const targets = memoryRepo.searchByText(wl.slug);
-        const match = targets.find(
-          (m) => m.title.toLowerCase() === wl.slug.toLowerCase() && m.id !== memoryId,
-        );
-        if (match) {
-          try {
-            linksRepo.insert({
-              // Content-derived (bead 8da.5): (source, target, type) edge identity,
-              // stable across clones. See the supersedes edge above.
-              id: deriveLinkId(memoryId, match.id, 'relates_to'),
-              sourceMemoryId: memoryId,
-              targetMemoryId: match.id,
-              linkType: 'relates_to',
-              weight: 1.0,
-              createdBy: 'curator',
-              source: 'curator',
-              importBatchId: null,
-              createdAt: now,
+    // R9 (jfv.6.9): commit ALL durable writes of one promotion as a SINGLE
+    // transaction — the optional supersession update + its 'superseded' event,
+    // the memory insert, the graph-edge links, the 'promoted' receipt, and any
+    // eval-result events. Previously these ran as ~5 separate autocommits, so a
+    // kill mid-promote (the cron `timeout 1800`, or a SIGTERM) could persist a
+    // promoted memory with NO 'promoted' audit event — a durable row without its
+    // receipt, which breaks the append-only-receipts promise and never
+    // self-heals. All-or-nothing means a crash rolls the memory back too, so the
+    // store is never left in that receipt-less state. Run as `.immediate()`
+    // (BEGIN IMMEDIATE) so the write lock is taken upfront, preserving
+    // AuditRepository's anti-fork guarantee — its nested `appendTxn` degrades to
+    // a savepoint inside this outer transaction (bead yxp).
+    memoryRepo.connection
+      .transaction((): void => {
+        if (input.supersession !== undefined) {
+          const oldMemory = memoryRepo.findById(input.supersession.supersededMemoryId);
+          if (oldMemory !== null) {
+            const updatedOld = CuratedMemorySchema.parse({
+              ...oldMemory,
+              lifecycle: 'superseded',
+              supersession: {
+                supersededBy: memoryId,
+                reason: `Title similarity: ${input.supersession.similarity.toFixed(2)}`,
+                linkedAt: now,
+              },
+              updatedAt: now,
             });
-          } catch {
-            // Unique constraint violation — link already exists, skip
+            memoryRepo.update(updatedOld);
           }
-        }
-      }
-    }
 
-    auditRepo.insert(
-      AuditEventSchema.parse({
-        // Content-derived (bead 8da.5): one 'promoted' event per memory, so the
-        // (memoryId, action) pair is already unique, so no discriminator needed.
-        id: deriveAuditEventId(memoryId, 'promoted'),
-        action: 'promoted',
-        memoryId,
-        tenantId: input.candidate.tenantId,
-        actor: { type: 'system', id: 'curator' },
-        reason: 'Passed all governance rules',
-        details: { candidateId: input.candidate.id },
-        timestamp: now,
-      }),
-    );
-
-    // Evidence emission (DR-010 Q3 unification thesis): if an eval callback is
-    // supplied, run it and write each verdict as an `eval-result` audit event.
-    // The audit chain SHA-256-chains these rows, making them tamper-evident and
-    // signable downstream. Contained by design — a throwing/faulty callback must
-    // NOT abort a promotion whose memory is already persisted; failures are
-    // swallowed here (the memory + 'promoted' event stand regardless).
-    if (evalCallback !== undefined) {
-      try {
-        for (const verdict of evalCallback(memory, input.pipelineResult)) {
           auditRepo.insert(
             AuditEventSchema.parse({
-              // Content-derived (bead 8da.5): several eval-result rows can be
-              // emitted per promotion, so the evaluator name discriminates them.
-              // Identical evaluator verdicts on two clones mint the same id.
-              id: deriveAuditEventId(memoryId, 'eval-result', verdict.name),
-              action: 'eval-result',
-              memoryId,
+              // Content-derived (bead 8da.5): identity is the superseded memory +
+              // the 'superseded' action + the superseding memory id as discriminator,
+              // so two clones supersede-by-the-same-memory mint the same audit id and
+              // hence the same v2 entry_hash at the same chain position.
+              id: deriveAuditEventId(input.supersession.supersededMemoryId, 'superseded', memoryId),
+              action: 'superseded',
+              memoryId: input.supersession.supersededMemoryId,
               tenantId: input.candidate.tenantId,
               actor: { type: 'system', id: 'curator' },
-              reason: `eval ${verdict.name}: ${verdict.passed ? 'pass' : 'fail'}`,
+              reason: `Superseded by ${memoryId}`,
               details: {
-                evaluator: verdict.name,
-                passed: verdict.passed,
-                score: verdict.score,
-                threshold: verdict.threshold,
-                ...verdict.details,
+                newMemoryId: memoryId,
+                similarity: input.supersession.similarity,
               },
               timestamp: now,
             }),
           );
         }
-      } catch {
-        // Eval emission is best-effort; the promotion itself has already
-        // succeeded. Do not let an eval-surface fault corrupt the curation path.
-      }
-    }
+
+        memoryRepo.insert(memory);
+
+        if (input.supersession !== undefined && linksRepo) {
+          linksRepo.insert({
+            // Content-derived (bead 8da.5): a graph edge's identity is its
+            // (source, target, type) triple, stable across clones for the same
+            // logical promotion. Not part of the audit chain, but kept deterministic
+            // so the whole promotion is byte-reproducible across clones.
+            id: deriveLinkId(memoryId, input.supersession.supersededMemoryId, 'supersedes'),
+            sourceMemoryId: memoryId,
+            targetMemoryId: input.supersession.supersededMemoryId,
+            linkType: 'supersedes',
+            weight: input.supersession.similarity,
+            createdBy: 'curator',
+            source: 'curator',
+            importBatchId: null,
+            createdAt: now,
+          });
+        }
+
+        // Extract wiki-links from content and create relates_to edges
+        if (linksRepo) {
+          const wikiLinks = extractWikiLinks(input.candidate.content);
+          for (const wl of wikiLinks) {
+            const targets = memoryRepo.searchByText(wl.slug);
+            const match = targets.find(
+              (m) => m.title.toLowerCase() === wl.slug.toLowerCase() && m.id !== memoryId,
+            );
+            if (match) {
+              try {
+                linksRepo.insert({
+                  // Content-derived (bead 8da.5): (source, target, type) edge identity,
+                  // stable across clones. See the supersedes edge above.
+                  id: deriveLinkId(memoryId, match.id, 'relates_to'),
+                  sourceMemoryId: memoryId,
+                  targetMemoryId: match.id,
+                  linkType: 'relates_to',
+                  weight: 1.0,
+                  createdBy: 'curator',
+                  source: 'curator',
+                  importBatchId: null,
+                  createdAt: now,
+                });
+              } catch {
+                // Unique constraint violation — link already exists, skip
+              }
+            }
+          }
+        }
+
+        auditRepo.insert(
+          AuditEventSchema.parse({
+            // Content-derived (bead 8da.5): one 'promoted' event per memory, so the
+            // (memoryId, action) pair is already unique, so no discriminator needed.
+            id: deriveAuditEventId(memoryId, 'promoted'),
+            action: 'promoted',
+            memoryId,
+            tenantId: input.candidate.tenantId,
+            actor: { type: 'system', id: 'curator' },
+            reason: 'Passed all governance rules',
+            details: { candidateId: input.candidate.id },
+            timestamp: now,
+          }),
+        );
+
+        // Evidence emission (DR-010 Q3 unification thesis): if an eval callback is
+        // supplied, run it and write each verdict as an `eval-result` audit event.
+        // The audit chain SHA-256-chains these rows, making them tamper-evident and
+        // signable downstream. Contained by design — a throwing/faulty callback must
+        // NOT abort a promotion whose memory is already persisted; failures are
+        // swallowed here (the memory + 'promoted' event stand regardless).
+        if (evalCallback !== undefined) {
+          try {
+            for (const verdict of evalCallback(memory, input.pipelineResult)) {
+              auditRepo.insert(
+                AuditEventSchema.parse({
+                  // Content-derived (bead 8da.5): several eval-result rows can be
+                  // emitted per promotion, so the evaluator name discriminates them.
+                  // Identical evaluator verdicts on two clones mint the same id.
+                  id: deriveAuditEventId(memoryId, 'eval-result', verdict.name),
+                  action: 'eval-result',
+                  memoryId,
+                  tenantId: input.candidate.tenantId,
+                  actor: { type: 'system', id: 'curator' },
+                  reason: `eval ${verdict.name}: ${verdict.passed ? 'pass' : 'fail'}`,
+                  details: {
+                    evaluator: verdict.name,
+                    passed: verdict.passed,
+                    score: verdict.score,
+                    threshold: verdict.threshold,
+                    ...verdict.details,
+                  },
+                  timestamp: now,
+                }),
+              );
+            }
+          } catch {
+            // Eval emission is best-effort; the promotion itself has already
+            // succeeded. Do not let an eval-surface fault corrupt the curation path.
+          }
+        }
+      })
+      .immediate();
   }
 
   return memory;

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -275,6 +275,22 @@ export class MemoryRepository {
     `);
   }
 
+  /**
+   * The underlying better-sqlite3 connection this repository was built on.
+   *
+   * Exposed read-only so a caller that writes across SEVERAL repositories on the
+   * SAME connection — the curator's `promote()`, which touches curated_memories,
+   * audit_events, and memory_links — can wrap all of those writes in ONE
+   * transaction (all-or-nothing). Every repository constructed from a single
+   * `createDatabase()` (as govern.ts / the daemon / the plugin do) shares this
+   * exact handle, so a transaction opened here serializes every repo's writes on
+   * the connection. Do not use it to bypass a repository's prepared statements —
+   * it exists only to own a multi-repository transaction.
+   */
+  get connection(): Database.Database {
+    return this.db;
+  }
+
   /** Insert a new curated memory. */
   insert(memory: CuratedMemory): void {
     this.stmtInsert.run({


### PR DESCRIPTION
## What

The curator's `promote()` non-dry-run path now commits **all** of its durable writes as a **single `better-sqlite3` transaction** — the optional supersession update + its `superseded` event, the memory insert, the graph-edge links, the `promoted` receipt, and any `eval-result` events. It runs as `.immediate()` (BEGIN IMMEDIATE). To reach the shared connection without changing the `Curator`'s public dependency API, `MemoryRepository` gains a read-only `connection` getter; `promote()` derives the transaction from the `memoryRepo` it already receives, so **no caller signature changed** (`curator.ts`, `merge-gate.ts`, and the plugin's `govern.ts` are untouched).

## Why & decision rationale

`promote()` did ~5 separate autocommits: (supersede-update + `superseded` event), then the memory insert, links, then the `promoted` event. A kill mid-promote — the compile cron's `timeout 1800`, or a SIGTERM — could leave a **promoted memory with NO `promoted` audit event**: a durable `curated_memories` row without its receipt. That violates the product's core append-only-receipts promise and never self-heals. `brain_transition` already used `db.transaction`; `promote()` was the straggler.

**Alternative considered: thread a raw `db` handle through the `Curator` constructor down to `promote()`.** Rejected — that changes the `Curator`'s public dependency API (`CuratorDependencies`), which must stay stable, and forces every construction site (including the plugin's `govern.ts`) to supply a `db` the `Curator` otherwise never needs. Exposing the already-shared connection via a read-only getter keeps every caller untouched and is the smaller, lower-blast-radius change. Ran `.immediate()` rather than the default deferred so the write lock is taken upfront — preserving `AuditRepository`'s anti-fork guarantee (its nested `appendTxn` BEGIN IMMEDIATE degrades to a savepoint inside the outer transaction; bead `yxp`).

## Layer(s) touched

Below the spool — **govern** (curator promotion) + **store** (`MemoryRepository`). It **preserves** the **append-only hash-chained receipts** invariant by making the receipt write atomic with the memory write (previously they could diverge). No other cross-layer invariant changed — no touch to spool UUIDs, `candidates` (still insert-only), tenant isolation, or promotion logic/ordering; the audit content is byte-identical (the transaction is a durability wrapper, not a content change). No AT-DECR needed — this strengthens the named invariant, it does not alter it.

## How it works

`MemoryRepository` exposes `get connection(): Database.Database` (all repos built from one `createDatabase()` share this handle). In `promote()`, the whole `if (!dryRun) { ... }` write block is wrapped in `memoryRepo.connection.transaction((): void => { ... }).immediate()`. Nested `auditRepo.insert()` calls (each an `appendTxn.immediate()`) become savepoints inside the outer transaction, so the prev-hash read + insert stay atomic and the outer BEGIN IMMEDIATE holds the write lock for the whole promotion. The eval-callback `try/catch` stays *inside* the transaction, so a faulty eval still can't abort a promotion whose memory + `promoted` receipt already committed together (unchanged best-effort semantics). Load-bearing: `apps/curator/src/promotion/promoter.ts` (the wrap), `packages/store/src/repositories/memory-repository.ts` (the getter).

## Verification & evidence

- [x] **Atomicity tests (new, `apps/curator/src/__tests__/promoter.test.ts`)** — (1) a `promoted`-insert throw AFTER the memory insert leaves **NEITHER** the memory (`findById` null, `count()===0`) **NOR** any partial audit event (`findByMemory` length 0); (2) in the supersession path, the earlier `superseded` event **and** the old-memory `active→superseded` update also roll back (old memory stays `active`, no `superseded` event, `count()===1`).
- [x] **Negative control** — with the transaction bypassed (patched to a plain IIFE), **both atomicity tests FAIL** (memory orphaned); with the transaction, both pass. So the tests catch the real regression, not a tautology.
- [x] **Suites** — curator **260/260** (promoter 28/28), api **304/304**, store **215/215**.
- [x] **Gates** — `tsc -b` clean, `eslint .` clean, `prettier --check` clean, `depcruise` 0 errors, `crap` OK (0 over threshold), `harness-pin` OK.

CI on this PR (`validate` + integration + `gitleaks`/`semgrep`) is the authoritative rerun.

## Risk assessment

- **What could break?** Only the promotion write path. The `.immediate()` transaction takes the write lock slightly earlier and holds it for the whole promotion (microseconds of SQLite work); `merge-gate.ts` calls `promote()` in a loop with no outer transaction, so each survivor write simply becomes its own atomic unit — an improvement, no nesting conflict.
- **Backward compatible?** Yes. Same public signatures, same committed rows and audit content on the happy path; the only behavioral change is that a *failed* promote now rolls back cleanly instead of leaving an orphan.
- **User-facing or internal?** Internal — deterministic govern kernel; no user-visible surface change.
- **Public API / contract change?** No endpoint/schema/tool change. Additive only: a new read-only `MemoryRepository.connection` getter.

## Operational impact

- **New dependencies:** none (`db.transaction` is already better-sqlite3). No lockfile change.
- No env vars, no schema migration, no cost change, no secrets, no deploy-order constraint. The daemon/api/plugin pick up the atomic promote on their next build against this INTKB — no data migration, no paired step.

## Follow-up & deferred

None. The change is self-contained; the merge-fold path (`merge-gate.ts`) wrapping its whole loop in one transaction is a separate, pre-existing design choice out of R9's scope (each promote is now individually atomic regardless).

## Governance links

6-engineer review Gate-1 finding **R9** (concurrency/atomicity); contrast with `brain_transition` (already `db.transaction`); bead `yxp` (the audit chain's seq-ordering + BEGIN IMMEDIATE anti-fork guarantee this preserves); commit/PR standard `013-OD-STND`.

## Refs

Refs jeremylongshore/qmd-team-intent-kb · Beads: `compile-then-govern-jfv.6.9` (wrap curator `promote()` in a transaction).

- Jeremy Longshore
intentsolutions.io
