### PR TITLE
feat(api): agent-review approve/reject surface + fix candidate status-flip bug (jfv.8)

### DIFF
--- a/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
+++ b/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
@@ -35,6 +35,11 @@ exports[`OpenAPI contract > publishes a stable apps/api surface (snapshot) 1`] =
         "post",
       ],
     },
+    "/api/candidates/{id}/reject": {
+      "methods": [
+        "post",
+      ],
+    },
     "/api/health": {
       "methods": [
         "get",

--- a/apps/api/src/__tests__/candidates.test.ts
+++ b/apps/api/src/__tests__/candidates.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import type Database from 'better-sqlite3';
-import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { createTestDatabase, CandidateRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
 import { buildApp } from '../app.js';
 import { makeCandidate, NOW } from './fixtures.js';
 import { injectJson } from './assertions.js';
@@ -165,6 +166,38 @@ describe('/api/candidates', () => {
     const res = await injectJson(app, 'GET', '/api/candidates');
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/tenantId/);
+  });
+
+  it('GET list with ?status=quarantined returns only that queue (jfv.8 brain_inbox)', async () => {
+    // Seed one quarantined + one inbox candidate for the tenant via the repo
+    // (intake always lands `inbox`; quarantine is stamped later by the govern
+    // sweep, so we set it directly here to exercise the filter).
+    const repo = new CandidateRepository(db);
+    const held = makeCandidate({ tenantId: 'team-alpha', content: 'held for review aaa' });
+    const open = makeCandidate({ tenantId: 'team-alpha', content: 'still in the inbox bbb' });
+    repo.insert(held, computeContentHash(held.content));
+    repo.insert(open, computeContentHash(open.content));
+    repo.updateStatus(held.id, 'quarantined', 'team-alpha');
+
+    const res = await injectJson(
+      app,
+      'GET',
+      '/api/candidates?tenantId=team-alpha&status=quarantined',
+    );
+    expect(res.status).toBe(200);
+    const list = res.body as Array<{ id: string; status: string }>;
+    expect(list.map((c) => c.id)).toEqual([held.id]);
+    expect(list.every((c) => c.status === 'quarantined')).toBe(true);
+  });
+
+  it('GET list with an invalid status returns 400 (closed vocabulary, never silent-empty)', async () => {
+    const res = await injectJson(
+      app,
+      'GET',
+      '/api/candidates?tenantId=team-alpha&status=not-a-status',
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/Invalid status/i);
   });
 
   it('POST preserves capturedAt timestamp exactly', async () => {

--- a/apps/api/src/__tests__/promote.test.ts
+++ b/apps/api/src/__tests__/promote.test.ts
@@ -39,9 +39,45 @@ describe('POST /api/candidates/:id/promote', () => {
     db.close();
   });
 
-  function promote(id: string, tenantId?: string) {
+  function promote(id: string, tenantId?: string, payload?: Record<string, unknown>) {
     const q = tenantId === undefined ? '' : `?tenantId=${tenantId}`;
-    return app.inject({ method: 'POST', url: `/api/candidates/${id}/promote${q}` });
+    return app.inject({
+      method: 'POST',
+      url: `/api/candidates/${id}/promote${q}`,
+      ...(payload !== undefined ? { payload } : {}),
+    });
+  }
+
+  /** Insert a candidate row directly at the SQL layer, BYPASSING the repository's
+   * disclosure choke — the only way to plant a secret-bearing row so the
+   * promote-time disclosure hard floor (014-AT-DECR #1) can be exercised. */
+  function insertRawCandidate(id: string, tenantId: string, content: string): void {
+    db.prepare(
+      `INSERT INTO candidates (id, status, source, content, title, category, trust_level,
+        author_json, tenant_id, metadata_json, pre_policy_flags_json, content_hash, captured_at)
+       VALUES (@id,'quarantined','mcp',@content,'raw','reference','medium',
+        @author,@tenant,'{}','{}',@hash,@at)`,
+    ).run({
+      id,
+      content,
+      author: JSON.stringify({ type: 'ai', id: 'governed-brain' }),
+      tenant: tenantId,
+      hash: computeContentHash(content),
+      at: '2026-07-11T10:00:00.000Z',
+    });
+  }
+
+  /** The single 'promoted' audit event for a memory, actor + reason parsed. */
+  function promotedEvent(memoryId: string): {
+    actor: { type: string; id: string };
+    reason: string;
+  } {
+    const row = db
+      .prepare(
+        `SELECT actor_json, reason FROM audit_events WHERE action='promoted' AND memory_id=@memoryId`,
+      )
+      .get({ memoryId }) as { actor_json: string; reason: string };
+    return { actor: JSON.parse(row.actor_json), reason: row.reason };
   }
 
   it('promotes an inbox candidate to a governed memory (200)', async () => {
@@ -101,6 +137,51 @@ describe('POST /api/candidates/:id/promote', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it('flips the candidate to `promoted` so it leaves the inbox (jfv.8 status-flip fix)', async () => {
+    // Regression for the confirmed status-flip bug: before jfv.8, promote()
+    // inserted the memory but never touched the candidates row, so an approved
+    // candidate kept its status and re-appeared in brain_inbox forever.
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+    expect(candidateRepo.findById(candidate.id)?.status).toBe('inbox');
+
+    const res = await promote(candidate.id, 'team-alpha');
+    expect(res.statusCode).toBe(200);
+    // The candidate row survives (Tier-A) but is now retired from the queue.
+    expect(candidateRepo.findById(candidate.id)?.status).toBe('promoted');
+  });
+
+  it('records the acting reviewer + reason on the promoted receipt (014-AT-DECR #2)', async () => {
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+
+    const res = await promote(candidate.id, 'team-alpha', {
+      actorType: 'ai',
+      reason: 'high-confidence durable convention',
+    });
+    expect(res.statusCode).toBe(200);
+    const memory = res.json() as { id: string };
+    const ev = promotedEvent(memory.id);
+    // The receipt is filterable by the AI reviewer, and carries its verdict.
+    expect(ev.actor.type).toBe('ai');
+    expect(ev.reason).toMatch(/high-confidence durable convention/);
+    expect(ev.reason).toMatch(/passed all governance rules/);
+  });
+
+  it('REJECTS a secret-bearing candidate at the promotion disclosure hard floor (014-AT-DECR #1)', async () => {
+    // A secret can't normally reach the inbox (intake blocks it), so plant one
+    // directly to prove the promote path is unlaunderable on its own — an agent's
+    // "promote" can NEVER move a secret into durable memory, policy config or not.
+    const id = randomUUID();
+    insertRawCandidate(id, 'team-alpha', 'deploy key AKIAIOSFODNN7EXAMPLE for the bucket');
+
+    const res = await promote(id, 'team-alpha');
+    expect(res.statusCode).toBe(422);
+    expect((res.json() as { error: string }).error).toMatch(/disclosure gate/i);
+    // Nothing was promoted and the candidate was NOT marked promoted.
+    expect(candidateRepo.findById(id)?.status).toBe('quarantined');
+  });
+
   it('returns 422 and leaves the candidate in the inbox when policy rejects', async () => {
     // Default makePolicy carries a secret_detection rule with action 'reject'.
     policyRepo.insert(makePolicy({ tenantId: 'team-alpha' }));
@@ -119,5 +200,82 @@ describe('POST /api/candidates/:id/promote', () => {
     expect((res.json() as { error: string }).error).toMatch(/rejected by policy/i);
     // The candidate is untouched — still in the inbox for a retry after a policy fix.
     expect(candidateRepo.findById(candidate.id)).not.toBeNull();
+  });
+});
+
+/**
+ * POST /api/candidates/:id/reject — the agent-review "this is noise, stop
+ * proposing it" verdict (jfv.8 / 014-AT-DECR). A non-destructive status flip +
+ * an on-chain receipt naming the reviewer. buildApp({ db }) = dev/admin, so the
+ * admin gating itself is covered in write-gate.test.ts.
+ */
+describe('POST /api/candidates/:id/reject', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let candidateRepo: CandidateRepository;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+    app = buildApp({ db, silent: true });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  function reject(id: string, tenantId?: string, payload?: Record<string, unknown>) {
+    const q = tenantId === undefined ? '' : `?tenantId=${tenantId}`;
+    return app.inject({
+      method: 'POST',
+      url: `/api/candidates/${id}/reject${q}`,
+      ...(payload !== undefined ? { payload } : {}),
+    });
+  }
+
+  it('marks the candidate `rejected` in place and writes a receipt naming the reviewer', async () => {
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+
+    const res = await reject(candidate.id, 'team-alpha', {
+      actorType: 'ai',
+      reason: 'duplicate of an existing convention — noise',
+    });
+    expect(res.statusCode).toBe(200);
+    // Row survives (Tier-A, never deleted) but is retired as rejected.
+    const row = candidateRepo.findById(candidate.id);
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe('rejected');
+    // A 'deleted'-action receipt names the AI reviewer + carries the reason.
+    const ev = db
+      .prepare(
+        `SELECT actor_json, reason FROM audit_events WHERE action='deleted' AND memory_id=@id`,
+      )
+      .get({ id: candidate.id }) as { actor_json: string; reason: string };
+    expect(JSON.parse(ev.actor_json).type).toBe('ai');
+    expect(ev.reason).toMatch(/duplicate of an existing convention/);
+  });
+
+  it('requires a non-empty reason (400)', async () => {
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+    const res = await reject(candidate.id, 'team-alpha', { actorType: 'ai' });
+    expect(res.statusCode).toBe(400);
+    // Untouched — still awaiting review.
+    expect(candidateRepo.findById(candidate.id)?.status).toBe('inbox');
+  });
+
+  it('returns 400 when tenantId is missing', async () => {
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+    const res = await reject(candidate.id, undefined, { reason: 'noise' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for a non-existent candidate', async () => {
+    const res = await reject(randomUUID(), 'team-alpha', { reason: 'noise' });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/middleware/write-gate.ts
+++ b/apps/api/src/middleware/write-gate.ts
@@ -23,6 +23,13 @@ const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  */
 const PROMOTE_PATH = /^\/api\/candidates\/[^/]+\/promote$/;
 
+/**
+ * Rejecting a reviewed candidate is likewise an admin disposition act under the
+ * otherwise member-allowed `/api/candidates` prefix (jfv.8 agent-review surface):
+ * `POST /api/candidates/:id/reject`.
+ */
+const REJECT_PATH = /^\/api\/candidates\/[^/]+\/reject$/;
+
 export function registerWriteGate(app: FastifyInstance): void {
   app.addHook('onRequest', async (request, reply) => {
     if (!MUTATION_METHODS.has(request.method)) {
@@ -32,6 +39,7 @@ export function registerWriteGate(app: FastifyInstance): void {
     const path = request.url.split('?')[0] ?? request.url;
     const isAdminWrite =
       PROMOTE_PATH.test(path) ||
+      REJECT_PATH.test(path) ||
       ADMIN_WRITE_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
     if (!isAdminWrite) {
       return;

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -8,8 +8,9 @@ import type { PromotionService } from '../services/promotion-service.js';
  *
  * POST   /api/candidates              — intake a new candidate (201)
  * POST   /api/candidates/:id/promote  — promote to a governed memory (200 | admin-only)
+ * POST   /api/candidates/:id/reject   — retire a reviewed candidate (200 | admin-only)
  * GET    /api/candidates/:id          — retrieve by UUID (200 | 404)
- * GET    /api/candidates              — list by tenantId query param (200 | 400)
+ * GET    /api/candidates              — list by tenantId (+ optional status) (200 | 400)
  */
 export function registerCandidateRoutes(
   app: FastifyInstance,
@@ -66,8 +67,65 @@ export function registerCandidateRoutes(
         if (tenantId === undefined || tenantId.trim().length === 0) {
           throw badRequest('tenantId query parameter is required');
         }
-        const memory = promotionService.promoteCandidate(id, tenantId);
+        // The acting reviewer: id is the SERVER-AUTHENTICATED token identity
+        // (unspoofable — `teamkb-review-agent` for the nightly agent), so the
+        // 'promoted' receipt is filterable by who approved it (014-AT-DECR #2).
+        // `actorType`/`reason` are the only client-supplied fields (the agent
+        // proxy sends `ai` + its verdict); actorType is constrained to the closed
+        // AuthorType vocabulary so a bad hint can't break the audit schema parse.
+        const body = (request.body ?? {}) as { reason?: string; actorType?: string };
+        const actorType =
+          body.actorType === 'ai' || body.actorType === 'system' ? body.actorType : 'human';
+        const memory = promotionService.promoteCandidate(
+          id,
+          tenantId,
+          { type: actorType, id: request.actor ?? 'admin' },
+          typeof body.reason === 'string' ? body.reason : undefined,
+        );
         return reply.status(200).send(memory);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.post(
+    '/api/candidates/:id/reject',
+    {
+      schema: {
+        tags: ['candidates'],
+        summary: 'Retire a reviewed candidate as rejected (admin-only)',
+        description:
+          'Non-destructively marks a candidate `rejected` (the row survives — candidates are ' +
+          'Tier-A source of truth) and writes an audit receipt naming the acting reviewer + ' +
+          'reason. The agent-review "this is noise" verdict (jfv.8 / 014-AT-DECR). Admin-only ' +
+          '(write gate). Requires a non-empty `reason` in the body; 404 if the candidate is ' +
+          'missing, 400 if tenantId or reason is missing.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const { tenantId } = request.query as { tenantId?: string };
+        if (tenantId === undefined || tenantId.trim().length === 0) {
+          throw badRequest('tenantId query parameter is required');
+        }
+        const body = (request.body ?? {}) as { reason?: string; actorType?: string };
+        if (typeof body.reason !== 'string' || body.reason.trim().length === 0) {
+          throw badRequest('a non-empty reason is required to reject a candidate');
+        }
+        const actorType =
+          body.actorType === 'ai' || body.actorType === 'system' ? body.actorType : 'human';
+        promotionService.rejectCandidate(
+          id,
+          tenantId,
+          { type: actorType, id: request.actor ?? 'admin' },
+          body.reason,
+        );
+        return reply.status(200).send({ ok: true, candidateId: id, status: 'rejected' });
       } catch (err) {
         if (err instanceof ApiError) {
           return reply.status(err.statusCode).send({ error: err.message });
@@ -104,14 +162,17 @@ export function registerCandidateRoutes(
     {
       schema: {
         tags: ['candidates'],
-        summary: 'List candidates for a tenant',
-        description: 'Requires `tenantId` query param. Returns 400 if missing.',
+        summary: 'List candidates for a tenant, optionally by status',
+        description:
+          'Requires `tenantId`. Optional `status` narrows to one CandidateStatus ' +
+          '(e.g. `quarantined` — the agent-review inbox queue). 400 if tenantId is ' +
+          'missing or status is not a valid CandidateStatus.',
       },
     },
     async (request, reply) => {
       try {
-        const { tenantId } = request.query as { tenantId?: string };
-        const candidates = service.list(tenantId);
+        const { tenantId, status } = request.query as { tenantId?: string; status?: string };
+        const candidates = service.list(tenantId, status);
         return reply.send(candidates);
       } catch (err) {
         if (err instanceof ApiError) {

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -1,5 +1,5 @@
 import type { AuditRepository, CandidateRepository } from '@qmd-team-intent-kb/store';
-import { AuditEvent, MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { AuditEvent, CandidateStatus, MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import {
   computeContentHash,
   deriveAuditEventId,
@@ -235,15 +235,26 @@ export class CandidateService {
   }
 
   /**
-   * List candidates, optionally filtered by tenant.
-   * When no tenantId is provided, a 400 ApiError is thrown — the API
-   * always requires a tenant scope for list operations.
+   * List candidates for a tenant, optionally narrowed to a single lifecycle
+   * `status` (e.g. `quarantined` — the queue the agent-review `brain_inbox` tool
+   * reads, jfv.8). When no tenantId is provided a 400 is thrown — the API always
+   * requires a tenant scope for list operations. An unknown `status` is a 400
+   * (closed CandidateStatus vocabulary), never a silent empty result.
    */
-  list(tenantId: string | undefined): MemoryCandidate[] {
-    if (tenantId !== undefined && tenantId.length > 0) {
-      return this.repo.findByTenant(tenantId);
+  list(tenantId: string | undefined, status?: string): MemoryCandidate[] {
+    if (tenantId === undefined || tenantId.length === 0) {
+      throw badRequest('tenantId query parameter is required');
     }
-    throw badRequest('tenantId query parameter is required');
+    if (status !== undefined && status.length > 0) {
+      const parsed = CandidateStatus.safeParse(status);
+      if (!parsed.success) {
+        throw badRequest(
+          `Invalid status filter '${status}' — must be one of: ${CandidateStatus.options.join(', ')}`,
+        );
+      }
+      return this.repo.findByStatus(parsed.data, tenantId);
+    }
+    return this.repo.findByTenant(tenantId);
   }
 
   /**

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -1,7 +1,13 @@
-import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { randomUUID } from 'node:crypto';
+import {
+  computeContentHash,
+  assertDisclosureClean,
+  DisclosureRejectedError,
+} from '@qmd-team-intent-kb/common';
 import { PolicyPipeline, type PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import { promote, detectSupersession } from '@qmd-team-intent-kb/curator';
-import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { AuditEvent as AuditEventSchema } from '@qmd-team-intent-kb/schema';
+import type { CuratedMemory, Author } from '@qmd-team-intent-kb/schema';
 import type {
   CandidateRepository,
   MemoryRepository,
@@ -41,17 +47,44 @@ export class PromotionService {
    * Promote the candidate identified by `candidateId` (scoped to `tenantId`) to
    * a curated memory, returning the new memory.
    *
+   * `promotedBy` / `promotionReason` name the acting reviewer on the 'promoted'
+   * receipt (the agent-review path passes `teamkb-review-agent` + its verdict, so
+   * the chain is filterable by the reviewing actor — 014-AT-DECR). Omitted → the
+   * batch curator identity, so existing callers are unchanged.
+   *
    * @throws 404 if the candidate does not exist.
    * @throws 400 if the candidate belongs to a different tenant than requested.
-   * @throws 422 if the content is already promoted, or policy rejects/flags it.
+   * @throws 422 if the content carries a secret/PII (disclosure hard floor), is
+   *   already promoted, or policy rejects/flags it.
    */
-  promoteCandidate(candidateId: string, tenantId: string): CuratedMemory {
+  promoteCandidate(
+    candidateId: string,
+    tenantId: string,
+    promotedBy?: Author,
+    promotionReason?: string,
+  ): CuratedMemory {
     const candidate = this.candidateRepo.findById(candidateId);
     if (candidate === null) {
       throw notFound(`Candidate ${candidateId} not found`);
     }
     if (candidate.tenantId !== tenantId) {
       throw badRequest('Candidate does not belong to the requested tenant scope');
+    }
+
+    // Deterministic hard floor (014-AT-DECR constraint #1): re-scan for
+    // secrets/PII at promotion, independent of whether the tenant has an enabled
+    // policy. The intake gate already blocks disclosures at capture, but this
+    // makes the promote path unlaunderable on its own — an agent's "promote"
+    // verdict can NEVER move a secret into durable memory, policy config or not.
+    try {
+      assertDisclosureClean(candidate);
+    } catch (err) {
+      if (err instanceof DisclosureRejectedError) {
+        throw unprocessable(
+          `Candidate rejected at the promotion disclosure gate — content contains disallowed material. Nothing was promoted.`,
+        );
+      }
+      throw err;
     }
 
     const contentHash = computeContentHash(candidate.content);
@@ -95,14 +128,67 @@ export class PromotionService {
     }
 
     // Approved → promote atomically: inserts the memory, writes the 'promoted'
-    // audit event, and applies supersession + wiki-links when applicable.
+    // audit event (actor = promotedBy), and applies supersession + wiki-links.
     const supersession = detectSupersession(candidate, this.memoryRepo, SUPERSESSION_THRESHOLD);
-    return promote(
-      { candidate, contentHash, pipelineResult, supersession: supersession ?? undefined },
+    const memory = promote(
+      {
+        candidate,
+        contentHash,
+        pipelineResult,
+        supersession: supersession ?? undefined,
+        promotedBy,
+        promotionReason,
+      },
       this.memoryRepo,
       this.auditRepo,
       false,
       this.linksRepo,
+    );
+
+    // Retire the candidate from the inbox/quarantine queue (jfv.8 status-flip fix).
+    // Before this, promote() only inserted the curated memory and never touched
+    // the candidates table, so an approved candidate kept its `inbox`/`quarantined`
+    // status and re-appeared in `brain_inbox` forever (re-promotion then 422'd on
+    // the dedup check). The flip is tenant-scoped; a 0-row result (already retired
+    // by a racing sweep) is benign — the memory exists, which is the durable truth.
+    this.candidateRepo.updateStatus(candidateId, 'promoted', tenantId);
+
+    return memory;
+  }
+
+  /**
+   * Retire a reviewed candidate as `rejected` WITHOUT promoting it — the
+   * agent-review path's "this is noise, don't keep proposing it" marker (jfv.8 /
+   * 014-AT-DECR). A non-destructive status flip (the row survives — `candidates`
+   * is Tier-A source of truth, never deleted) plus an on-chain receipt naming the
+   * acting reviewer + reason, so every agent decision (promote AND reject) is
+   * auditable. Uses the 'deleted' audit action (the curator's rejection semantics:
+   * no curated memory was created).
+   *
+   * @throws 404 if the candidate does not exist.
+   * @throws 400 if the candidate belongs to a different tenant than requested.
+   */
+  rejectCandidate(candidateId: string, tenantId: string, actor: Author, reason: string): void {
+    const candidate = this.candidateRepo.findById(candidateId);
+    if (candidate === null) {
+      throw notFound(`Candidate ${candidateId} not found`);
+    }
+    if (candidate.tenantId !== tenantId) {
+      throw badRequest('Candidate does not belong to the requested tenant scope');
+    }
+
+    this.candidateRepo.updateStatus(candidateId, 'rejected', tenantId);
+    this.auditRepo.insert(
+      AuditEventSchema.parse({
+        id: randomUUID(),
+        action: 'deleted',
+        memoryId: candidate.id,
+        tenantId,
+        actor,
+        reason,
+        details: { candidateId: candidate.id, disposition: 'rejected' },
+        timestamp: new Date().toISOString(),
+      }),
     );
   }
 }

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -8,7 +8,12 @@ import {
   CuratedMemory as CuratedMemorySchema,
   AuditEvent as AuditEventSchema,
 } from '@qmd-team-intent-kb/schema';
-import type { MemoryCandidate, CuratedMemory, PolicyEvaluation } from '@qmd-team-intent-kb/schema';
+import type {
+  MemoryCandidate,
+  CuratedMemory,
+  PolicyEvaluation,
+  Author,
+} from '@qmd-team-intent-kb/schema';
 import type {
   MemoryRepository,
   AuditRepository,
@@ -24,7 +29,24 @@ export interface PromotionInput {
   contentHash: string;
   pipelineResult: PipelineResult;
   supersession?: SupersessionMatch;
+  /**
+   * Who is promoting this candidate — recorded verbatim as the actor of the
+   * 'promoted' audit receipt AND the curated memory's `promotedBy` (jfv.8). The
+   * agent-review path passes `{ type: 'ai', id: 'teamkb-review-agent' }` so the
+   * receipt is filterable by the reviewing actor (014-AT-DECR constraint #2).
+   * Defaults to the batch curator's identity when omitted, so every existing
+   * caller (merge-gate, batch pipeline) is unchanged.
+   */
+  promotedBy?: Author;
+  /**
+   * The reviewer's justification, folded into the 'promoted' receipt's reason so
+   * the agent's verdict + reasoning is on the append-only chain (014-AT-DECR).
+   */
+  promotionReason?: string;
 }
+
+/** The default promoter identity for the batch/merge paths that name no actor. */
+const CURATOR_ACTOR: Author = { type: 'system', id: 'curator' };
 
 /**
  * Verdict shape an {@link EvalCallback} may return — a structurally-minimal
@@ -133,7 +155,7 @@ export function promote(
     contentHash: input.contentHash,
     policyEvaluations,
     promotedAt: now,
-    promotedBy: { type: 'system', id: 'curator' },
+    promotedBy: input.promotedBy ?? CURATOR_ACTOR,
     updatedAt: now,
     version: 1,
   });
@@ -248,8 +270,11 @@ export function promote(
             action: 'promoted',
             memoryId,
             tenantId: input.candidate.tenantId,
-            actor: { type: 'system', id: 'curator' },
-            reason: 'Passed all governance rules',
+            actor: input.promotedBy ?? CURATOR_ACTOR,
+            reason:
+              input.promotionReason !== undefined && input.promotionReason.trim().length > 0
+                ? `${input.promotionReason} (passed all governance rules)`
+                : 'Passed all governance rules',
             details: { candidateId: input.candidate.id },
             timestamp: now,
           }),

--- a/packages/store/src/__tests__/candidate-repository-status.test.ts
+++ b/packages/store/src/__tests__/candidate-repository-status.test.ts
@@ -44,7 +44,7 @@ describe('CandidateRepository — status marker (B1)', () => {
     expect(repo.findByStatus('inbox', 't2')).toHaveLength(1);
 
     // Retire one of t1's candidates → it leaves the t1 inbox.
-    expect(repo.updateStatus(a.id, 'promoted')).toBe(1);
+    expect(repo.updateStatus(a.id, 'promoted', 't1')).toBe(1);
     const inboxT1 = repo.findByStatus('inbox', 't1');
     expect(inboxT1.map((x) => x.id)).toEqual([b.id]);
     expect(repo.findByStatus('promoted', 't1').map((x) => x.id)).toEqual([a.id]);
@@ -56,7 +56,7 @@ describe('CandidateRepository — status marker (B1)', () => {
     const { candidate, contentHash } = makeCandidate({ tenantId: 't1' });
     repo.insert(candidate, contentHash);
 
-    const changed = repo.updateStatus(candidate.id, 'quarantined');
+    const changed = repo.updateStatus(candidate.id, 'quarantined', 't1');
     expect(changed).toBe(1);
 
     // Row still present — its content survives (Tier-A source of truth).
@@ -68,14 +68,25 @@ describe('CandidateRepository — status marker (B1)', () => {
   });
 
   it('updateStatus returns 0 for an unknown id (no row changed)', () => {
-    expect(repo.updateStatus('11111111-1111-4111-8111-111111111111', 'promoted')).toBe(0);
+    expect(repo.updateStatus('11111111-1111-4111-8111-111111111111', 'promoted', 't1')).toBe(0);
+  });
+
+  it('updateStatus is tenant-guarded — a matching id but wrong tenant changes nothing (jfv.2.5a)', () => {
+    const { candidate, contentHash } = makeCandidate({ tenantId: 't1' });
+    repo.insert(candidate, contentHash);
+    // Right id, WRONG tenant → 0 rows changed, row untouched (no cross-tenant flip).
+    expect(repo.updateStatus(candidate.id, 'promoted', 't2')).toBe(0);
+    expect(repo.findById(candidate.id)?.status).toBe('inbox');
+    // Right id AND right tenant → the flip lands.
+    expect(repo.updateStatus(candidate.id, 'promoted', 't1')).toBe(1);
+    expect(repo.findById(candidate.id)?.status).toBe('promoted');
   });
 
   it('updateStatus rejects a value outside the closed CandidateStatus vocabulary', () => {
-    const { candidate, contentHash } = makeCandidate();
+    const { candidate, contentHash } = makeCandidate({ tenantId: 't1' });
     repo.insert(candidate, contentHash);
     // @ts-expect-error — off-vocabulary status is a type error AND a runtime throw.
-    expect(() => repo.updateStatus(candidate.id, 'not-a-real-status')).toThrow();
+    expect(() => repo.updateStatus(candidate.id, 'not-a-real-status', 't1')).toThrow();
     // The row is untouched — still inbox.
     expect(repo.findById(candidate.id)?.status).toBe('inbox');
   });

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -165,9 +165,11 @@ export class CandidateRepository {
 
     // Non-destructive terminal marker for a governed candidate (B1). The row is
     // NEVER deleted (candidates is Tier-A source of truth); the sweep only stamps
-    // its outcome via this UPDATE.
+    // its outcome via this UPDATE. Tenant-scoped (id AND tenant_id) so a caller
+    // holding a candidate UUID can never flip another tenant's row by id alone
+    // (jfv.2.5(a) — closed as part of the agent-review approve surface, jfv.8).
     this.stmtUpdateStatus = db.prepare(`
-      UPDATE candidates SET status = @status WHERE id = @id
+      UPDATE candidates SET status = @status WHERE id = @id AND tenant_id = @tenantId
     `);
 
     this.stmtCount = db.prepare(`
@@ -281,13 +283,15 @@ export class CandidateRepository {
    *
    * Validates `status` against the closed {@link CandidateStatus} vocabulary before
    * writing (a raw UPDATE otherwise bypasses the enum-membership backstop that
-   * `insert()` enforces). Returns the number of rows changed (0 if `id` is absent).
+   * `insert()` enforces). Scoped to `tenantId` so the primitive cannot flip a row
+   * outside the caller's tenant. Returns the number of rows changed (0 if no row
+   * matches `id` AND `tenantId`).
    *
    * @throws {z.ZodError} if `status` is not a valid CandidateStatus value.
    */
-  updateStatus(id: string, status: CandidateStatus): number {
+  updateStatus(id: string, status: CandidateStatus, tenantId: string): number {
     const validated = CandidateStatus.parse(status);
-    return this.stmtUpdateStatus.run({ id, status: validated }).changes;
+    return this.stmtUpdateStatus.run({ id, status: validated, tenantId }).changes;
   }
 
   /**


### PR DESCRIPTION
## What
Backs the agent-review capture surface (Capture epic `jfv.2`, decision `014-AT-DECR`) with the server-side endpoints the plugin's three admin MCP tools proxy to:
- **`GET /api/candidates?status=…`** — optional status filter (→ existing `CandidateRepository.findByStatus`), so `brain_inbox` lists just the `quarantined` queue instead of dumping all statuses.
- **`POST …/promote`** now (a) **flips the candidate to `promoted`** after a successful promotion, (b) **names the acting reviewer + reason** on the `'promoted'` receipt, (c) **re-scans for secrets/PII** as a promotion-time hard floor.
- **NEW `POST …/reject`** — a non-destructive `rejected` status marker + an on-chain receipt (the agent's "this is noise" verdict). Admin-gated.
- **`CandidateRepository.updateStatus` is now tenant-scoped** (`id AND tenant_id`).

## Why (+ decision rationale)
- **Status-flip bug (CONFIRMED via code grounding):** neither `promote()` nor `PromotionService.promoteCandidate` ever touched the candidates row, and `updateStatus` had **zero production callers** — so an approved candidate kept its `inbox`/`quarantined` status and re-appeared in `brain_inbox` forever (re-promotion then 422'd on dedup). *Chose a status MARKER over a DELETE* because `candidates` is Tier-A source of truth (a teammate's proposal + the review queue must survive).
- **Actor on the receipt (`014-AT-DECR` #2):** threaded `promotedBy`/`promotionReason` through the `PromotionInput` bundle (*chosen over positional params* so merge-gate + batch callers are untouched). The id is the **server-authenticated** token identity (unspoofable); `actorType` is the only client hint (constrained to the closed `AuthorType` vocab).
- **Disclosure hard floor (`014-AT-DECR` #1):** the intake gate already blocks secrets at capture, but `PromotionService`'s policy re-scan is skipped when a tenant has no enabled policy — so an explicit `assertDisclosureClean` at promote makes the path unlaunderable regardless of policy config.
- **Tenant-guarded `updateStatus` (folds `jfv.2.5a`):** jfv.8 is its first production caller, so the id-only-WHERE footgun is closed now.

## Layer(s) touched
INTKB deterministic control plane — the remote write/govern surface team mode proxies to. The govern/quarantine **sweep** itself lives in the plugin (`brain_govern`, local mode) over the shared `~/.teamkb`; this PR is only the admin disposition surface + its bug fixes. No schema/migration change (uses existing `CandidateStatus` values + `AuditEvent`).

## How it works
`brain_approve` → `POST …/promote` → `PromotionService.promoteCandidate` runs disclosure-scan → dedup → policy → `promote()` (actor = reviewer) → flips candidate `promoted`. `brain_reject` → `POST …/reject` → status `rejected` + `'deleted'` receipt. `brain_inbox` → `GET …?status=quarantined`.

## Verification & evidence
- `pnpm typecheck` (whole graph) **exit 0**; `pnpm lint` (store/curator/api) **exit 0**.
- Tests: **store 223 + api 322** pass. 9 new: status-flip regression, actor/reason receipt, promotion disclosure hard floor (a real `AKIA…`-bearing raw row → 422, not promoted), reject happy/400/404, list status-filter + invalid-status-400, tenant-guarded `updateStatus`.
- OpenAPI contract snapshot updated for the new `/reject` route (intended surface change; diff is exactly the one new POST path).

## Risk
`promote()`'s new optional `PromotionInput` fields default to the curator identity → batch + merge-gate paths byte-identical (audit v2 `entry_hash` already excludes the timestamp). The status flip is a separate write after the transactional promote — a rare failure there leaves the memory promoted but the candidate re-listable (dedup-blocked on retry), which is benign and self-corrects.

## Operational impact
None — no env/migration/dep/deploy-order change. Redeploy the API to expose `/reject`.

## Follow-up / deferred
Companion PR on `governed-second-brain-plugin` adds the `brain_inbox`/`brain_approve`/`brain_reject` MCP tools; the nightly review agent + digest follow (Track 1b/1c).

## Governance links
Decision: `governed-second-brain` `000-docs/014-AT-DECR`. Refs `compile-then-govern jfv.8` (+ `jfv.2.5a`); `governed-second-brain#36`.

- Jeremy Longshore
intentsolutions.io