### PR TITLE
ci(dependabot): batch all update-types + ignore breaking majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,32 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - 'dependencies'
-    # Batch routine updates into a few PRs instead of one-per-package. Majors stay
-    # ungrouped (individual PRs) so breaking bumps still get reviewed on their own.
+    # Batch EVERYTHING (incl. majors) into two PRs — one dev, one prod — instead of
+    # one-PR-per-major. Kills the per-major noise; a breaking major fails the group's
+    # CI and gets triaged then (add an ignore or migrate) rather than sitting open.
     groups:
       dev-dependencies:
         dependency-type: 'development'
-        update-types:
-          - 'minor'
-          - 'patch'
       production-dependencies:
         dependency-type: 'production'
+    # Known-breaking majors held back until we do the migration (they broke `validate`):
+    #   dependency-cruiser 18 (config migration) · @eslint/js 10 (flat-config changes)
+    ignore:
+      - dependency-name: 'dependency-cruiser'
         update-types:
-          - 'minor'
-          - 'patch'
+          - 'version-update:semver-major'
+      - dependency-name: '@eslint/js'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - 'dependencies'
       - 'ci'


### PR DESCRIPTION
## What
Reconfigure `.github/dependabot.yml`: batch **all** npm update-types (incl. majors) into the two existing `dev-dependencies` / `production-dependencies` groups, `ignore` the two majors that currently break `validate` (`dependency-cruiser` ≥18, `@eslint/js` ≥10), and drop the open-PR limit 5→3.

## Why + rationale
The per-major individual PRs were the noise (2 of the 4 open ones — `dependency-cruiser` 18, the dev-group carrying `@eslint/js` 10 — can't pass CI unmigrated). Chose **batch-everything + ignore-the-breakers** over keeping majors ungrouped because that caps npm churn at ~2 PRs/week and stops the two known-breaking majors from re-opening every cycle.

## Layer / how
CI config only (Dependabot). No product code, no compile/spool/govern surface.

## Verification
YAML is valid (Dependabot schema); the 4 stale PRs (#217/#218/#219/#225) are closed; Dependabot will recreate current, grouped, CI-tested PRs on the next run.

## Risk / operational
Low — config only. The two ignored majors are deferred (a `dependency-cruiser` / `eslint` migration is the follow-up to lift the ignore); security-alert PRs are unaffected by grouping.

## Follow-up
Migrate `dependency-cruiser` 18 + `@eslint/js` 10 config, then remove the ignores.

Refs the dependabot-noise cleanup.

- Jeremy Longshore
intentsolutions.io