### PR TITLE
test(qmd-adapter): gate retrieval on a self-contained stratified ratchet (6ps.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,38 @@ jobs:
         # UNDOCUMENTED false-negative. Documented gaps are reported, not failed.
         run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
 
+  retrieval-eval:
+    # Self-contained retrieval RATCHET (bead compile-then-govern-6ps.6, Track 2).
+    # Runs in parallel with the other CI jobs. The live retrieval eval
+    # (governed-brain-v1) reads `~/.teamkb` and so skips on every cold runner —
+    # its number is measured but never enforced. This job builds a THROWAWAY qmd
+    # index over the COMMITTED synthetic corpus (never ~/.teamkb), runs the
+    # `synthetic-v1` stratified set through the production BM25 path, and fails
+    # if lexical OR semantic Recall@10 regresses below its committed baseline.
+    # Kept as its own individually-named check so retrieval quality is a
+    # first-class, branch-protection-eligible gate — not a step buried in
+    # `validate` a refactor could silently drop.
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Put workspace bins on PATH (pinned @tobilu/qmd)
+        # The ratchet baseline is measured against the pinned workspace qmd, so
+        # the gate must run against that same binary, not a stray system qmd.
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+      - name: Verify qmd on PATH
+        run: qmd --version
+      - name: Build workspace (the compiled eval script imports workspace packages via dist)
+        run: pnpm build
+      - name: Retrieval ratchet (stratified Recall@10 over the committed synthetic corpus)
+        run: pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci
+
   integration:
     # L4 integration tests via testcontainers. Pulls real Docker images
     # (~50MB postgres:16-alpine for now). Slower than the validate job;

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "reindex": "node dist/cli.js reindex",
-    "search-canary": "node dist/cli.js canary"
+    "search-canary": "node dist/cli.js canary",
+    "eval:retrieval:ci": "node dist/eval/ci-retrieval-ratchet.js"
   },
   "dependencies": {
     "@qmd-team-intent-kb/schema": "workspace:*",

--- a/packages/qmd-adapter/src/eval/ci-retrieval-ratchet.ts
+++ b/packages/qmd-adapter/src/eval/ci-retrieval-ratchet.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * CI retrieval RATCHET (bead compile-then-govern-6ps.6, Track 2 of the
+ * "most-PROVEN" testing initiative).
+ *
+ * The problem this closes: `eval-retrieval-live.test.ts` and
+ * `scripts/eval-retrieval.ts` both read the LIVE `~/.teamkb` index, so they
+ * `describe.skipIf` / exit 2 on any cold runner. The real retrieval number
+ * (governed-brain-v1) is therefore NEVER enforced in CI — it is a local-only
+ * figure. This script makes retrieval a first-class, self-contained CI gate:
+ *
+ *   1. Build a THROWAWAY qmd BM25 index over the COMMITTED synthetic corpus
+ *      (`fixtures/synthetic-corpus/`) in a temp dir — NEVER `~/.teamkb`.
+ *   2. Run the `synthetic-v1` stratified query set through the exact same
+ *      production `adapter.query()` BM25 path `brain_search` uses.
+ *   3. Compute Recall@10 per stratum SEPARATELY (lexical + semantic), never the
+ *      blended average — a healthy overall can hide a semantic collapse.
+ *   4. Assert a RATCHET: fail (exit 1) if either stratum's Recall@10 drops below
+ *      its committed baseline minus epsilon. This guards the retrieval we ship
+ *      against regression; it deliberately does NOT gate on the absolute 0.85
+ *      ADR-038 sufficiency bar (that is a build-the-semantic-path decision
+ *      threshold, not a ship gate).
+ *
+ * Determinism: qmd BM25 over a fixed corpus + fixed queries is deterministic, so
+ * the baseline in `datasets/synthetic-v1.ts` is a stable floor for the pinned
+ * `@tobilu/qmd` version. Run via `pnpm --filter @qmd-team-intent-kb/qmd-adapter
+ * eval:retrieval:ci` (puts the pinned workspace qmd on PATH); CI does `pnpm
+ * build` first so this compiled entry can resolve its workspace-package imports.
+ *
+ * Exit codes: 0 = ratchet held; 1 = a stratum regressed (or an unexpected
+ * error); 2 = qmd unavailable or the freshly built index answered nothing
+ * (misconfig — fail loudly rather than report a fake 0).
+ *
+ * @module eval/ci-retrieval-ratchet
+ */
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { QmdAdapter } from '../adapter.js';
+import { reindex } from '../reindex/reindex.js';
+import { runEval } from './run-eval.js';
+import { stratify, formatStratifiedReport } from './stratified-report.js';
+import type { StratumMetrics } from './stratified-report.js';
+import { qmdRetrievalFn } from './qmd-retrieval.js';
+import {
+  SYNTHETIC_V1_DATASET,
+  SYNTHETIC_V1_BASELINE,
+  RATCHET_EPSILON,
+} from './datasets/synthetic-v1.js';
+
+/** A synthetic tenant — the temp index is bound to it; it never touches the real brain. */
+const SYNTHETIC_TENANT = 'synthetic';
+
+/**
+ * Locate the committed synthetic corpus. This file runs compiled from
+ * `dist/eval/ci-retrieval-ratchet.js` (CI) but the `.md` fixtures live in
+ * `src/eval/fixtures/synthetic-corpus/` (tsc does not copy them), so resolve
+ * against both the src layout (tsx) and the dist layout (compiled) and fail
+ * loudly if neither exists — a missing corpus must not silently pass as "0 hits".
+ */
+function resolveCorpusDir(): string {
+  const hereDir = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(hereDir, 'fixtures', 'synthetic-corpus'), // running from src (tsx)
+    join(hereDir, '..', '..', 'src', 'eval', 'fixtures', 'synthetic-corpus'), // running from dist
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(
+    `synthetic corpus not found; looked in:\n  ${candidates.join('\n  ')}\n` +
+      '(did the build move the fixtures, or is the working dir wrong?)',
+  );
+}
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** One stratum's ratchet verdict. */
+interface RatchetCheck {
+  stratum: string;
+  measured: number;
+  baseline: number;
+  floor: number;
+  held: boolean;
+}
+
+function checkStratum(
+  m: StratumMetrics | undefined,
+  stratum: string,
+  baseline: number,
+): RatchetCheck {
+  const measured = m?.meanRecallAtK ?? 0;
+  const floor = baseline - RATCHET_EPSILON;
+  return { stratum, measured, baseline, floor, held: measured >= floor };
+}
+
+/**
+ * Build the temp index, run the eval, print the stratified report, and enforce
+ * the ratchet. Returns the process exit code; a caller (or the entry guard)
+ * turns that into `process.exit`.
+ */
+export async function runRetrievalRatchet(): Promise<number> {
+  if (!qmdAvailable()) {
+    console.error(
+      'qmd binary not on PATH — cannot run the retrieval ratchet. Run via ' +
+        '`pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci` so the pinned workspace qmd resolves.',
+    );
+    return 2;
+  }
+
+  const corpusDir = resolveCorpusDir();
+  // Isolated temp base — TEAMKB_BASE_PATH drives every qmd index/registry path
+  // (config/cache under <base>/qmd-index/<tenant>/...), so nothing here can read
+  // or write the real `~/.teamkb`. MUST be set BEFORE constructing QmdAdapter,
+  // whose executor snapshots the tenant XDG env at construction time.
+  const tmpBase = mkdtempSync(join(tmpdir(), 'teamkb-retrieval-ratchet-'));
+  process.env['TEAMKB_BASE_PATH'] = tmpBase;
+
+  try {
+    const exportDir = join(tmpBase, 'kb-export');
+    cpSync(corpusDir, exportDir, { recursive: true });
+
+    const adapter = new QmdAdapter({ tenantId: SYNTHETIC_TENANT, exportDir });
+    const built = await reindex(adapter);
+    if (!built.ok) {
+      console.error(
+        `Failed to build the synthetic qmd index: ${built.error.code}: ${built.error.message}`,
+      );
+      return 2;
+    }
+
+    const retrieve = qmdRetrievalFn(adapter, SYNTHETIC_TENANT, 'curated');
+    const report = await runEval(SYNTHETIC_V1_DATASET, retrieve, { k: 10, backend: 'qmd-bm25' });
+
+    // A totally empty result set means the index did not build, not that BM25
+    // scored 0. Fail loudly (exit 2) rather than let the ratchet read a fake 0.
+    if (!report.perQuery.some((r) => r.retrieved.length > 0)) {
+      console.error(
+        'Every query returned 0 hits against the freshly built synthetic index — ' +
+          'the index is empty/misbuilt, not a real regression.',
+      );
+      return 2;
+    }
+
+    const sr = stratify(report, SYNTHETIC_V1_DATASET.queries);
+
+    console.log(`\n=== Governed Second Brain — synthetic retrieval ratchet (${sr.dataset}) ===`);
+    console.log(`corpus: ${corpusDir}`);
+    console.log(
+      `temp index: ${tmpBase}  ·  tenant: ${SYNTHETIC_TENANT}  ·  queries: ${report.queryCount}\n`,
+    );
+    console.log(formatStratifiedReport(sr));
+
+    const lexical = sr.byKind.find((s) => s.stratum === 'lexical');
+    const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+    const checks = [
+      checkStratum(lexical, 'lexical', SYNTHETIC_V1_BASELINE.lexicalRecallAtK),
+      checkStratum(semantic, 'semantic', SYNTHETIC_V1_BASELINE.semanticRecallAtK),
+    ];
+
+    console.log(`\n=== ratchet (per-stratum Recall@10 ≥ baseline − ${RATCHET_EPSILON}) ===`);
+    for (const c of checks) {
+      console.log(
+        `  ${c.stratum.padEnd(9)} measured=${c.measured.toFixed(4)}  ` +
+          `baseline=${c.baseline.toFixed(4)}  floor=${c.floor.toFixed(4)}  ` +
+          `${c.held ? 'OK' : 'REGRESSED'}`,
+      );
+    }
+
+    const regressed = checks.filter((c) => !c.held);
+    if (regressed.length > 0) {
+      console.error(
+        `\nRATCHET FAILED — ${regressed.length} stratum/strata regressed below the committed floor:`,
+      );
+      for (const c of regressed) {
+        console.error(
+          `  ${c.stratum}: ${c.measured.toFixed(4)} < ${c.floor.toFixed(4)}. ` +
+            'Investigate the retrieval change; if it is a legitimate improvement elsewhere, ' +
+            're-measure and update SYNTHETIC_V1_BASELINE in the same PR.',
+        );
+      }
+      // Surface which queries missed, for the person reading the failing log.
+      const misses = report.perQuery.filter((r) => r.recallAtK === 0);
+      if (misses.length > 0) {
+        console.error(`\n  BM25 misses (${misses.length}/${report.queryCount}):`);
+        for (const m of misses) {
+          console.error(`    [${m.kind ?? 'untagged'}] ${m.id}: "${m.query}"`);
+        }
+      }
+      return 1;
+    }
+
+    console.log('\nRATCHET PASS — no stratum regressed below its committed floor.');
+    return 0;
+  } finally {
+    rmSync(tmpBase, { recursive: true, force: true });
+  }
+}
+
+/** Entry point — resolve the exit code and terminate. */
+export async function main(): Promise<void> {
+  let code: number;
+  try {
+    code = await runRetrievalRatchet();
+  } catch (err: unknown) {
+    console.error('retrieval ratchet crashed:', err);
+    code = 1;
+  }
+  process.exit(code);
+}
+
+// Direct-execution guard: run `main()` only when invoked as the process entry
+// (`node dist/eval/ci-retrieval-ratchet.js`), not when imported. Mirrors cli.ts.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  void main();
+}

