### PR TITLE
feat(api): capture hardening — per-actor quota, aligned DB path, no-op anchor skip (jfv.10/2.5c)

### DIFF
--- a/apps/api/src/__tests__/capture-quota.test.ts
+++ b/apps/api/src/__tests__/capture-quota.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+import { makeCandidate } from './fixtures.js';
+
+/**
+ * Per-actor capture quota on POST /api/candidates (jfv.10). buildApp({ db }) runs
+ * dev mode = every request is actor 'dev', so all POSTs share one quota bucket.
+ */
+describe('capture quota — per-actor cap on candidate intake (jfv.10)', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db, silent: true, captureQuotaMax: 2, captureQuotaWindowMs: 60_000 });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  const post = (content: string) =>
+    app.inject({ method: 'POST', url: '/api/candidates', payload: makeCandidate({ content }) });
+
+  it('429s the (N+1)th intake from one actor within the window', async () => {
+    // maxCaptures = 2 → the 3rd POST is over quota.
+    expect((await post('first distinct proposal aaaa')).statusCode).toBe(201);
+    expect((await post('second distinct proposal bbbb')).statusCode).toBe(201);
+    const third = await post('third distinct proposal cccc');
+    expect(third.statusCode).toBe(429);
+    expect(
+      (third.json() as { message?: string; error?: string }).message ??
+        (third.json() as { error?: string }).error,
+    ).toMatch(/quota exceeded/i);
+  });
+
+  it('does NOT count reads or other paths against the capture quota', async () => {
+    // Two GETs + a POST to a different path do not consume the capture bucket.
+    await app.inject({ method: 'GET', url: '/api/candidates?tenantId=team-alpha' });
+    await app.inject({ method: 'GET', url: '/api/health' });
+    // The capture bucket is still empty → two intakes succeed.
+    expect((await post('proposal after some reads dddd')).statusCode).toBe(201);
+    expect((await post('another proposal eeee')).statusCode).toBe(201);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import { ImportService } from './services/import-service.js';
 import { registerGraphRoutes } from './routes/graph.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerRateLimiter } from './middleware/rate-limiter.js';
+import { registerCaptureQuota } from './middleware/capture-quota.js';
 import { registerApiKeyAuth } from './middleware/api-key-auth.js';
 import { registerWriteGate } from './middleware/write-gate.js';
 import { registerTenancyGuard } from './middleware/tenancy-guard.js';
@@ -57,6 +58,10 @@ export interface AppDependencies {
   rateLimitMax?: number;
   /** Rate limit window in ms (default 60000) */
   rateLimitWindowMs?: number;
+  /** Max candidate intakes ONE token may propose per window (jfv.10, default 60) */
+  captureQuotaMax?: number;
+  /** Per-actor capture quota window in ms (default 60000) */
+  captureQuotaWindowMs?: number;
   /** Max body size in bytes (default 1MB) */
   maxBodySize?: number;
   /**
@@ -113,6 +118,10 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   // tenant-scoped read/write to the token's tenant allowlist and locks the raw
   // candidate inbox to admin (EPIC 0 — compile-then-govern-c5k).
   registerTenancyGuard(app);
+  // Must follow auth so `request.actor` is stamped: a per-actor cap on candidate
+  // intake so one token/hook can't flood the inbox (jfv.10 — the IP limiter can't,
+  // since every tailnet device is its own IP).
+  registerCaptureQuota(app, deps.captureQuotaMax ?? 60, deps.captureQuotaWindowMs ?? 60000);
   registerInputSanitizer(app, deps.maxBodySize ?? 1_048_576);
 
   // OpenAPI must be registered BEFORE routes so their schema metadata

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -19,7 +19,8 @@ export interface AppConfig {
 /**
  * Load configuration from environment variables with sensible defaults.
  * The API port defaults to 3847, host to loopback, and database path
- * to ~/.teamkb/data/teamkb.db.
+ * to ~/.teamkb/teamkb.db — the SAME file the plugin's local mode + the govern
+ * sweep use, so a no-override deployment writes where the brain reads.
  */
 export function loadConfig(): AppConfig {
   const apiKeyRaw = process.env['TEAMKB_API_KEY'];
@@ -31,7 +32,12 @@ export function loadConfig(): AppConfig {
     // time (an unauthenticated brain reachable off-host). `||` collapses '' and
     // whitespace-only values to 127.0.0.1 before anything else sees them.
     host: process.env['TEAMKB_API_HOST']?.trim() || '127.0.0.1',
-    dbPath: process.env['TEAMKB_DB_PATH'] ?? resolveTeamKbPath('data/teamkb.db'),
+    // Default aligned to the plugin/brain path `~/.teamkb/teamkb.db` (jfv.10
+    // footgun): the prior `data/teamkb.db` default diverged from the plugin's
+    // `teamkb.db`, so a deployment without the TEAMKB_DB_PATH override silently
+    // wrote teammate captures to a DB the govern sweep never read. TEAMKB_DB_PATH
+    // still overrides for any bespoke layout.
+    dbPath: process.env['TEAMKB_DB_PATH'] ?? resolveTeamKbPath('teamkb.db'),
     logLevel: process.env['TEAMKB_LOG_LEVEL'] ?? 'info',
     apiKey: apiKeyRaw !== undefined && apiKeyRaw !== '' ? apiKeyRaw : undefined,
     rateLimitMax: parseInt(process.env['TEAMKB_RATE_LIMIT_MAX'] ?? '100', 10),

--- a/apps/api/src/middleware/capture-quota.ts
+++ b/apps/api/src/middleware/capture-quota.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from 'fastify';
+
+interface QuotaEntry {
+  count: number;
+  windowStart: number;
+}
+
+/**
+ * Per-ACTOR capture quota on `POST /api/candidates` (jfv.10).
+ *
+ * The global rate-limiter is keyed on source IP, which gives no real cap on the
+ * tailnet: every teammate device is its own `100.x` IP, so one runaway or
+ * compromised token — or an over-eager auto-capture hook (Track 4) — could flood
+ * the inbox with quarantined rows (the backlog canary only warns at 200). This
+ * caps how many candidates ONE token identity (`request.actor`) may propose per
+ * window, so the limit follows the token, not the machine.
+ *
+ * Intake only: promote/reject are admin-gated and low-volume, so they are not
+ * capped here. Registered as an `onRequest` hook AFTER auth, so `request.actor`
+ * is already stamped.
+ */
+export function registerCaptureQuota(
+  app: FastifyInstance,
+  maxCaptures: number,
+  windowMs: number,
+): void {
+  const actors = new Map<string, QuotaEntry>();
+
+  const cleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of actors) {
+      if (now - entry.windowStart > windowMs * 2) actors.delete(key);
+    }
+  }, windowMs);
+  cleanup.unref();
+
+  app.addHook('onRequest', async (request, reply) => {
+    if (request.method !== 'POST') return;
+    const path = request.url.split('?')[0] ?? request.url;
+    if (path !== '/api/candidates') return;
+
+    // Key on the authenticated token identity; fall back to IP only on the
+    // loopback dev/no-auth path (where every request is actor='dev').
+    const key = request.actor ?? request.ip;
+    const now = Date.now();
+    const entry = actors.get(key);
+
+    if (entry === undefined || now - entry.windowStart > windowMs) {
+      actors.set(key, { count: 1, windowStart: now });
+      return;
+    }
+
+    entry.count++;
+    if (entry.count > maxCaptures) {
+      reply.status(429);
+      throw new Error(
+        `Capture quota exceeded for this token (max ${maxCaptures} per ${Math.round(
+          windowMs / 1000,
+        )}s). Slow down, or ask an admin to raise the quota.`,
+      );
+    }
+  });
+}

--- a/apps/api/src/middleware/capture-quota.ts
+++ b/apps/api/src/middleware/capture-quota.ts
@@ -33,6 +33,10 @@ export function registerCaptureQuota(
     }
   }, windowMs);
   cleanup.unref();
