### PR TITLE
chore(greptile): add repo-tailored .greptile review config (INTKB)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,62 @@
+{
+  "strictness": 3,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": true,
+  "fixWithAI": true,
+  "confidenceScoreSection": { "included": true },
+  "sequenceDiagramSection": { "included": true },
+  "ignorePatterns": "node_modules/\ndist/\nbuild/\ncoverage/\n*.min.js\n*.map\n*.tsbuildinfo\npnpm-lock.yaml\npackage-lock.json\n.audit-harness/\nkb-export/\nqmd-index/\n.beads/",
+  "rules": [
+    {
+      "id": "deterministic-govern-no-model-below-spool",
+      "severity": "high",
+      "scope": ["packages/policy-engine/**", "apps/curator/src/promotion/**", "packages/store/**"],
+      "rule": "The spool is the trust boundary. BELOW it — the `packages/policy-engine` pipeline, `apps/curator/src/promotion` promotion, and every audit write in `packages/store` — is DETERMINISTIC: no LLM inference. The 8-rule PolicyPipeline (content-length, content-sanitization, dedup-check, relevance-score, secret-detection, sensitivity-gate, source-trust, tenant-match) is pattern/heuristic logic — `scanForSecrets` is regex-based even though it imports from `@qmd-team-intent-kb/claude-runtime`. Flag any diff that introduces a real model-inference or network call (anthropic / openai / messages.create / generateText / an LLM `fetch`) into the policy engine, the promoter, or the audit path, or that lets the model own durable state, policy, promotion, or audit writes. The model proposes; deterministic code disposes."
+    },
+    {
+      "id": "promote-and-receipt-atomic",
+      "severity": "high",
+      "scope": ["apps/curator/src/promotion/promoter.ts", "packages/store/**"],
+      "rule": "A promotion writes the `curated_memories` row AND its hash-chained `audit_events` receipt; the two MUST be committed atomically (one transaction). A memory promoted without its receipt — or a receipt without the memory — breaks the audit guarantee. Flag any change that un-atomizes `promote()` by splitting the memory write and the receipt write into separate non-transactional steps, or that reorders them so a mid-write failure can leave one without the other."
+    },
+    {
+      "id": "candidates-insert-only-source-of-truth",
+      "severity": "high",
+      "scope": ["packages/store/**", "apps/curator/src/intake/**", "apps/api/src/**"],
+      "rule": "The `candidates` table is insert-only, Tier-A source of truth (005-AT-ARCH): the immutable record of what was proposed, and remote captures live nowhere else. A diff that DELETEs candidates, UPDATEs a candidate row in place, or retires flagged/rejected captures destructively must justify against that classification. Retirement is marker-based — keep flagged/rejected rows for admin review (the intake `proposed`/`inbox` receipt path, R8), never a hard delete."
+    },
+    {
+      "id": "receipts-append-only-never-rehash",
+      "severity": "high",
+      "scope": ["packages/store/audit-*.ts", "packages/store/src/**"],
+      "rule": "`audit_events` are append-only and SHA-256 hash-chained (`entry_hash` / `prev_entry_hash`). NEVER suggest re-hashing the chain, editing or deleting past events, or 'fixing' the 155 carried CHAIN_FORK breaks by re-hashing — ratified decision D5: those forks are benign same-timestamp ordering, every hash is intact. New writes append; the chain IS the tamper record. `brain_audit_verify` / audit-verify returning ok:false means REAL tamper — investigate, never migrate the chain."
+    },
+    {
+      "id": "tokens-hashed-at-rest",
+      "severity": "high",
+      "scope": ["apps/api/src/auth/**", "apps/api/src/**"],
+      "rule": "Brain API bearer tokens are scrypt-hashed at rest (`~/.teamkb/tokens.json`). `InMemoryTokenRegistry` accepts an already-salted `scrypt$salt$hash` record verbatim (via `parseStoredHash`) so no plaintext bearer secret ever lands on disk — any backup of `~/.teamkb` would otherwise leak live tokens. Never suggest storing a plaintext bearer secret, logging a token, or reverting the accept-pre-hashed path. No plaintext secret in any committed file."
+    },
+    {
+      "id": "immutable-release-floor",
+      "severity": "medium",
+      "scope": ["scripts/deploy-brain-api.sh", "apps/api/**", "000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md"],
+      "rule": "The brain API runs from an immutable, versioned release (`$TEAMKB_API_OPT/current -> releases/<tag>`), never Jeremy's working tree. The release floor is tag v0.8.0 (contains E1 commit `a2143be`). Never suggest deploying a ref that lacks `a2143be` — a pre-E1 build double-hashes the now-hashed `tokens.json` and locks out every user (041-OD-OPSM) — or reverting to a run-from-working-tree deploy. Rollback is a symlink flip to a prior release; note that after the live token reseed a plain code revert also requires reseeding `tokens.json` in the same step."
+    },
+    {
+      "id": "no-gate-weakening",
+      "severity": "high",
+      "rule": "The required CI checks are the deterministic merge gate: `ci.yml` `validate` (pnpm lint + typecheck + test-with-coverage / Codecov), the `security.yml` jobs (gitleaks, Semgrep SAST, dependency audit / CodeQL), and `docs-quality.yml` (markdownlint). Never suggest lowering a coverage threshold, skipping / deleting / weakening a test or assertion, or disabling a security / typecheck / policy check — unless the same PR replaces it with a strictly stronger equivalent."
+    },
+    {
+      "id": "honesty-invariants",
+      "severity": "high",
+      "rule": "NEVER introduce or accept the words tamper-proof / immutable / non-repudiation (for local mode) / blockchain as product claims — in code, comments, strings, or docs. The audit chain is tamper-EVIDENT only: integrity + ordering + rewrite-detection. Keep 'tamper-evident'. Flag any diff that softens the honesty framing or overclaims what a receipt proves; local mode does not, on its own, prove WHO wrote what (cross-actor attribution needs the pushed anchor + per-actor signatures)."
+    },
+    {
+      "id": "commit-pr-standard",
+      "severity": "medium",
+      "rule": "PRs follow 013-OD-STND (commit/branch/PR conventions): What / Why + decision rationale (chose X over Y because Z) / Layer(s) touched + any cross-layer invariant changed / Verification & evidence (linked artifact, not a bare 'verified') / Risk assessment / Operational impact / Follow-up & deferred (each with a bead) / Refs. Flag a non-trivial PR missing the Layer(s)-touched declaration or the evidence link, and any bare `fix`/`update` subject."
+    }
+  ]
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -40,7 +40,11 @@
     {
       "id": "immutable-release-floor",
       "severity": "medium",
-      "scope": ["scripts/deploy-brain-api.sh", "apps/api/**", "000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md"],
+      "scope": [
+        "scripts/deploy-brain-api.sh",
+        "apps/api/**",
+        "000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md"
+      ],
       "rule": "The brain API runs from an immutable, versioned release (`$TEAMKB_API_OPT/current -> releases/<tag>`), never Jeremy's working tree. The release floor is tag v0.8.0 (contains E1 commit `a2143be`). Never suggest deploying a ref that lacks `a2143be` — a pre-E1 build double-hashes the now-hashed `tokens.json` and locks out every user (041-OD-OPSM) — or reverting to a run-from-working-tree deploy. Rollback is a symlink flip to a prior release; note that after the live token reseed a plain code revert also requires reseeding `tokens.json` in the same step."
     },
     {

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,40 @@
+{
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "description": "The repo's operating contract: a governed team-memory control plane where DETERMINISTIC code (not LLM judgment) decides what becomes durable memory; qmd is the retrieval edge; git is a mirror/export layer, not the canonical DB; default search targets curated knowledge only."
+    },
+    {
+      "path": "packages/policy-engine/src/pipeline.ts",
+      "description": "The deterministic 8-rule PolicyPipeline that runs BELOW the spool — dedupe / secret-scan / length / trust / tenant / sensitivity / relevance. No model call lives here; this is the govern gate."
+    },
+    {
+      "path": "packages/policy-engine/src/rules",
+      "description": "The eight individual policy rules (regex / heuristic, deterministic). secret-detection uses scanForSecrets (pattern-based); sensitivity-gate uses classifyContent — both deterministic despite the claude-runtime import name."
+    },
+    {
+      "path": "apps/curator/src/promotion/promoter.ts",
+      "description": "promote(): writes the curated_memories row and its hash-chained audit_events receipt atomically. The place the 'promote + receipt must be one transaction' invariant lives."
+    },
+    {
+      "path": "apps/curator/src/intake/spool-intake.ts",
+      "description": "Spool -> candidates intake (the ICO->INTKB handoff consumer). Home of the intake override + the `proposed` receipt path (R8); candidates are insert-only source of truth."
+    },
+    {
+      "path": "apps/api/src/auth/token-registry.ts",
+      "description": "The tailnet brain API bearer-token registry. Accepts pre-hashed scrypt tokens at rest (parseStoredHash) so ~/.teamkb/tokens.json carries hashes, never plaintext secrets."
+    },
+    {
+      "path": "packages/store/src/schema.ts",
+      "description": "The govern store schema: candidates (insert-only), curated_memories (lifecycle-managed), audit_events (append-only SHA-256 hash-chain), governance_policies, derived memory_links/FTS."
+    },
+    {
+      "path": "packages/store/src/audit-verify.ts",
+      "description": "Walks and verifies the audit_events hash-chain and cross-checks the git-anchored anchors. ok:false means real tamper; benign CHAIN_FORK (same-timestamp ordering) is reported separately and is NEVER re-hashed away."
+    },
+    {
+      "path": "scripts/deploy-brain-api.sh",
+      "description": "Immutable versioned-release deploy: current -> releases/<tag>, floor commit a2143be (E1). A pre-E1 build double-hashes the hashed tokens.json and locks out users; rollback is a symlink flip."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,58 @@
+# qmd-team-intent-kb (INTKB — the govern engine) — review context for Greptile
+
+INTKB is the **deterministic control plane** of the Governed Second Brain ("Bob's Big Brain"). It
+consumes the compile engine's (ICO's) spool and runs **dedupe -> policy -> promotion** into an
+append-only, hash-chained audit log. It is **not** a qmd fork, **not** git-as-database, and **not**
+prompt-only memory governance. TypeScript/Node monorepo (pnpm, Node >= 20).
+
+## The one architecture you must protect: the spool is the trust boundary
+
+```
+ICO compile (probabilistic, model-driven)
+  -> spool  (the trust boundary: content-stable UUID-v5 + manifest SHA-256)
+  -> INTKB govern  (DETERMINISTIC — no model call): dedupe(content_hash)
+       -> 8-rule PolicyPipeline -> promote -> curated_memories + append audit_events
+  -> git-exporter -> kb-export/ -> qmd BM25 index -> brain_search (qmd:// citations)
+```
+
+**The model proposes; deterministic code owns durable state, policy, promotion, and every audit
+write.** Nothing below the spool calls an LLM. `packages/policy-engine` is pattern/heuristic logic —
+`scanForSecrets` is regex-based even though it imports from a package named `claude-runtime`. A diff
+that adds a real model-inference/network call into the policy engine, the promoter, or the audit path
+is an architecture violation, not an optimization.
+
+## Prioritize (in order)
+
+- **Govern determinism** — no LLM below the spool; the 8-rule pipeline stays deterministic.
+- **Receipt integrity** — `audit_events` are append-only + hash-chained; promotion writes the memory
+  and its receipt in ONE transaction; the chain is NEVER re-hashed (ratified D5 — the 155 carried
+  CHAIN_FORK breaks are benign same-timestamp ordering, all hashes intact). `ok:false` = real tamper.
+- **Source-of-truth data model** — `candidates` is insert-only; retirement is marker-based, never a
+  destructive delete of flagged/rejected rows.
+- **Secrets at rest** — bearer tokens are scrypt-hashed in `~/.teamkb/tokens.json`; never regress to
+  plaintext, never log a token.
+- **Deploy safety** — the API runs from an immutable `releases/<tag>` (floor `a2143be`); never a
+  working-tree run, never a pre-E1 ref (it double-hashes the hashed tokens and locks everyone out).
+- **Gate integrity** — never weaken a CI check (`validate` = lint + typecheck + coverage; `security`
+  = gitleaks + Semgrep + audit; `docs-quality` = markdownlint).
+
+## Deprioritize
+
+- Style-only / naming nits — eslint, prettier, and markdownlint already cover these.
+- Churn on generated output: `dist/`, `coverage/`, `kb-export/`, `qmd-index/`, `*.map`.
+- Comments that merely restate a linter or the typechecker.
+
+## Honesty invariant (brand-load-bearing)
+
+The wedge is **govern + receipts**, not recall. The chain is **tamper-evident**, not tamper-proof.
+**Forbidden as product claims:** tamper-proof, immutable, non-repudiation (local mode), blockchain.
+Local mode gives integrity + ordering + rewrite-detection; cross-actor attribution needs the pushed
+anchor + per-actor signatures.
+
+## Related repos (multi-repo context)
+
+INTKB is one of five repos under the `intent-solutions-io/governed-second-brain` umbrella. It is
+bundled by the public `governed-second-brain-plugin` (local + team modes) and consumes the ICO
+compile engine's spool. Greptile's config schema has no multi-repo key, so these are noted here for
+reviewer context. Full topology + the code-verified system map: umbrella `000-docs/005-AT-ARCH` and
+`007-AT-SMAP`.


### PR DESCRIPTION
## What
Adds a repo-tailored `.greptile/` config (`config.json` + `files.json` + `rules.md`) so Greptile auto-reviews PRs on this repo. Greptile is installed org-wide but silent here because there was no `.greptile/config.json` — `triggerOnUpdates:true` (set in this config) is what enables auto-review.

## Why
INTKB is the deterministic govern engine; a generic reviewer misses its load-bearing invariants. The rules encode them so an AI reviewer (and any human reading the config) learns the repo: the spool trust boundary, atomic promote+receipt, append-only/never-rehash receipts, insert-only `candidates`, scrypt-hashed tokens at rest, and the immutable release floor.

## Layer(s) touched
Tooling/config only (`.greptile/`). No runtime, schema, or dependency change. No cross-layer invariant changed.

## What's in it (INTKB-specific rules)
`deterministic-govern-no-model-below-spool`, `promote-and-receipt-atomic`, `candidates-insert-only-source-of-truth`, `tokens-hashed-at-rest`, `immutable-release-floor` — plus the shared `receipts-append-only-never-rehash`, `no-gate-weakening` (INTKB check names), `honesty-invariants`, `commit-pr-standard`. `files.json` points Greptile at the policy-engine, promoter, intake, token-registry, store schema/audit-verify, and the deploy script.

## Verification & evidence
`jq -e .` passes on both JSON files; `triggerOnUpdates:true` confirmed. Config-only addition — no code, no CI job change; existing checks (validate / gitleaks / semgrep) are unaffected.

## Risk / Operational impact
None — additive config, no env/deps/migrations. Worst case Greptile ignores an unknown key.

## Refs
Wired to the review-gate hardening tracked in 013-OD-STND §7 / `jfv.6.17`.

- Jeremy Longshore
intentsolutions.io