--- a/packages/qmd-adapter/src/eval/datasets/README-synthetic.md
+++ b/packages/qmd-adapter/src/eval/datasets/README-synthetic.md
@@ -1,0 +1,67 @@
+# `synthetic-v1` — the self-contained, CI-gated retrieval eval
+
+`governed-brain-v1` is the _real_ number, but its gold ids point at the live
+`~/.teamkb` corpus, so it can only be produced on a warm dev box and is
+`describe.skipIf`-skipped on every cold CI runner — the number is measured but
+**never enforced**. `synthetic-v1` closes that gap: it runs against a small
+corpus that is **committed to the repo**, so the retrieval quality gate holds on
+a cold runner with zero access to the real brain.
+
+| Piece                | Path                                                              |
+| -------------------- | ----------------------------------------------------------------- |
+| Corpus (16 docs)     | [`../fixtures/synthetic-corpus/`](../fixtures/synthetic-corpus/)  |
+| Dataset (20 queries) | [`./synthetic-v1.ts`](./synthetic-v1.ts)                          |
+| CI ratchet           | [`../ci-retrieval-ratchet.ts`](../ci-retrieval-ratchet.ts)        |
+| Run                  | `pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci` |
+
+## The corpus
+
+16 tiny governed-brain-style memories under `curated/` (12), `decisions/` (2),
+and `guides/` (2) — the three default-searchable collections. Every doc is a
+short, self-contained "memory": **no secrets, no real internal data**, so the
+corpus is dual-usable as a public showcase. The id space is exactly what
+`qmd search` returns for a locally-built index over these files:
+`qmd://kb-{curated,decisions,guides}/<file-basename>.md`.
+
+## The queries (stratified, semantic-weighted: 8 lexical, 12 semantic)
+
+The split is the whole point — a blended average hides a semantic collapse.
+
+- **lexical (8)** reuse the target doc's exact headline terms → BM25's home
+  turf → all hit.
+- **semantic (12)** avoid the headline. Seven are _body-overlap_ paraphrases
+  (reuse distinctive body wording — BM25 still finds them); five are
+  _synonym / low-overlap_ paraphrases that restate the concept in words the doc
+  never uses (the genuine BM25 recall wall → miss). Real misses are **kept**, not
+  reworded away — that is the signal.
+
+## The ratchet
+
+`ci-retrieval-ratchet.ts` builds a throwaway qmd index over the corpus in a temp
+dir (never `~/.teamkb`), runs the set through the production `adapter.query()`
+BM25 path, computes Recall@10 **per stratum separately**, and fails (exit 1) if
+either stratum drops below its committed baseline minus a small epsilon.
+
+Baselines are **measured, not guessed** — the numbers this corpus + query set
+actually produce against the pinned `@tobilu/qmd` (see `SYNTHETIC_V1_BASELINE`
+in `synthetic-v1.ts`):
+
+| Stratum  | Hits  | Recall@10 |
+| -------- | ----- | --------- |
+| lexical  | 8/8   | 1.0       |
+| semantic | 7/12  | ≈ 0.5833  |
+| overall  | 15/20 | 0.75      |
+
+The ratchet guards the retrieval we already ship against regression. It does
+**not** gate on the absolute 0.85 BM25-sufficiency bar — that is the
+build-the-semantic-path decision threshold from
+[ADR 038-AT-DECR](../../../../../000-docs/038-AT-DECR-retrieval-backend-decision-2026-06-18.md),
+not a ship gate. A retrieval _improvement_ never fails; if a `qmd` bump
+legitimately raises a floor, re-measure and bump the baseline in the same PR.
+
+## Reproduce
+
+```bash
+pnpm build                                                       # emit dist the script imports
+pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci  # build temp index, run, gate
+```