+  // Clear the sweep timer when the app closes so it can't leak across app
+  // instances — buildApp is constructed per-test, so an un-cleared unref'd timer
+  // accumulates one live handle per test run.
+  app.addHook('onClose', async () => clearInterval(cleanup));
 
   app.addHook('onRequest', async (request, reply) => {
     if (request.method !== 'POST') return;
@@ -52,12 +56,14 @@ export function registerCaptureQuota(
 
     entry.count++;
     if (entry.count > maxCaptures) {
-      reply.status(429);
-      throw new Error(
-        `Capture quota exceeded for this token (max ${maxCaptures} per ${Math.round(
+      // Send a structured 429 + return, rather than THROWING a generic Error into
+      // Fastify's error pipeline — an expected quota rejection should not be logged
+      // as a server error / trip error-monitoring false alarms.
+      return reply.status(429).send({
+        error: `Capture quota exceeded for this token (max ${maxCaptures} per ${Math.round(
           windowMs / 1000,
         )}s). Slow down, or ask an admin to raise the quota.`,
-      );
+      });
     }
   });
 }

--- a/packages/store/src/audit-anchor.test.ts
+++ b/packages/store/src/audit-anchor.test.ts
@@ -74,6 +74,26 @@ describe('audit-anchor', () => {
     expect(readAnchors(anchorPath)).toHaveLength(2);
   });
 
+  it('appendAnchor is a no-op on an UNCHANGED head — a no-op run adds no anchor (jfv.2.5c)', () => {
+    const repo = mockRepo(buildChain(['a', 'b', 'c']));
+    const first = appendAnchor(repo, anchorPath, {
+      tenantId: 'local',
+      nowFn: () => '2026-06-17T01:00:00.000Z',
+    });
+    // Same head, same row count (a no-op govern run) → returns the last record,
+    // writes NO new anchor line and no new chain link.
+    const again = appendAnchor(repo, anchorPath, {
+      tenantId: 'local',
+      nowFn: () => '2026-06-17T02:00:00.000Z',
+    });
+    expect(again).toEqual(first);
+    expect(readAnchors(anchorPath)).toHaveLength(1);
+    // But a REAL new write still anchors.
+    const grown = mockRepo(buildChain(['a', 'b', 'c', 'd']));
+    appendAnchor(grown, anchorPath, { tenantId: 'local', nowFn: () => '2026-06-17T03:00:00.000Z' });
+    expect(readAnchors(anchorPath)).toHaveLength(2);
+  });
+
   it('verifyAnchors passes on a clean chain + intact log', () => {
     const repo = mockRepo(buildChain(['a', 'b', 'c']));
     appendAnchor(repo, anchorPath, { tenantId: 'local' });

--- a/packages/store/src/audit-anchor.ts
+++ b/packages/store/src/audit-anchor.ts
@@ -104,6 +104,23 @@ export function appendAnchor(
   const rows = chainedRowsOf(repo);
   const head = rows.length > 0 ? (rows[rows.length - 1]!.entry_hash ?? '') : '';
   const existing = readAnchors(anchorPath);
+
+  // No-op guard (jfv.2.5c): a govern/transition run that changed no durable state
+  // leaves the chain head AND the chained-row count identical to the last anchor.
+  // Re-appending an identical-head anchor (and, for the git-committing caller,
+  // re-committing it) every no-op nightly bloats the append-only log + git history
+  // for ZERO tamper-evidence gain — the head is already witnessed. Return the last
+  // record unchanged instead. Skips ONLY on an EXACT (chainHead, chainedRows) match,
+  // so any real new write still anchors; never touches or rewrites existing anchors.
+  const lastAnchor = existing.length > 0 ? existing[existing.length - 1]! : null;
+  if (
+    lastAnchor !== null &&
+    lastAnchor.chainHead === head &&
+    lastAnchor.chainedRows === rows.length
+  ) {
+    return lastAnchor;
+  }
+
   const prevAnchorHash = existing.length > 0 ? existing[existing.length - 1]!.anchorHash : null;
 
   const body: AnchorBody = {


### PR DESCRIPTION
> **Stacked on #239 → #238** (base = `feat/capture-intake-dedup`). Retargets to `main` as the stack merges.

## What (Track 3)
- **Per-actor capture quota (`jfv.10`)** — a `capture-quota` middleware caps how many candidates ONE token identity (`request.actor`) may `POST /api/candidates` per window (default 60/60s), after auth. Intake only.
- **Aligned default DB path** (footgun) — the API default was `~/.teamkb/data/teamkb.db` while the plugin/brain uses `~/.teamkb/teamkb.db`; a no-`TEAMKB_DB_PATH` deploy silently wrote captures to a DB the govern sweep never read. Default is now `resolveTeamKbPath('teamkb.db')`.
- **No-op anchor skip (`jfv.2.5c`)** — `appendAnchor` returns the last record unchanged (writes no new line) when the chain head **and** row count match the last anchor, so a no-op nightly stops bloating the anchor log + git history.

## Why (+ decision rationale)
- Quota: the IP limiter gives no real cap on the tailnet (every device = its own IP). *Chose a per-actor onRequest hook on the intake path over extending the IP limiter* so the cap follows the token; reads/promote/reject unaffected.
- DB path: *chose to align the default over assert-and-warn* — a warning still loses captures; aligning makes a no-override deploy correct. The live deploy uses `TEAMKB_DB_PATH`, unaffected.
- Anchor: *chose to guard inside `appendAnchor` (skip on exact head+rows match) over exporting a peek accessor* — one contained change fixes every caller and never touches/rewrites existing anchors (honoring never-rehash-the-chain).

## Layer(s) touched
INTKB control plane — intake middleware + config (api), and the audit-anchor primitive (store; the plugin's govern consumes it via the bundled store, so `jfv.2.5c` reaches the runtime on the plugin bundle rebuild).

## Verification & evidence
- `pnpm typecheck` (whole graph) **exit 0**; `pnpm lint` **exit 0**; **store 225 + api 325** pass. New: quota 429s the (N+1)th intake + ignores reads/other paths; `appendAnchor` no-op on unchanged head (one anchor after two identical calls; a real new write still anchors).

## Risk
DB-path default change is behavioural for **no-override** deploys only (live deploy overrides). The anchor no-op skips only an EXACT-match redundant append (`verifyAnchors` semantics unchanged). Quota default (60/60s) is generous; tune via `captureQuotaMax`.

## Operational impact
No migration. Fresh API deploy defaults to `~/.teamkb/teamkb.db`; existing deploys keep `TEAMKB_DB_PATH`. `captureQuotaMax`/`WindowMs` are `buildApp` options.

## Follow-up / deferred
`jfv.2.5(b)` non-swallowing batch receipt is the companion plugin PR (it lives in the plugin's `govern.ts`). Track 4 (`jfv.7`) next.

## Governance links
Refs `compile-then-govern jfv.10, jfv.2.5c` (+ DB-path footgun); `014-AT-DECR`; `governed-second-brain#36`. Stacked on #239.

- Jeremy Longshore
intentsolutions.io