### PR TITLE
ci(track2): promote the govern-decision + provenance evals to a named required job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,25 +68,11 @@ jobs:
         # only the coverage instrumentation is added.
         run: pnpm test:coverage
 
-      - name: Provenance-integrity eval (real on-disk brain, forks pass / tamper fails)
-        # A REAL end-to-end run of evaluateProvenanceIntegrity against a seeded
-        # throwaway brain carrying a benign CHAIN_FORK. Named gate for
-        # 010-AT-RISK R5 / bead compile-then-govern-e06.2: proves the eval passes
-        # on a forked-but-untampered chain (the live brain's shape: 155 forks,
-        # 0 tamper) while still failing closed on genuine tampering. Complements
-        # the in-memory unit tests above with a real-DB regression guard.
-        run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
-
-      - name: Govern-decision eval (per-check precision/recall, fail-closed on missed secret/PII)
-        # 010-AT-RISK R5/R10 · bead compile-then-govern-e06.3: runs the govern
-        # decision over the versioned adversarial labeled set (dataset/v1) and
-        # prints PER-CHECK precision/recall + the false-negative list. Fails
-        # CLOSED on any UNDOCUMENTED false-negative — a missed secret/PII the
-        # dataset did not already flag as a known, tracked gap (i.e. a regression
-        # or a new evasion). Documented gaps (split keys, base64, boundary blind
-        # spots) are reported, not failed. Determinism is not efficacy; this gate
-        # makes the moat's catch-rate a required, measured property.
-        run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
+      # The provenance-integrity + govern-decision "moat" evals moved to their own
+      # required `moat-evals` job (below) so each is an INDIVIDUALLY-NAMED,
+      # branch-protection-required check — the moat's catch-rate is a first-class
+      # gate, not a step buried in `validate` that a refactor could silently weaken
+      # (bead compile-then-govern-6ps.5, Track 2).
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
@@ -118,6 +104,43 @@ jobs:
           name: test-results
           path: coverage/
           retention-days: 14
+
+  moat-evals:
+    # The govern-by-code moat as an INDIVIDUALLY-NAMED, required per-PR gate
+    # (bead compile-then-govern-6ps.5, Track 2). Runs in parallel with `validate`.
+    # Two fail-closed evals prove the differentiators with numbers, not adjectives:
+    #   • provenance-integrity — a forked-but-untampered chain passes; genuine
+    #     tampering fails closed (the receipts moat).
+    #   • govern-decision — per-check precision/recall over the versioned
+    #     adversarial labeled set; fails on any UNDOCUMENTED false-negative (a
+    #     missed secret/PII the dataset didn't already track). The catch-rate is
+    #     a required, measured property — determinism is not efficacy.
+    # Kept out of `validate` so a refactor there can't silently drop the gate, and
+    # so "moat-evals" is a distinct check the branch-protection rule requires.
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Put workspace bins on PATH (qmd)
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+      - name: Provenance-integrity eval (real on-disk brain, forks pass / tamper fails)
+        # 010-AT-RISK R5 / bead compile-then-govern-e06.2: evaluateProvenanceIntegrity
+        # against a seeded throwaway brain with a benign CHAIN_FORK — passes on a
+        # forked-but-untampered chain (the live brain's shape: 155 forks, 0 tamper)
+        # while failing closed on genuine tampering.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
+      - name: Govern-decision eval (per-check precision/recall, fail-closed on missed secret/PII)
+        # 010-AT-RISK R5/R10 · bead compile-then-govern-e06.3: the govern decision
+        # over the versioned adversarial labeled set (dataset/v1); prints PER-CHECK
+        # precision/recall + the false-negative list. Fails CLOSED on any
+        # UNDOCUMENTED false-negative. Documented gaps are reported, not failed.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
 
   integration:
     # L4 integration tests via testcontainers. Pulls real Docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Put workspace bins on PATH (qmd)
         run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+      - name: Build workspace (tsc -b emits the dist the eval tsx scripts import)
+        # provenance:ci imports @qmd-team-intent-kb/{common,store,schema} via their
+        # package.json "exports" -> dist/, so the project-references build must run
+        # first. In `validate` this happens as a side effect of `typecheck` (also
+        # `tsc -b`); moat-evals builds explicitly so it is self-contained.
+        run: pnpm build
       - name: Provenance-integrity eval (real on-disk brain, forks pass / tamper fails)
         # 010-AT-RISK R5 / bead compile-then-govern-e06.2: evaluateProvenanceIntegrity
         # against a seeded throwaway brain with a benign CHAIN_FORK — passes on a


### PR DESCRIPTION
## What
Extracts the two **moat evals** (provenance-integrity + govern-decision) from the monolithic `validate` job into a dedicated **`moat-evals`** job that runs in parallel on every PR, so each is an individually-named, branch-protection-required check.

## Why
Bead `compile-then-govern-6ps.5` (Track 2 of the GSB testing initiative, epic intent-solutions-io/governed-second-brain#41 / BRAIN-11). The evals were already fail-closed steps inside the branch-protection-required `validate` job — so they *did* block merge — but as buried steps they were (a) invisible as a first-class gate and (b) refactor-fragile (a `validate` reorg or a stray `continue-on-error` could silently weaken the moat). A named `moat-evals` required check makes the govern-by-code catch-rate + the receipts tamper-gate **visible, individually-required** properties.

**Chose** a separate job **over** a belt-and-suspenders double-run in both jobs (the evals would run twice per PR) and **over** leaving them buried in `validate` (the status quo the bead targets).

## Layer(s) touched
CI/enforcement only — no product code, no eval-logic change (identical `provenance:ci` + `govern:ci` commands).

## How it works
`moat-evals` mirrors `validate`'s setup (checkout / pnpm / node 20 / install / qmd-on-PATH) minus the coverage machinery, then runs the two eval scripts. They resolve workspace packages from source via `tsx` (only `integration` runs `pnpm build`), so no build step is needed.

## Verification & evidence
- `python3 yaml.safe_load` parses; `actionlint` clean; jobs = `[validate, moat-evals, integration]`.
- `govern:ci` run **locally**: PASS — dataset v1.2.0, 33 cases, **mean F1 0.8526**, per-check precision 1.0000 across all four checks, **zero UNDOCUMENTED false-negatives** (all misses are tracked gaps: split/base64/hex-encoded secrets, metadata-filepath PII, tenant-spoof).
- CI on this PR is the live proof the extracted job runs green.

## Risk
Low but **enforcement-sensitive**: moving the evals out of the required `validate` job means `moat-evals` MUST be added to branch protection required checks or the gate goes soft. Mitigation: `moat-evals` is added to required checks **before** this PR merges (GitHub permits requiring a check before its first report) — no window where the evals are non-blocking.

## Operational impact
On ship, branch-protection `required_status_checks.contexts` gains `moat-evals` (via `gh api`). No env/deps/secrets/deploy-order change.

## Follow-up & deferred
`6ps.6` adds the retrieval-eval ratchet as a sibling required gate (fixes the CI silent-skip).

## Refs
Part of epic `compile-then-govern-6ps` (#41). Bead `6ps.5`.

- Jeremy Longshore
intentsolutions.io