--- a/packages/qmd-adapter/src/eval/datasets/synthetic-v1.ts
+++ b/packages/qmd-adapter/src/eval/datasets/synthetic-v1.ts
@@ -1,0 +1,221 @@
+import type { EvalDataset } from '../eval-types.js';
+
+/**
+ * The SELF-CONTAINED, CI-GATED retrieval eval dataset (bead
+ * compile-then-govern-6ps.6, Track 2 of the "most-PROVEN" testing initiative).
+ *
+ * Unlike `governed-brain-v1`, whose gold ids point at the live `~/.teamkb`
+ * corpus (so its number can only be produced on a warm dev box and is never
+ * enforced in CI), every gold id here resolves against the COMMITTED synthetic
+ * corpus under `../fixtures/synthetic-corpus/`. `ci-retrieval-ratchet.ts` builds
+ * a throwaway qmd index over those fixtures in a temp dir and runs this set, so
+ * the number is reproducible on a cold CI runner with zero access to the real
+ * brain. The corpus is also dual-usable as a public showcase — no secrets, no
+ * real internal data, just governed-brain-style memories.
+ *
+ * Id space: `qmd://kb-{curated,decisions,guides}/<basename>.md` — the same space
+ * `qmd search` returns for a locally-built index over the fixtures (confirmed:
+ * the citation is `qmd://<collection>/<file-basename>`).
+ *
+ * STRATIFIED, weighted toward semantic (8 lexical, 12 semantic) — the split is
+ * the point. `lexical` queries reuse the target's exact headline terms (BM25's
+ * home turf → all hit). `semantic` queries are of two deliberate flavors:
+ *   - body-overlap paraphrases that avoid the headline but reuse distinctive
+ *     body wording (BM25 usually still finds them), and
+ *   - synonym / low-overlap paraphrases that restate the concept in words the
+ *     doc never uses (the genuine BM25 recall wall → miss).
+ * Keeping real misses in the set is what makes the semantic Recall@10 land below
+ * 1.0 and gives the ratchet something honest to defend. Queries were NEVER
+ * reworded to make BM25 succeed.
+ *
+ * The `notes` on each query record the observed outcome at label time against
+ * `@tobilu/qmd` 2.5.3 (the pinned workspace binary CI runs). See
+ * `../ci-retrieval-ratchet.ts` for the gate and `./README-synthetic.md` for the
+ * methodology + reproduction.
+ */
+export const SYNTHETIC_V1_DATASET: EvalDataset = {
+  name: 'synthetic-v1',
+  idSpace: 'qmd:// citation (synthetic corpus)',
+  queries: [
+    // --- lexical (8) — exact headline terms; BM25's home turf ---
+    {
+      id: 'q-lex-01',
+      kind: 'lexical',
+      query: 'confused deputy problem',
+      relevant: ['qmd://kb-curated/confused-deputy.md'],
+      notes: 'Exact title term. Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-02',
+      kind: 'lexical',
+      query: 'hash chain audit log',
+      relevant: ['qmd://kb-curated/hash-chain-audit.md'],
+      notes: 'Exact concept term (spaces, not hyphens). Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-03',
+      kind: 'lexical',
+      query: 'compile then govern',
+      relevant: ['qmd://kb-curated/compile-then-govern.md'],
+      notes: 'Signature architecture name. Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-04',
+      kind: 'lexical',
+      query: 'token passthrough prohibition',
+      relevant: ['qmd://kb-curated/token-passthrough.md'],
+      notes: 'Exact anti-pattern name. Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-05',
+      kind: 'lexical',
+      query: 'row level security',
+      relevant: ['qmd://kb-curated/row-level-security.md'],
+      notes: 'Exact term. Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-06',
+      kind: 'lexical',
+      query: 'multi stage docker build',
+      relevant: ['qmd://kb-curated/multi-stage-docker.md'],
+      notes: 'Exact term (space form; the hyphenated one-token form is weaker). Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-07',
+      kind: 'lexical',
+      query: 'governed memory positioning',
+      relevant: ['qmd://kb-decisions/governed-memory-positioning.md'],
+      notes: 'Exact decision title — exercises the kb-decisions collection. Gold at rank 1.',
+    },
+    {
+      id: 'q-lex-08',
+      kind: 'lexical',
+      query: 'reindex runbook',
+      relevant: ['qmd://kb-guides/reindex-runbook.md'],
+      notes: 'Exact guide title — exercises the kb-guides collection. Gold at rank 1.',
+    },
+
+    // --- semantic, body-overlap (7) — paraphrase avoids the headline but reuses
+    //     distinctive body wording; BM25 still finds the gold ---
+    {
+      id: 'q-sem-01',
+      kind: 'semantic',
+      query: 'a trusted service is tricked into misusing its authority on behalf of a caller',
+      relevant: ['qmd://kb-curated/confused-deputy.md'],
+      notes: 'Paraphrase of the confused-deputy concept reusing body wording. HIT.',
+    },
+    {
+      id: 'q-sem-02',
+      kind: 'semantic',
+      query: 'each entry embeds a hash of the previous entry so editing a past event is detectable',
+      relevant: ['qmd://kb-curated/hash-chain-audit.md'],
+      notes: 'Definition-style paraphrase avoiding "hash chain"; high body overlap. HIT.',
+    },
+    {
+      id: 'q-sem-03',
+      kind: 'semantic',
+      query: 'deny an operation by default and only proceed when a request is explicitly permitted',
+      relevant: ['qmd://kb-curated/fail-closed.md'],
+      notes: 'Concept paraphrase of fail-closed reusing body phrasing. HIT.',
+    },
+    {
+      id: 'q-sem-04',
+      kind: 'semantic',
+      query: 'the model proposes but the deterministic system owns durable state and control',
+      relevant: ['qmd://kb-curated/compile-then-govern.md'],
+      notes: 'Restatement of the control-plane thesis; near-verbatim body match. HIT.',
+    },
+    {
+      id: 'q-sem-05',
+      kind: 'semantic',
+      query: 'a server must reject any credential that was not issued directly to it',
+      relevant: ['qmd://kb-curated/token-passthrough.md'],
+      notes: 'Restatement of the token-passthrough rule reusing body wording. HIT.',
+    },
+    {
+      id: 'q-sem-06',
+      kind: 'semantic',
+      query: 'hand a read-only connection to code paths that must never mutate state',
+      relevant: ['qmd://kb-curated/dual-pool-postgres.md'],
+      notes: 'Paraphrase of dual-pool Postgres avoiding "dual-pool"; strong body overlap. HIT.',
+    },
+    {
+      id: 'q-sem-07',
+      kind: 'semantic',
+      query: 'use real containers instead of mocks to catch integration bugs',
+      relevant: ['qmd://kb-curated/testcontainers.md'],
+      notes: 'Paraphrase of testcontainers-based testing reusing body wording. HIT.',
+    },
+
+    // --- semantic, synonym / low-overlap (5) — restates the concept in words the
+    //     doc never uses; the genuine BM25 recall wall → miss ---
+    {
+      id: 'q-sem-08',
+      kind: 'semantic',
+      query: 'a proxy abuses its elevated permissions for an untrusted client',
+      relevant: ['qmd://kb-curated/confused-deputy.md'],
+      notes:
+        'Same concept as q-sem-01 in synonyms the doc never uses (proxy/abuses/elevated/untrusted). MISS — the wall.',
+    },
+    {
+      id: 'q-sem-09',
+      kind: 'semantic',
+      query: 'a tamper evident ledger where altering history invalidates later entries',
+      relevant: ['qmd://kb-curated/hash-chain-audit.md'],
+      notes: 'Synonym paraphrase (ledger/altering history/invalidates) of the audit chain. MISS.',
+    },
+    {
+      id: 'q-sem-10',
+      kind: 'semantic',
+      query: 'refuse everything unless it appears on an allowlist',
+      relevant: ['qmd://kb-curated/fail-closed.md'],
+      notes:
+        'Concept of fail-closed in words (allowlist/refuse everything) the doc never uses. MISS.',
+    },
+    {
+      id: 'q-sem-11',
+      kind: 'semantic',
+      query: 'keep customers from seeing each other accounts in shared storage',
+      relevant: ['qmd://kb-curated/row-level-security.md'],
+      notes: 'Tenant-isolation concept in synonyms (customers/accounts) the RLS doc avoids. MISS.',
+    },
+    {
+      id: 'q-sem-12',
+      kind: 'semantic',
+      query: 'concentrate on a lone objective and ignore interruptions',
+      relevant: ['qmd://kb-curated/single-tasking.md'],
+      notes:
+        'Single-tasking concept in fresh words (concentrate/lone objective/interruptions). MISS.',
+    },
+  ],
+};
+
+/**
+ * The committed RATCHET baseline — the measured per-stratum Recall@10 this
+ * dataset produces over the committed synthetic corpus with `@tobilu/qmd` 2.5.3.
+ *
+ * These are MEASURED, not guessed:
+ *   - lexical:  8/8 queries hit  → Recall@10 = 1.0
+ *   - semantic: 7/12 queries hit → Recall@10 = 7/12 ≈ 0.5833
+ *
+ * The ratchet fails (non-zero exit) if either stratum's live Recall@10 drops
+ * below its baseline minus {@link RATCHET_EPSILON}. It deliberately does NOT
+ * gate on the absolute 0.85 BM25-sufficiency bar — that is a
+ * build-the-semantic-path DECISION threshold (ADR 038), not a ship gate. The
+ * ratchet only guards against a REGRESSION in the retrieval we already ship.
+ *
+ * The literals mirror the harness math exactly (`7 / 12` is byte-identical to
+ * the mean the eval computes), so a green run has the full epsilon of slack and
+ * only a real discrete regression (any query flipping hit→miss) trips the gate.
+ * A retrieval IMPROVEMENT never fails; if a `qmd` bump legitimately raises the
+ * floor, re-measure and bump these numbers up in the same PR.
+ */
+export const SYNTHETIC_V1_BASELINE = {
+  /** 8/8 lexical queries hit. */
+  lexicalRecallAtK: 1.0,
+  /** 7/12 semantic queries hit. */
+  semanticRecallAtK: 7 / 12,
+} as const;
+
+/** Float-noise tolerance for the ratchet; a genuine regression is far larger. */
+export const RATCHET_EPSILON = 0.001;

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/compile-then-govern.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/compile-then-govern.md
@@ -1,0 +1,11 @@
+# Compile Then Govern
+
+Compile then govern is the signature architecture of the stack. The model
+proposes and compiles raw material into derived knowledge, but the
+deterministic system owns durable state and control. The probabilistic compiler
+never writes the system of record directly; it emits candidates into a spool.
+
+Governance is then applied by code, not by a model: dedupe, policy checks,
+secret detection, trust levels, and promotion are all deterministic. This keeps
+raw and derived strictly separated with provenance from the first byte, and it
+means every durable write passed through a rule a human can read.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/confused-deputy.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/confused-deputy.md
@@ -1,0 +1,13 @@
+# Confused Deputy Problem
+
+The confused deputy problem is a security anti-pattern where a privileged
+service is tricked into misusing its own authority on behalf of a less
+privileged caller. The deputy holds credentials for a downstream system and
+performs an action the caller could not perform directly, so the caller
+smuggles their intent through the trusted intermediary.
+
+In a governed brain the risk shows up when a shared tool holds a broad token
+and a request from one tenant causes it to touch another tenant's data. The
+fix is to never let the intermediary act on ambient authority: scope every
+downstream call to the identity of the original requester and refuse when the
+requester's scope does not cover the target.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/dual-pool-postgres.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/dual-pool-postgres.md
@@ -1,0 +1,11 @@
+# Dual-Pool Postgres
+
+Dual-pool Postgres runs two separate connection pools against one database: a
+writer pool with read-write privileges and a reader pool restricted to
+read-only. Code paths that must never mutate state — the audit verifier, the
+search surface — are handed the reader pool.
+
+Separating the pools makes an accidental write structurally impossible on the
+verification path rather than merely discouraged by convention. The privilege
+boundary lives in the connection, so a bug in read-only code cannot corrupt the
+record it is supposed to be checking.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/fail-closed.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/fail-closed.md
@@ -1,0 +1,11 @@
+# Fail-Closed Default
+
+A fail-closed system denies an operation by default and only proceeds when a
+request is explicitly permitted. When a check cannot run, when a token is
+missing, or when a scope is ambiguous, the safe outcome is refusal rather than
+a silent allow.
+
+The governed brain applies this at every boundary: an unscoped search returns
+nothing instead of leaking a tenant's index, and a governance rule that errors
+is treated as a block, never as a pass. Failing open would trade a visible
+error for an invisible breach, so the default posture is always to stop.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/hash-chain-audit.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/hash-chain-audit.md
@@ -1,0 +1,12 @@
+# Hash Chain Audit Log
+
+The audit log is an append-only sequence of events where each entry embeds a
+cryptographic hash of the previous entry. Because every record commits to the
+one before it, editing or reordering any past event breaks the chain and the
+tampering becomes detectable on the next verification pass.
+
+This is the receipts wedge: the differentiator is not better recall, it is a
+tamper-evident trail that anyone can re-verify after the fact. Note the trail
+is tamper-evident, not tamper-proof — a writer with local access can rewrite an
+event and re-hash forward, so cross-actor guarantees need an external anchor on
+the chain head.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/knowledge-compilation.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/knowledge-compilation.md
@@ -1,0 +1,11 @@
+# Knowledge Compilation
+
+Knowledge compilation transforms a raw corpus into structured, derived
+knowledge through a series of defined passes. Each pass extracts something the
+raw text only implies — summaries, concepts, contradictions, open gaps — and
+records where it came from.
+
+The point is to derive, not merely to index: indexing leaves the material as-is
+and searches over it, while compilation produces new artifacts with provenance
+back to the source. Raw and derived stay strictly separated so a reader can
+always trace a claim to the byte it was built from.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/multi-stage-docker.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/multi-stage-docker.md
@@ -1,0 +1,11 @@
+# Multi Stage Docker Build
+
+A multi stage Docker build separates the build environment from the runtime
+environment inside a single Dockerfile. An early stage installs the full
+toolchain and compiles the artifact; a later, minimal stage copies only the
+finished output and ships that.
+
+The payoff is a much smaller final image with a smaller attack surface: the
+compilers, headers, and dev dependencies never reach production. Keeping the
+heavy build tools out of the runtime layer is the main reason to reach for this
+pattern.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/row-level-security.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/row-level-security.md
@@ -1,0 +1,11 @@
+# Row Level Security
+
+Row level security enforces tenant isolation inside the database itself. A
+policy attached to each table restricts which rows a session can read or write
+based on the current tenant, so isolation does not depend on every query
+remembering to add a filter.
+
+This is defense in depth for multi-tenant storage: even if application code
+forgets a scope clause, the engine still refuses to return another tenant's
+rows. The policy is the last line, evaluated on every statement, and it cannot
+be bypassed by a forgotten predicate in the application layer.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/single-tasking.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/single-tasking.md
@@ -1,0 +1,11 @@
+# Single-Tasking
+
+Single-tasking is the practice of giving one task your complete attention
+before moving to the next. Instead of interleaving several threads of work, you
+pick a single item, clear away distractions, and stay with it until it reaches
+a natural stopping point.
+
+The benefit is less context-switching cost and higher quality output. Each
+switch between tasks carries a hidden reload penalty, so batching attention into
+one stream at a time tends to finish more work with less fatigue than juggling
+everything at once.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/sops-age-secrets.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/sops-age-secrets.md
@@ -1,0 +1,11 @@
+# SOPS Age Secrets Management
+
+SOPS with age encrypts secrets at rest so the ciphertext can be committed to
+git safely. Each value is sealed to one or more age public keys, and only a
+holder of the matching private key can decrypt it, so the repository carries the
+secret without ever exposing the plaintext.
+
+The workflow decrypts in memory at process start rather than writing a
+plaintext file to disk. Committing the encrypted file keeps a single source of
+truth under version control while the private key stays out of the tree,
+rotated independently of the code.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/testcontainers.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/testcontainers.md
@@ -1,0 +1,11 @@
+# Testcontainers-Based Testing
+
+Testcontainers spins up real dependencies — a genuine database, a message
+broker — inside disposable containers for the duration of a test run. Rather
+than substituting a hand-written stand-in for the datastore, the suite talks to
+the same engine that runs in production.
+
+Using real containers instead of mocks catches integration bugs that a fake
+would paper over: dialect quirks, constraint violations, and transaction
+behavior. The container is created before the tests and torn down afterward, so
+each run starts from a clean, reproducible state.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/token-passthrough.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/token-passthrough.md
@@ -1,0 +1,11 @@
+# Token Passthrough Prohibition
+
+Token passthrough is the practice of accepting a bearer token that was issued
+for a different audience and replaying it to an upstream service. It is
+prohibited because it collapses the audience boundary: the receiving server can
+no longer prove that the token was minted for itself.
+
+A server must reject any credential that was not issued directly to it. Instead
+of forwarding an inbound token, exchange it for a fresh, correctly scoped one or
+refuse the call. Passthrough turns every intermediary into a universal key and
+defeats per-audience revocation.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/decisions/governed-memory-positioning.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/decisions/governed-memory-positioning.md
@@ -1,0 +1,11 @@
+# Governed Memory Positioning
+
+Decision: position the product as governed memory, not as another wiki or
+recall engine. The competitive axis is govern plus receipts, not who remembers
+the most. Anyone can store text and search it; the moat is that every durable
+write is deterministic, auditable, and carries a citation.
+
+We deliberately avoid marketing that leans on recall quality, because recall is
+a commodity and receipts are not. The wording stays precise — deterministic,
+append-only, hash-chained — rather than softening into vague memory language,
+since the precision is the whole differentiator.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/decisions/retrieval-backend-bm25-first.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/decisions/retrieval-backend-bm25-first.md
@@ -1,0 +1,11 @@
+# Retrieval Backend BM25 First
+
+Decision: ship keyword BM25 retrieval now and only add a heavier semantic
+vector backend once an eval proves it is needed. BM25 is zero-dependency, runs
+in-process, and every hit is already a citation, so it clears the bar for the
+first release without carrying hundreds of megabytes of model weights.
+
+The gate is a measured recall number on a labeled query set, not a hunch.
+Building the embedding path before the eval shows a real recall wall would be
+premature optimization, so the semantic backend stays deferred until the
+numbers justify its footprint.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/reindex-runbook.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/reindex-runbook.md
@@ -1,0 +1,11 @@
+# Reindex Runbook
+
+The search index is derived state: it can be rebuilt at any time from the
+export tree and is never the source of truth. When search returns nothing on
+known-good queries, the index is stale or was never registered, and the fix is
+to rebuild it rather than to touch the underlying database.
+
+Reindexing registers each collection against its exported directory and then
+updates the index over the current files. The operation is idempotent — running
+it twice with no change to the corpus is a harmless no-op — so it is safe to run
+whenever the search surface looks degraded.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/team-mode-onboarding.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/team-mode-onboarding.md
@@ -1,0 +1,11 @@
+# Team Mode Onboarding
+
+In team mode every teammate reaches one shared brain over the private network
+instead of each running their own local copy. A member's client proxies its
+search to the remote governed brain and authenticates with a per-user bearer
+token, so there is exactly one system of record rather than many divergent ones.
+
+Onboarding a teammate means minting them a scoped token and pointing their
+client at the shared endpoint. The member proposes reads and writes; the server
+still disposes, applying the same governance rules centrally so a new joiner
+cannot bypass policy from their own machine.

