### PR TITLE
feat(api): idempotent candidate intake — tenant-scoped content-hash dedup (jfv.9)

### DIFF
--- a/apps/api/src/__tests__/candidates.test.ts
+++ b/apps/api/src/__tests__/candidates.test.ts
@@ -62,16 +62,48 @@ describe('/api/candidates', () => {
     expect((getRes.body as { content: string }).content).toBe(content);
   });
 
-  it('POST accepts duplicate candidates with different IDs', async () => {
-    const content = 'Shared content between two candidates';
-    const first = makeCandidate({ content });
-    const second = makeCandidate({ content, id: randomUUID() });
+  it('POST is idempotent by content within a tenant — a re-send returns the existing row, no duplicate (jfv.9)', async () => {
+    const content = 'Shared content — a re-sent proposal must not duplicate the inbox row';
+    const first = makeCandidate({ content, tenantId: 'team-alpha' });
+    // A re-send: SAME content, DIFFERENT id (models a retry / outbox drain that
+    // re-derived the row). Content-hash dedup catches it regardless of id.
+    const second = makeCandidate({ content, id: randomUUID(), tenantId: 'team-alpha' });
 
     const r1 = await injectJson(app, 'POST', '/api/candidates', first);
     const r2 = await injectJson(app, 'POST', '/api/candidates', second);
 
     expect(r1.status).toBe(201);
     expect(r2.status).toBe(201);
+    // The re-send returns the FIRST candidate (deduped), not a second row.
+    expect((r2.body as { id: string }).id).toBe((r1.body as { id: string }).id);
+    const list = (await injectJson(app, 'GET', '/api/candidates?tenantId=team-alpha'))
+      .body as Array<{ content: string }>;
+    expect(list.filter((c) => c.content === content).length).toBe(1);
+  });
+
+  it('POST does NOT dedup identical content across tenants (tenant-scoped, jfv.9)', async () => {
+    const content = 'A convention two teams independently wrote down';
+    await injectJson(
+      app,
+      'POST',
+      '/api/candidates',
+      makeCandidate({ content, tenantId: 'team-alpha' }),
+    );
+    await injectJson(
+      app,
+      'POST',
+      '/api/candidates',
+      makeCandidate({ content, id: randomUUID(), tenantId: 'team-beta' }),
+    );
+    const a = (await injectJson(app, 'GET', '/api/candidates?tenantId=team-alpha')).body as Array<{
+      content: string;
+    }>;
+    const b = (await injectJson(app, 'GET', '/api/candidates?tenantId=team-beta')).body as Array<{
+      content: string;
+    }>;
+    // Each tenant keeps its own copy — one tenant's content is never deduped against another's.
+    expect(a.filter((c) => c.content === content).length).toBe(1);
+    expect(b.filter((c) => c.content === content).length).toBe(1);
   });
 
   it('POST with full metadata fields succeeds', async () => {

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -177,6 +177,18 @@ export class CandidateService {
     }
 
     const contentHash = computeContentHash(candidate.content);
+
+    // Idempotent intake (jfv.9): a re-sent proposal — a retried/hook-driven capture,
+    // or the plugin's durable-outbox drain replaying the SAME row — must not create a
+    // duplicate inbox candidate. If identical content already exists FOR THIS TENANT,
+    // return the existing candidate instead of inserting a second row (and skip a
+    // second 'proposed' receipt — the original already carries one). Tenant-scoped so
+    // one tenant's content can never be deduped against (or leak) another's.
+    const existing = this.repo.findByContentHashAndTenant(contentHash, candidate.tenantId);
+    if (existing !== null) {
+      return existing;
+    }
+
     this.repo.insert(candidate, contentHash);
 
     // R8 intake receipt: every accepted proposal gets a provenance receipt from

--- a/packages/store/src/__tests__/candidate-repository.test.ts
+++ b/packages/store/src/__tests__/candidate-repository.test.ts
@@ -54,6 +54,22 @@ describe('CandidateRepository', () => {
     expect(found?.id).toBe(candidate.id);
   });
 
+  it('findByContentHashAndTenant is tenant-scoped — same content, other tenant → null (jfv.9)', () => {
+    // team-alpha and team-beta both store the SAME content.
+    const { candidate: a, contentHash } = makeCandidate({
+      tenantId: 'team-alpha',
+      content: 'shared body',
+    });
+    const { candidate: b } = makeCandidate({ tenantId: 'team-beta', content: 'shared body' });
+    repo.insert(a, contentHash);
+    repo.insert(b, contentHash);
+    // The dedup lookup only ever returns the caller's OWN tenant's row.
+    expect(repo.findByContentHashAndTenant(contentHash, 'team-alpha')?.id).toBe(a.id);
+    expect(repo.findByContentHashAndTenant(contentHash, 'team-beta')?.id).toBe(b.id);
+    // A tenant with no such content gets null (not another tenant's row).
+    expect(repo.findByContentHashAndTenant(contentHash, 'team-gamma')).toBeNull();
+  });
+
   it('count returns the correct number of candidates', () => {
     expect(repo.count()).toBe(0);
     const { candidate: c1, contentHash: h1 } = makeCandidate();

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -124,6 +124,7 @@ export class CandidateRepository {
   private readonly stmtFindByTenant: Database.Statement;
   private readonly stmtFindByStatus: Database.Statement;
   private readonly stmtFindByHash: Database.Statement;
+  private readonly stmtFindByHashAndTenant: Database.Statement;
   private readonly stmtCount: Database.Statement;
   private readonly stmtCountByTenant: Database.Statement;
   private readonly stmtDeleteByBatch: Database.Statement;
@@ -161,6 +162,13 @@ export class CandidateRepository {
 
     this.stmtFindByHash = db.prepare(`
       SELECT * FROM candidates WHERE content_hash = ? LIMIT 1
+    `);
+
+    // Tenant-scoped content-hash lookup — the idempotent-intake dedup (jfv.9). Scoped
+    // by (content_hash, tenant_id) so one tenant's re-sent proposal is never deduped
+    // against (nor can it read) another tenant's candidate.
+    this.stmtFindByHashAndTenant = db.prepare(`
+      SELECT * FROM candidates WHERE content_hash = ? AND tenant_id = ? LIMIT 1
     `);
 
     // Non-destructive terminal marker for a governed candidate (B1). The row is
@@ -300,6 +308,17 @@ export class CandidateRepository {
    */
   findByContentHash(hash: string): MemoryCandidate | null {
     const row = this.stmtFindByHash.get(hash);
+    return row !== undefined ? rowToCandidate(row) : null;
+  }
+
+  /**
+   * Return the first candidate with the given content hash FOR A TENANT, or null —
+   * the tenant-scoped dedup the idempotent intake path uses (jfv.9). Prefer this
+   * over {@link findByContentHash} on any per-tenant write path: the unscoped
+   * variant can return another tenant's row.
+   */
+  findByContentHashAndTenant(hash: string, tenantId: string): MemoryCandidate | null {
+    const row = this.stmtFindByHashAndTenant.get(hash, tenantId);
     return row !== undefined ? rowToCandidate(row) : null;
   }
 


### PR DESCRIPTION
> Supersedes #239, which GitHub auto-closed when its base branch (#238's head) was deleted on the squash-merge. Same content, rebased onto `main` (now targets `main` cleanly).

## What
Wire the (previously dead) content-hash dedup into candidate intake so a re-sent proposal doesn't create a duplicate inbox row:
- `CandidateService.intake` now looks up `findByContentHashAndTenant(contentHash, tenantId)` **before** insert; on a hit it returns the existing candidate (skipping a second `proposed` receipt) instead of inserting a second row.
- NEW `CandidateRepository.findByContentHashAndTenant` — a **tenant-scoped** variant of the existing (cross-tenant) `findByContentHash`.

## Why (+ decision rationale)
Intake never deduped (`findByHash` existed but was never called on the intake path — dead code), so a retried/hook-driven `brain_capture`, or the plugin's durable-outbox drain replaying the same row, piled up duplicates. Server half of `jfv.9` idempotency (client half = the plugin's UUIDv5 id). *Chose a new tenant-scoped `findByContentHashAndTenant` over reusing `findByContentHash`* because the latter is cross-tenant (`WHERE content_hash=? LIMIT 1`) — deduping against it would match another tenant's row, leaking cross-tenant state.

## Layer(s) touched
INTKB control plane — the remote-capture intake path (candidate-service + store). No schema/migration change.

## Verification & evidence
`pnpm typecheck` (whole graph) + `pnpm lint` exit 0; **store 224 + api 323** pass. New tests: repo tenant-scoping (same content, other tenant → null); API idempotent-within-tenant (re-send returns the first row, one row total); API not-deduped-across-tenants. Rebased-diff vs `main` is exactly these 4 files (verified post-rebase).

## Risk
Intended behaviour change: a same-content re-send within a tenant returns the existing candidate (201) instead of a second row. Cross-tenant identical content unaffected. No public-API shape change. Internal control plane.

## Operational impact
None — no env/migration/dep. Redeploy the API to take effect. Pairs with the plugin UUIDv5 id + durable outbox.

## Follow-up / deferred
Client-side UUIDv5 id + outbox = `governed-second-brain-plugin` PR (#27). `#240` (jfv.10/2.5c) stacks on THIS branch.

## Governance links
Refs `compile-then-govern jfv.9` (Track 2); `014-AT-DECR`; `governed-second-brain#36`. Base #238 merged (e72f2fd).

- Jeremy Longshore
intentsolutions.io