### PR TITLE
feat(store,curator): B1 marker-based auto-govern primitives (jfv.2.1)

### DIFF
--- a/apps/curator/src/__tests__/curator-b1-sweep.test.ts
+++ b/apps/curator/src/__tests__/curator-b1-sweep.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import type Database from 'better-sqlite3';
+import { Curator } from '../curator.js';
+import type { CuratorDependencies } from '../curator.js';
+import { makeCandidate, makeCuratedMemory, makePolicy } from './fixtures.js';
+
+function makeDeps(db: Database.Database): CuratorDependencies {
+  return {
+    candidateRepo: new CandidateRepository(db),
+    memoryRepo: new MemoryRepository(db),
+    policyRepo: new PolicyRepository(db),
+    auditRepo: new AuditRepository(db),
+  };
+}
+
+/**
+ * B1 (bead compile-then-govern-jfv.2.1) — the two Curator behaviors the auto-govern
+ * sweep relies on: tenant-scoped dedup, and suppressible per-candidate reject
+ * receipts.
+ */
+describe('Curator — tenant-scoped dedup (B1)', () => {
+  let deps: CuratorDependencies;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('does NOT suppress a candidate as a duplicate of ANOTHER tenant memory', () => {
+    const content = 'Prefer composition over inheritance in service wiring layers';
+    // A memory with this exact content already exists — but under a DIFFERENT tenant.
+    deps.memoryRepo.insert(makeCuratedMemory({ tenantId: 'team-other', content }));
+
+    const curator = new Curator(deps, { tenantId: 'team-mine' });
+    const result = curator.processSingle(makeCandidate({ tenantId: 'team-mine', content }));
+
+    // Globally the content exists, but not for team-mine → it must PROMOTE, not
+    // be swallowed as a cross-tenant duplicate.
+    expect(result.outcome).toBe('promoted');
+  });
+
+  it('still flags a genuine SAME-tenant duplicate', () => {
+    const content = 'Prefer composition over inheritance in service wiring layers';
+    deps.memoryRepo.insert(makeCuratedMemory({ tenantId: 'team-mine', content }));
+
+    const curator = new Curator(deps, { tenantId: 'team-mine' });
+    const result = curator.processSingle(makeCandidate({ tenantId: 'team-mine', content }));
+    expect(result.outcome).toBe('duplicate');
+  });
+});
+
+describe('Curator — suppressRejectionReceipts (B1)', () => {
+  let deps: CuratorDependencies;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('writes a per-candidate reject receipt by DEFAULT', () => {
+    // content_length rule rejects a too-short candidate.
+    deps.policyRepo.insert(
+      makePolicy({
+        tenantId: 'team-mine',
+        rules: [
+          {
+            id: 'len',
+            type: 'content_length',
+            action: 'reject',
+            enabled: true,
+            priority: 0,
+            parameters: { min: 1000 },
+            description: 'reject short',
+          },
+        ],
+      }),
+    );
+    const curator = new Curator(deps, { tenantId: 'team-mine' });
+    const result = curator.processSingle(
+      makeCandidate({ tenantId: 'team-mine', content: 'too short body' }),
+    );
+    expect(result.outcome).toBe('rejected');
+    // A 'deleted' (rejection) audit event WAS written.
+    expect(deps.auditRepo.findByAction('deleted').length).toBe(1);
+  });
+
+  it('suppresses the per-candidate reject receipt when configured (sweep mode)', () => {
+    deps.policyRepo.insert(
+      makePolicy({
+        tenantId: 'team-mine',
+        rules: [
+          {
+            id: 'len',
+            type: 'content_length',
+            action: 'reject',
+            enabled: true,
+            priority: 0,
+            parameters: { min: 1000 },
+            description: 'reject short',
+          },
+        ],
+      }),
+    );
+    const curator = new Curator(deps, { tenantId: 'team-mine', suppressRejectionReceipts: true });
+    const result = curator.processSingle(
+      makeCandidate({ tenantId: 'team-mine', content: 'too short body' }),
+    );
+    // Outcome still surfaces...
+    expect(result.outcome).toBe('rejected');
+    // ...but NO per-candidate reject receipt was written (idempotent re-sweeps).
+    expect(deps.auditRepo.findByAction('deleted').length).toBe(0);
+  });
+
+  it('still writes the promoted receipt while suppressing rejections', () => {
+    const curator = new Curator(deps, { tenantId: 'team-mine', suppressRejectionReceipts: true });
+    const result = curator.processSingle(
+      makeCandidate({
+        tenantId: 'team-mine',
+        content: 'A sufficiently long and clean governed body of text.',
+      }),
+    );
+    expect(result.outcome).toBe('promoted');
+    expect(deps.auditRepo.findByAction('promoted').length).toBe(1);
+  });
+});

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -53,7 +53,8 @@ export class Curator {
   processSingle(candidate: MemoryCandidate, existingHashes?: Set<string>): CurationResult {
     const contentHash = computeContentHash(candidate.content);
 
-    const dedup = checkDuplicate(candidate, this.deps.memoryRepo);
+    // Tenant-scoped dedup (B1): never treat another tenant's memory as a duplicate.
+    const dedup = checkDuplicate(candidate, this.deps.memoryRepo, this.config.tenantId);
     if (dedup.isDuplicate) {
       return {
         candidateId: candidate.id,
@@ -82,14 +83,24 @@ export class Curator {
     }
 
     const pipeline = new PolicyPipeline(policy);
-    const hashSet = existingHashes ?? new Set(this.deps.memoryRepo.getAllContentHashes());
+    // Tenant-scoped existing-hash set (B1) — mirrors the API promotion-service so
+    // the policy dedup rule sees only this tenant's memories.
+    const hashSet =
+      existingHashes ??
+      new Set(this.deps.memoryRepo.getContentHashesByTenant(this.config.tenantId));
     const pipelineResult = pipeline.evaluate(candidate, {
       existingHashes: hashSet,
       tenantId: this.config.tenantId,
     });
 
+    // Suppress the per-candidate reject receipt when configured (B1 sweep) — the
+    // outcome still returns, only the audit write is skipped (see
+    // CuratorConfig.suppressRejectionReceipts). `dryRun` also suppresses it.
+    const suppressReject =
+      this.config.dryRun === true || this.config.suppressRejectionReceipts === true;
+
     if (pipelineResult.outcome === 'rejected') {
-      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, this.config.dryRun);
+      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, suppressReject);
       return {
         candidateId: candidate.id,
         outcome: 'rejected',
@@ -99,7 +110,7 @@ export class Curator {
     }
 
     if (pipelineResult.outcome === 'flagged') {
-      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, this.config.dryRun);
+      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, suppressReject);
       return {
         candidateId: candidate.id,
         outcome: 'flagged',
@@ -125,7 +136,10 @@ export class Curator {
     let flagged = 0;
     let duplicates = 0;
 
-    const existingHashes = new Set(this.deps.memoryRepo.getAllContentHashes());
+    // Tenant-scoped (B1): the batch's pre-existing-hash set is this tenant's only.
+    const existingHashes = new Set(
+      this.deps.memoryRepo.getContentHashesByTenant(this.config.tenantId),
+    );
 
     for (const candidate of candidates) {
       const result = this.processSingle(candidate, existingHashes);

--- a/apps/curator/src/dedup/dedup-checker.ts
+++ b/apps/curator/src/dedup/dedup-checker.ts
@@ -19,13 +19,24 @@ export interface DedupResult {
  * Returns a DedupResult with isDuplicate=true when an exact match is found,
  * or isDuplicate=false for novel content. The contentHash is always populated
  * so callers can reuse it without re-computing.
+ *
+ * TENANT SCOPING (B1, bead compile-then-govern-jfv.2.1): when `tenantId` is
+ * supplied the match is scoped to that tenant's memories, so a candidate is never
+ * suppressed as a "duplicate" of a DIFFERENT tenant's memory (a cross-tenant leak
+ * the API's promotion-service already guards against). The Curator always passes
+ * its `config.tenantId`. Omitting `tenantId` preserves the legacy global match for
+ * any caller that has not opted in.
  */
 export function checkDuplicate(
   candidate: MemoryCandidate,
   memoryRepo: MemoryRepository,
+  tenantId?: string,
 ): DedupResult {
   const contentHash = computeContentHash(candidate.content);
-  const existing = memoryRepo.findByContentHash(contentHash);
+  const existing =
+    tenantId !== undefined
+      ? memoryRepo.findByContentHashAndTenant(contentHash, tenantId)
+      : memoryRepo.findByContentHash(contentHash);
 
   if (existing !== null) {
     return {

--- a/apps/curator/src/intake/spool-intake.ts
+++ b/apps/curator/src/intake/spool-intake.ts
@@ -29,6 +29,21 @@ export interface IngestFromSpoolOptions {
    * `<file>.tamper.json` evidence sidecar recording the hash mismatch.
    */
   quarantineDir?: string;
+  /**
+   * When set, each spool file is MOVED here after its candidates are
+   * successfully read + ingested (B1, bead compile-then-govern-jfv.2.1). Bounds
+   * the nightly sweep's re-read work and makes a re-run over unchanged input a
+   * genuine no-op: the auto-govern job re-runs every night but `listSpoolFiles`
+   * only lists the top-level spool dir, so an already-ingested file in the
+   * archive subdir is never re-read (or re-manifest-verified). The candidate
+   * `findById` dedup already prevents a re-INSERT; archiving additionally stops
+   * the O(all-spool-files-ever) growth in read/verify work. Best-effort: a move
+   * failure is logged, never fatal (findById still guards correctness). The
+   * `<file>.manifest.json` sidecar moves alongside. Left unset by the daemon/CLI
+   * (their behavior is unchanged); the plugin's nightly `runGovern` sets it to
+   * `<spool>/ingested`.
+   */
+  archiveIngestedDir?: string;
 }
 
 /** Record of a spool file refused during ingest because it failed manifest
@@ -157,9 +172,40 @@ export async function ingestFromSpoolDetailed(
         throw e;
       }
     }
+
+    // Idempotency (B1): once a file's candidates are read + ingested, move it out
+    // of the top-level spool dir so subsequent runs never re-read/re-verify it.
+    // Best-effort — a failed move is logged but not fatal (findById dedup already
+    // prevents any re-insert).
+    if (opts?.archiveIngestedDir !== undefined) {
+      await archiveIngestedFile(filepath, opts.archiveIngestedDir);
+    }
   }
 
   return { ok: true, value: { ingested, tampered, rejected } };
+}
+
+/**
+ * Move a fully-ingested spool file (and its `.manifest.json` sidecar, if present)
+ * into the archive directory (B1). Best-effort: any I/O failure is swallowed after
+ * a stderr note — the file simply stays in the spool dir and is skipped next run
+ * via the candidate `findById` dedup, so correctness never depends on this move.
+ */
+async function archiveIngestedFile(spoolFilePath: string, archiveDir: string): Promise<void> {
+  try {
+    await mkdir(archiveDir, { recursive: true });
+    const dest = join(archiveDir, basename(spoolFilePath));
+    await rename(spoolFilePath, dest);
+    try {
+      await rename(`${spoolFilePath}.manifest.json`, `${dest}.manifest.json`);
+    } catch {
+      // manifest may not exist — non-fatal.
+    }
+  } catch (e) {
+    process.stderr.write(
+      `[spool-intake] archive skipped for ${basename(spoolFilePath)}: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+  }
 }
 
 /**

--- a/apps/curator/src/types.ts
+++ b/apps/curator/src/types.ts
@@ -32,4 +32,21 @@ export interface CuratorConfig {
    * Range 0.0–1.0. Default 0.6.
    */
   supersessionThreshold?: number;
+  /**
+   * When true, a rejected/flagged candidate does NOT get its own per-candidate
+   * `reject` audit receipt — only the batch outcome is returned in the
+   * {@link CurationResult} (B1, bead compile-then-govern-jfv.2.1). Promotions still
+   * write their full durable state + `promoted` receipt.
+   *
+   * The auto-govern inbox sweep sets this. Rationale: the sweep LEAVES
+   * policy-flagged/rejected candidates in the inbox for human review (it never
+   * retires them), so they are re-evaluated on EVERY nightly run. A per-candidate
+   * reject receipt (a fresh random-id audit event) each night would grow the audit
+   * chain without bound — the exact "second run is a no-op" idempotency the sweep
+   * must guarantee. The sweep instead emits ONE batch-level `governed` receipt (in
+   * runGovern) recording the outcomes, and only when durable state actually
+   * changed. Defaults to false (the daemon / CLI keep per-candidate reject
+   * receipts).
+   */
+  suppressRejectionReceipts?: boolean;
 }

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -20,7 +20,44 @@ export type MemoryCategory = z.infer<typeof MemoryCategory>;
 export const MemoryLifecycleState = z.enum(['active', 'deprecated', 'superseded', 'archived']);
 export type MemoryLifecycleState = z.infer<typeof MemoryLifecycleState>;
 
-export const CandidateStatus = z.literal('inbox');
+/**
+ * Lifecycle status of a raw memory candidate (B1, bead compile-then-govern-jfv.2.1).
+ *
+ * Widened from the original `z.literal('inbox')` so the nightly auto-govern sweep
+ * can MARK a governed candidate's terminal outcome IN PLACE, never deleting the
+ * row. `candidates` is INSERT-ONLY / Tier-A source of truth (005-AT-ARCH §candidates):
+ * a remote team-mode `brain_capture` writes the proposal NOWHERE else, so the row
+ * is the only copy — retirement is a status MARKER, not a DELETE.
+ *
+ * Semantics of each value:
+ *   - `inbox`       — awaiting governance (the capture default; every write path
+ *                     still inserts candidates as `inbox`).
+ *   - `promoted`    — the sweep promoted it to a curated memory; row retired, LEFT
+ *                     the inbox.
+ *   - `duplicate`   — the sweep found its content already curated; row retired.
+ *   - `quarantined` — a MEMBER-authored proposal held back from auto-promotion for
+ *                     admin digest-approval (the B1 member-quarantine gate); retired
+ *                     from the sweep but never silently promoted.
+ *   - `flagged` / `rejected` — reserved terminal markers for an ADMIN disposing of a
+ *                     candidate the sweep left in the inbox for review. The SWEEP
+ *                     itself never sets these (it leaves policy-flagged/rejected
+ *                     candidates in `inbox` so the human review queue + the content
+ *                     survive); they exist so a later admin action can retire a
+ *                     reviewed candidate non-destructively.
+ *
+ * A closed enum so the disclosure scanner and the repository enum-membership
+ * backstop keep treating `status` as closed-vocabulary. Additive/backward-compatible:
+ * the DB `status` column is already TEXT with a DEFAULT of `'inbox'`, and every
+ * pre-B1 row is `inbox`.
+ */
+export const CandidateStatus = z.enum([
+  'inbox',
+  'promoted',
+  'rejected',
+  'flagged',
+  'duplicate',
+  'quarantined',
+]);
 export type CandidateStatus = z.infer<typeof CandidateStatus>;
 
 export const SearchScope = z.enum(['curated', 'all', 'inbox', 'archived']).default('curated');
@@ -57,6 +94,14 @@ export const AuditAction = z.enum([
   // provenance receipt (actor + contentHash + tenant) from byte one, before any
   // promotion. `memoryId` on this row is the candidate's UUID.
   'proposed',
+  // Batch-level receipt for one auto-govern inbox SWEEP (B1, bead
+  // compile-then-govern-jfv.2.1). ONE event per sweep that changed durable state,
+  // recording the per-candidate outcomes (candidate ids + outcome, NEVER content)
+  // so the drain of the remote-capture inbox is on the append-only chain. Replaces
+  // the per-candidate reject receipts the sweep would otherwise emit (which would
+  // re-fire every night for a candidate left in the inbox → unbounded chain bloat).
+  // `memoryId` is a fixed sweep sentinel UUID (the sweep is not tied to one memory).
+  'governed',
 ]);
 export type AuditAction = z.infer<typeof AuditAction>;
 

--- a/packages/store/src/__tests__/candidate-repository-enum-membership.test.ts
+++ b/packages/store/src/__tests__/candidate-repository-enum-membership.test.ts
@@ -120,7 +120,9 @@ describe('CandidateRepository.insert - enum-membership choke point', () => {
   });
 
   it('rejects an off-vocabulary status that is NOT disclosure-shaped (EnumConstraintViolationError)', () => {
-    const { candidate, contentHash } = withRawEnumField('status', 'promoted');
+    // 'promoted' is now a valid CandidateStatus (B1 widened the enum), so use a
+    // value still outside the closed vocabulary to exercise the enum backstop.
+    const { candidate, contentHash } = withRawEnumField('status', 'not-a-real-status');
     let err: unknown;
     try {
       repo.insert(candidate, contentHash);

--- a/packages/store/src/__tests__/candidate-repository-status.test.ts
+++ b/packages/store/src/__tests__/candidate-repository-status.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { CandidateRepository } from '../repositories/candidate-repository.js';
+import { makeCandidate } from './fixtures.js';
+
+/**
+ * B1 (bead compile-then-govern-jfv.2.1) — the auto-govern sweep's non-destructive
+ * status primitives on CandidateRepository: findByStatus (tenant-scoped, tolerant
+ * read) + updateStatus (in-place marker, never a delete).
+ */
+describe('CandidateRepository — status marker (B1)', () => {
+  let db: Database.Database;
+  let repo: CandidateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new CandidateRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('findByStatus returns only rows in that status AND tenant', () => {
+    const { candidate: a, contentHash: ha } = makeCandidate({
+      tenantId: 't1',
+      content: 'aaa aaa aaa',
+    });
+    const { candidate: b, contentHash: hb } = makeCandidate({
+      tenantId: 't1',
+      content: 'bbb bbb bbb',
+    });
+    const { candidate: c, contentHash: hc } = makeCandidate({
+      tenantId: 't2',
+      content: 'ccc ccc ccc',
+    });
+    repo.insert(a, ha);
+    repo.insert(b, hb);
+    repo.insert(c, hc);
+
+    // All three start in the inbox.
+    expect(repo.findByStatus('inbox', 't1')).toHaveLength(2);
+    expect(repo.findByStatus('inbox', 't2')).toHaveLength(1);
+
+    // Retire one of t1's candidates → it leaves the t1 inbox.
+    expect(repo.updateStatus(a.id, 'promoted')).toBe(1);
+    const inboxT1 = repo.findByStatus('inbox', 't1');
+    expect(inboxT1.map((x) => x.id)).toEqual([b.id]);
+    expect(repo.findByStatus('promoted', 't1').map((x) => x.id)).toEqual([a.id]);
+    // t2 is untouched by t1's sweep.
+    expect(repo.findByStatus('inbox', 't2')).toHaveLength(1);
+  });
+
+  it('updateStatus stamps the marker in place and never deletes the row', () => {
+    const { candidate, contentHash } = makeCandidate({ tenantId: 't1' });
+    repo.insert(candidate, contentHash);
+
+    const changed = repo.updateStatus(candidate.id, 'quarantined');
+    expect(changed).toBe(1);
+
+    // Row still present — its content survives (Tier-A source of truth).
+    const row = repo.findById(candidate.id);
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe('quarantined');
+    expect(row?.content).toBe(candidate.content);
+    expect(repo.count()).toBe(1);
+  });
+
+  it('updateStatus returns 0 for an unknown id (no row changed)', () => {
+    expect(repo.updateStatus('11111111-1111-4111-8111-111111111111', 'promoted')).toBe(0);
+  });
+
+  it('updateStatus rejects a value outside the closed CandidateStatus vocabulary', () => {
+    const { candidate, contentHash } = makeCandidate();
+    repo.insert(candidate, contentHash);
+    // @ts-expect-error — off-vocabulary status is a type error AND a runtime throw.
+    expect(() => repo.updateStatus(candidate.id, 'not-a-real-status')).toThrow();
+    // The row is untouched — still inbox.
+    expect(repo.findById(candidate.id)?.status).toBe('inbox');
+  });
+
+  it('findByStatus is TOLERANT — one unparseable row is skipped+reported, not thrown', () => {
+    const { candidate: good, contentHash: hg } = makeCandidate({
+      tenantId: 't1',
+      content: 'good good good',
+    });
+    repo.insert(good, hg);
+
+    // Corrupt a row directly at the SQL layer (bypass the repo's validating insert)
+    // to simulate a truncated/legacy row: invalid author_json.
+    db.prepare(
+      `INSERT INTO candidates (id, status, source, content, title, category, trust_level,
+        author_json, tenant_id, metadata_json, pre_policy_flags_json, content_hash, captured_at)
+       VALUES (@id,'inbox','mcp','x','x','reference','medium','{not json',@tenant,'{}','{}',@hash,@at)`,
+    ).run({
+      id: '22222222-2222-4222-8222-222222222222',
+      tenant: 't1',
+      hash: 'f'.repeat(64),
+      at: '2026-01-15T10:00:00.000Z',
+    });
+
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const inbox = repo.findByStatus('inbox', 't1');
+    // The good row is returned; the corrupt one is dropped (not thrown).
+    expect(inbox.map((x) => x.id)).toEqual([good.id]);
+    // The skip was reported to stderr with the bad row's id (never content).
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[0])).toContain('22222222-2222-4222-8222-222222222222');
+    warn.mockRestore();
+  });
+});

--- a/packages/store/src/__tests__/memory-repository-tenant-dedup.test.ts
+++ b/packages/store/src/__tests__/memory-repository-tenant-dedup.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { createTestDatabase } from '../database.js';
+import { MemoryRepository } from '../repositories/memory-repository.js';
+import { makeMemory } from './fixtures.js';
+
+/**
+ * B1 (bead compile-then-govern-jfv.2.1) — tenant-scoped dedup lookups. A sweep
+ * must never treat another tenant's memory as a duplicate.
+ */
+describe('MemoryRepository — tenant-scoped dedup (B1)', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('findByContentHashAndTenant only matches within the tenant', () => {
+    const content = 'shared body of text that both tenants happen to hold';
+    const hash = computeContentHash(content);
+    repo.insert(makeMemory({ tenantId: 'team-a', content }));
+
+    // Same content, DIFFERENT tenant → not a duplicate for team-b.
+    expect(repo.findByContentHashAndTenant(hash, 'team-a')?.tenantId).toBe('team-a');
+    expect(repo.findByContentHashAndTenant(hash, 'team-b')).toBeNull();
+    // The un-scoped lookup still finds it globally (legacy behavior preserved).
+    expect(repo.findByContentHash(hash)).not.toBeNull();
+  });
+
+  it('getContentHashesByTenant returns only that tenant hashes', () => {
+    repo.insert(makeMemory({ tenantId: 'team-a', content: 'aaa content one' }));
+    repo.insert(makeMemory({ tenantId: 'team-a', content: 'aaa content two' }));
+    repo.insert(makeMemory({ tenantId: 'team-b', content: 'bbb content one' }));
+
+    expect(repo.getContentHashesByTenant('team-a')).toHaveLength(2);
+    expect(repo.getContentHashesByTenant('team-b')).toHaveLength(1);
+    expect(repo.getAllContentHashes()).toHaveLength(3);
+  });
+});

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { MemoryCandidate, CandidateStatus } from '@qmd-team-intent-kb/schema';
 import { assertDisclosureClean } from '@qmd-team-intent-kb/common';
 import { assertEnumMembership } from './enum-membership.js';
 
@@ -87,6 +87,33 @@ function rowToCandidate(row: unknown): MemoryCandidate {
 }
 
 /**
+ * Skip-and-report variant of {@link rowToCandidate} for bulk reads that must not
+ * be aborted by a single malformed row (B1, bead compile-then-govern-jfv.2.1).
+ *
+ * The nightly auto-govern sweep reads the ENTIRE inbox via {@link
+ * CandidateRepository.findByStatus} and processes it. `rowToCandidate` THROWS on
+ * any row that fails validation, so one corrupt/partial row (a truncated write, a
+ * legacy row predating a schema field) would abort the whole sweep FOREVER — the
+ * inbox could never drain. This wrapper contains that: a bad row is logged to
+ * stderr (id + reason, never content) and dropped, so the sweep governs every good
+ * row and the operator still sees the poison row surfaced. Returns null on failure.
+ */
+function rowToCandidateSafe(row: unknown): MemoryCandidate | null {
+  try {
+    return rowToCandidate(row);
+  } catch (e) {
+    const id =
+      row !== null && typeof row === 'object' && 'id' in row
+        ? String((row as { id: unknown }).id)
+        : '<unknown>';
+    process.stderr.write(
+      `[candidate-repository] skipping unparseable candidate row id=${id}: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+    return null;
+  }
+}
+
+/**
  * Repository for raw memory candidate proposals.
  * All methods use prepared statements for safety and performance.
  * Validation is the responsibility of the caller.
@@ -95,10 +122,12 @@ export class CandidateRepository {
   private readonly stmtInsert: Database.Statement;
   private readonly stmtFindById: Database.Statement;
   private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtFindByStatus: Database.Statement;
   private readonly stmtFindByHash: Database.Statement;
   private readonly stmtCount: Database.Statement;
   private readonly stmtCountByTenant: Database.Statement;
   private readonly stmtDeleteByBatch: Database.Statement;
+  private readonly stmtUpdateStatus: Database.Statement;
 
   constructor(db: Database.Database) {
     this.stmtInsert = db.prepare(`
@@ -123,8 +152,22 @@ export class CandidateRepository {
       SELECT * FROM candidates WHERE tenant_id = ?
     `);
 
+    // Tenant-scoped status lookup — the auto-govern sweep's drain query (B1).
+    // Scoped by (status, tenant_id) so one tenant's sweep never reads another
+    // tenant's candidates; backed by idx_candidates_status_tenant (migration 8).
+    this.stmtFindByStatus = db.prepare(`
+      SELECT * FROM candidates WHERE status = ? AND tenant_id = ?
+    `);
+
     this.stmtFindByHash = db.prepare(`
       SELECT * FROM candidates WHERE content_hash = ? LIMIT 1
+    `);
+
+    // Non-destructive terminal marker for a governed candidate (B1). The row is
+    // NEVER deleted (candidates is Tier-A source of truth); the sweep only stamps
+    // its outcome via this UPDATE.
+    this.stmtUpdateStatus = db.prepare(`
+      UPDATE candidates SET status = @status WHERE id = @id
     `);
 
     this.stmtCount = db.prepare(`
@@ -206,6 +249,45 @@ export class CandidateRepository {
   findByTenant(tenantId: string): MemoryCandidate[] {
     const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToCandidate);
+  }
+
+  /**
+   * Return every candidate in the given `status`, scoped to `tenantId` (B1, bead
+   * compile-then-govern-jfv.2.1). The auto-govern sweep calls
+   * `findByStatus('inbox', config.tenantId)` to drain the pre-governance inbox.
+   *
+   * TOLERANT read: a row that fails validation is skipped and reported to stderr
+   * (via {@link rowToCandidateSafe}) rather than thrown, so a single malformed
+   * candidate can never abort the whole sweep — the inbox always drains. Tenant
+   * scoping is mandatory (not optional) so a sweep can never read across the
+   * tenant boundary.
+   */
+  findByStatus(status: CandidateStatus, tenantId: string): MemoryCandidate[] {
+    const rows = this.stmtFindByStatus.all(status, tenantId);
+    const out: MemoryCandidate[] = [];
+    for (const row of rows) {
+      const c = rowToCandidateSafe(row);
+      if (c !== null) out.push(c);
+    }
+    return out;
+  }
+
+  /**
+   * Stamp a candidate's terminal status IN PLACE (B1) — the non-destructive
+   * retirement primitive the sweep uses instead of DELETE. `candidates` is
+   * insert-only Tier-A source of truth, so a governed candidate LEAVES the inbox
+   * by changing its status marker, never by deletion (which would destroy the only
+   * copy of a remote teammate's proposal + the human review queue).
+   *
+   * Validates `status` against the closed {@link CandidateStatus} vocabulary before
+   * writing (a raw UPDATE otherwise bypasses the enum-membership backstop that
+   * `insert()` enforces). Returns the number of rows changed (0 if `id` is absent).
+   *
+   * @throws {z.ZodError} if `status` is not a valid CandidateStatus value.
+   */
+  updateStatus(id: string, status: CandidateStatus): number {
+    const validated = CandidateStatus.parse(status);
+    return this.stmtUpdateStatus.run({ id, status: validated }).changes;
   }
 
   /**

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -163,6 +163,8 @@ export class MemoryRepository {
   private readonly stmtFindById: Database.Statement;
   private readonly stmtFindByTenant: Database.Statement;
   private readonly stmtFindByHash: Database.Statement;
+  private readonly stmtFindByHashAndTenant: Database.Statement;
+  private readonly stmtTenantHashes: Database.Statement;
   private readonly stmtFindByLifecycle: Database.Statement;
   private readonly stmtUpdateLifecycle: Database.Statement;
   private readonly stmtUpdate: Database.Statement;
@@ -213,6 +215,19 @@ export class MemoryRepository {
 
     this.stmtFindByHash = db.prepare(`
       SELECT * FROM curated_memories WHERE content_hash = ? LIMIT 1
+    `);
+
+    // Tenant-scoped dedup lookups (B1, bead compile-then-govern-jfv.2.1). The
+    // auto-govern sweep must NOT dedup across tenants — a global hash match would
+    // let tenant A's candidate be silently suppressed as a "duplicate" of tenant
+    // B's memory (a cross-tenant leak the API's promotion-service already guards
+    // against). These mirror that tenant scoping.
+    this.stmtFindByHashAndTenant = db.prepare(`
+      SELECT * FROM curated_memories WHERE content_hash = ? AND tenant_id = ? LIMIT 1
+    `);
+
+    this.stmtTenantHashes = db.prepare(`
+      SELECT content_hash FROM curated_memories WHERE tenant_id = ?
     `);
 
     this.stmtFindByLifecycle = db.prepare(`
@@ -393,6 +408,26 @@ export class MemoryRepository {
   getAllContentHashes(): string[] {
     const rows = this.stmtAllHashes.all() as Array<{ content_hash: string }>;
     return rows.map((r) => r.content_hash);
+  }
+
+  /**
+   * Return the content hashes of the given tenant's memories only (B1). The
+   * tenant-scoped counterpart to {@link getAllContentHashes}, used by the curator's
+   * dedup so a batch/sweep never treats another tenant's memory as a duplicate.
+   */
+  getContentHashesByTenant(tenantId: string): string[] {
+    const rows = this.stmtTenantHashes.all(tenantId) as Array<{ content_hash: string }>;
+    return rows.map((r) => r.content_hash);
+  }
+
+  /**
+   * Return the first memory in the given tenant with the given content hash, or
+   * null (B1). The tenant-scoped counterpart to {@link findByContentHash}, so
+   * exact-hash dedup never crosses the tenant boundary.
+   */
+  findByContentHashAndTenant(hash: string, tenantId: string): CuratedMemory | null {
+    const row = this.stmtFindByHashAndTenant.get(hash, tenantId);
+    return row !== undefined ? rowToMemory(row) : null;
   }
 
   /** Count memories grouped by lifecycle state */

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -299,4 +299,20 @@ UPDATE audit_events SET seq = rowid WHERE seq IS NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_seq ON audit_events(seq);
     `.trim(),
   },
+  {
+    // Index the auto-govern inbox sweep's hot lookup (B1, bead
+    // compile-then-govern-jfv.2.1). The nightly sweep calls
+    // `CandidateRepository.findByStatus('inbox', tenantId)` — a filter on
+    // (status, tenant_id) — to drain the remote-capture inbox. Purely additive:
+    // no column change (the `candidates.status` column is already TEXT with a
+    // DEFAULT of 'inbox'; the B1 enum widening is enforced in Zod, not by a DB
+    // CHECK), just a compound index so the sweep does not table-scan `candidates`
+    // as the inbox grows. `IF NOT EXISTS` keeps it replay-safe on fresh and
+    // pre-existing databases alike.
+    version: 8,
+    name: 'add_candidates_status_tenant_index',
+    sql: `
+CREATE INDEX IF NOT EXISTS idx_candidates_status_tenant ON candidates(status, tenant_id);
+    `.trim(),
+  },
 ];


### PR DESCRIPTION
## What

The store + curator primitives for **B1 — auto-govern the remote `brain_capture`
inbox nightly**. All non-destructive: a governed candidate is retired by a status
**marker**, never a `DELETE`.

- **schema** — widen `CandidateStatus` from `z.literal('inbox')` to the closed
  enum `inbox | promoted | rejected | flagged | duplicate | quarantined`; add the
  `governed` `AuditAction` (the batch sweep receipt).
- **store** — migration #8 (additive compound index `idx_candidates_status_tenant`);
  `CandidateRepository.findByStatus(status, tenantId)` (tenant-scoped, tolerant read)
  and `updateStatus(id, status)` (validated in-place marker);
  `MemoryRepository.getContentHashesByTenant` / `findByContentHashAndTenant`
  (tenant-scoped dedup lookups).
- **curator** — tenant-scope the dedup to `config.tenantId`;
  `CuratorConfig.suppressRejectionReceipts`; `ingestFromSpool` `archiveIngestedDir`.

## Why & decision rationale

The remote team-mode `brain_capture` path POSTs a proposal to `/api/candidates` →
the `candidates` table with `status='inbox'`. Nothing drains it (the nightly
compile's `runGovern` only ingested the spool file), so teammate proposals sat in
`inbox` forever. B1 (in the plugin PR) sweeps that inbox; this PR is the store +
curator foundation it needs.

- **Marker over DELETE.** The original B1 design retired flagged/rejected/promoted
  candidates by deleting the row. A 6-engineer review (bead jfv.2.1) rejected it:
  `candidates` is Tier-A insert-only source of truth (005-AT-ARCH) — a remote
  capture lives *nowhere else*, so a delete destroys the only copy of a teammate's
  proposal **and** the human review queue, and (because spool files are never
  cleaned + `ingestFromSpool` dedups by `findById`) re-inserts + re-rejects every
  candidate every night → unbounded audit-chain bloat. **Chose a status marker
  over a delete because the row is the sole copy and must survive review.**
- **Tenant-scoped dedup over global.** The curator's `checkDuplicate` /
  existing-hash set were global; the API's promotion-service already tenant-scopes
  to avoid a cross-tenant leak (tenant A's candidate suppressed as a "duplicate" of
  tenant B's memory). **Chose to mirror promotion-service** rather than leave the
  sweep on the global path.
- **`suppressRejectionReceipts` over per-candidate reject events in the sweep.**
  The sweep re-evaluates review-queue leftovers every night; a per-candidate reject
  receipt each night grows the chain without bound. **Chose one batch receipt (in
  the plugin) + suppressible per-candidate rejects** so a re-run is a genuine no-op.

## Layer(s) touched

**store + curator (govern layer, below the spool).**

Cross-layer invariant note — **the `Insert-only candidates` invariant is refined,
deliberately, and this is its authorizing record (bead jfv.2.1, the corrected
design):** rows are still **never deleted** and the source-of-truth *content* is
**never rewritten** — B1 mutates only the lifecycle `status` **marker** column
(`inbox → promoted|duplicate|quarantined`). The marker-vs-delete choice *is* the
point of the reviewed correction; the delete design was the one that actually
violated the invariant (data loss). All other invariants unchanged: **no model
below the spool** (govern stays deterministic), **append-only hash-chained
receipts** (audit untouched), **tenant isolation** (dedup is now *more* strictly
scoped, not less).

## How it works

- `packages/schema/src/enums.ts` — `CandidateStatus` enum + `governed` action.
- `packages/store/src/schema.ts` — migration #8 (index only; the `status` column is
  already `TEXT DEFAULT 'inbox'`, so no column change and every pre-B1 row is
  `inbox`).
- `packages/store/src/repositories/candidate-repository.ts` — `findByStatus` uses a
  **skip-and-report** mapper (`rowToCandidateSafe`) so one unparseable row is
  logged + dropped, never thrown (a corrupt row can't wedge the sweep forever);
  `updateStatus` validates against the closed enum before the `UPDATE`.
- `packages/store/src/repositories/memory-repository.ts` — tenant-scoped hash
  lookups.
- `apps/curator/src/{curator,dedup/dedup-checker,types}.ts` — tenant-scoped dedup +
  `suppressRejectionReceipts` (promotions still write their full `promoted` receipt).
- `apps/curator/src/intake/spool-intake.ts` — opt-in `archiveIngestedDir` moves each
  spool file to `<spool>/ingested` after ingest (top-level `listSpoolFiles` never
  re-reads it), bounding re-read work and making a re-run a no-op.

## Verification & evidence

- [x] **Full validate green:** `pnpm format:check && pnpm lint && pnpm typecheck &&
  pnpm test` — **1990/1990 tests pass**, lint + typecheck clean.
- [x] **New tests:** `candidate-repository-status.test.ts` (findByStatus tenant
  scoping, updateStatus in-place marker + closed-vocab rejection, tolerant mapper
  skips a corrupt row), `memory-repository-tenant-dedup.test.ts`,
  `curator-b1-sweep.test.ts` (cross-tenant content NOT suppressed, same-tenant still
  deduped, per-candidate reject receipt written by default / suppressed in sweep
  mode / promotion receipt still written).
- [x] **Migration:** `migrations.test.ts` (reads `MIGRATIONS` dynamically) applies
  and asserts #8; the pre-existing enum-membership test updated (`'promoted'` is now
  a valid status → uses `'not-a-real-status'` to still exercise the backstop).
- The end-to-end sweep is proven in the **plugin PR's** `smoke/b1-inbox-sweep.mjs`
  against the shipped bundle (this PR's primitives inlined).

## Risk assessment

| Question | Answer |
|---|---|
| What could break? | Curator dedup is now tenant-scoped — a caller that *relied on* global cross-tenant dedup would change behavior. None do: only the Curator called it (daemon + CLI are single-tenant per config); `merge-gate` + `eval-surface` keep their own global `getAllContentHashes`. |
| Backward compatible? | Yes. Enum widening is additive (old rows are `inbox`); migration #8 is index-only; `archiveIngestedDir` + `suppressRejectionReceipts` are opt-in (daemon/CLI behavior unchanged); `checkDuplicate`'s `tenantId` is an optional param (omitting it = legacy global). |
| User-facing or internal? | Internal (store/curator library surface). |
| Public API / contract change? | No HTTP/tool-surface change. Schema-vocabulary widening only (`CandidateStatus`, `AuditAction`). |

## Operational impact

- **Env vars:** none.
- **Schema migrations:** #8 `add_candidates_status_tenant_index` — additive index,
  replay-safe (`IF NOT EXISTS`), no backfill, no lock of concern (single-writer WAL).
- **Dependencies:** none.
- **Cost / secrets / permissions:** none.
- **Deploy order:** code-first, no data step. The plugin bundle inlines these
  primitives, so the plugin PR ships them to the runtime; this repo's API/daemon pick
  them up on their next build. No paired live step.

## Follow-up & deferred

- The `flagged` / `rejected` enum values are reserved for a future **admin
  disposition** action (the sweep itself never sets them — it leaves those in the
  inbox). Wiring an admin review/disposition surface is future work under the B1
  epic (jfv.2).
- None else deferred by this PR.

## Governance links

- Corrected design + 6-engineer review: bead **compile-then-govern-jfv.2.1** (notes).
- Grounded system map / insert-only classification: umbrella
  `000-docs/005-AT-ARCH-grounded-system-map-and-backup-scope.md`.
- R8 (server-side `proposedByRole` marker the plugin's quarantine gate reads):
  bead compile-then-govern-jfv.6.7 (merged, PR #230).

## Refs / Beads

Refs Beads: **compile-then-govern-jfv.2.1** (paired with the plugin PR — the plugin
consumes these primitives). Sibling of B1 epic **compile-then-govern-jfv.2**.

- Jeremy Longshore
intentsolutions.io