--- a/packages/qmd-adapter/src/eval/index.ts
+++ b/packages/qmd-adapter/src/eval/index.ts
@@ -17,3 +17,8 @@ export { stratify, formatStratifiedReport } from './stratified-report.js';
 export type { StratumMetrics, StratifiedReport } from './stratified-report.js';
 export { qmdRetrievalFn } from './qmd-retrieval.js';
 export { GOVERNED_BRAIN_V1_DATASET } from './datasets/governed-brain-v1.js';
+export {
+  SYNTHETIC_V1_DATASET,
+  SYNTHETIC_V1_BASELINE,
+  RATCHET_EPSILON,
+} from './datasets/synthetic-v1.js';


### PR DESCRIPTION
## What
Replaces the CI-invisible retrieval eval with an **enforced, self-contained stratified ratchet**. Adds a committed synthetic corpus (16 governed-brain-style docs, no secrets), a 20-query stratified `synthetic-v1` dataset (8 lexical / 12 semantic), a ratchet gate (`ci-retrieval-ratchet.ts` + `eval:retrieval:ci`), and an individually-named `retrieval-eval` CI job.

## Why
Bead `compile-then-govern-6ps.6` (Track 2, epic intent-solutions-io/governed-second-brain#41 / BRAIN-11). The live retrieval eval (`governed-brain-v1`) reads `~/.teamkb`, so it `describe.skipIf`-skips on every cold CI runner — the ~0.56 number was **measured but never enforced**. This builds a throwaway qmd index over a *committed* corpus (never `~/.teamkb`), runs the production BM25 path, and **fails if lexical OR semantic Recall@10 regresses** below a committed baseline.

**Chose** a ratchet (regression-only) **over** the absolute 0.85 gate: 0.85 is the ADR-038 *build-the-semantic-path decision* threshold, not a ship gate — gating on it would be permanently-red and ignored. Reports lexical + semantic **separately**, never the blended average.

## Layer(s) touched
Retrieve layer / CI only. Reuses the existing harness (`runEval`/`stratify`/`qmdRetrievalFn`/`reindex`) verbatim — zero new metric code. Does not touch `validate` or `integration`.

## How it works
`retrieval-eval` job: install → put `node_modules/.bin` on PATH (the **pinned** `@tobilu/qmd`, so the gate runs against the same binary the baseline was measured on) → `pnpm build` → `eval:retrieval:ci`. The gate builds a `mktemp` index via a `TEAMKB_BASE_PATH` override, runs the 20 queries, and asserts each stratum ≥ baseline − epsilon (0.001). An empty/misbuilt index is reported as such, not a false regression.

## Verification & evidence
- **Independently reproduced via the exact CI path** (pinned qmd 2.5.3 on PATH): lexical **1.0000 (8/8)**, semantic **0.5833 (7/12)**, `RATCHET PASS`, exit 0.
- Deterministic on the pinned qmd. (Running with a *different* qmd — e.g. system 2.0.1 — legitimately shifts one semantic query 7→6/12; that's the version coupling, see below, not flakiness.)
- `pnpm typecheck` / `lint` / `format:check` clean; `depcruise` 0 errors; qmd-adapter suite 158/158.
- `~/.teamkb` untouched across a full run (temp index only, cleaned in `finally`).

## Risk
Low. **Version coupling (intended):** the baseline is tied to the pinned `@tobilu/qmd`. A Dependabot qmd bump that changes tokenization/ranking can legitimately trip the ratchet — the header documents the fix: re-measure + bump `SYNTHETIC_V1_BASELINE` in that same PR. The gate is tight (epsilon 0.001, ~12 semantic queries → a single query flip trips it) — deliberately, since any regression is worth a look.

## Operational impact
On ship, add `retrieval-eval` to branch-protection required checks (via `gh api`, after the first green run). **ci.yml note:** this branch is off `origin/main` (no `moat-evals` yet — that's sibling PR #242); both insert a job before `integration:`, so whichever merges second needs a trivial keep-both conflict resolution.

## Follow-up & deferred
Optional `validate`-level dataset-integrity unit test (id-format + stratum counts) as belt-and-suspenders — deferred; the `retrieval-eval` job exercises the whole pipeline each run.

## Refs
Part of epic `compile-then-govern-6ps` (#41). Bead `6ps.6`.

- Jeremy Longshore
intentsolutions.io