### PR TITLE
docs(phase4): add SUPPORT.md (repo-dress drift)

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,29 @@
+# Support
+
+## Getting Help
+
+- **Documentation**: Check the [README](README.md) and [000-docs/](000-docs/) directory
+- **Bug Reports**: [Open an issue](https://github.com/jeremylongshore/qmd-team-intent-kb/issues/new?template=bug_report.md)
+- **Feature Requests**: [Open an issue](https://github.com/jeremylongshore/qmd-team-intent-kb/issues/new?template=feature_request.md)
+- **Discussions**: [GitHub Discussions](https://github.com/jeremylongshore/qmd-team-intent-kb/discussions)
+- **Security Issues**: See [SECURITY.md](SECURITY.md) — do NOT open public issues
+
+## Response Times
+
+| Channel           | Response Time   |
+| ----------------- | --------------- |
+| Security reports  | 24 hours        |
+| Bug reports       | 3 business days |
+| Feature requests  | 1 week          |
+| General questions | 1 week          |
+
+## Before Opening an Issue
+
+1. Search [existing issues](https://github.com/jeremylongshore/qmd-team-intent-kb/issues) first
+2. Check the [documentation](000-docs/)
+3. Include version info and reproduction steps (which package under `packages/`/`apps/`, `qmd --version`)
+
+## Contact
+
+- **Email**: <jeremy@jeremylongshore.com>
+- **GitHub**: [@jeremylongshore](https://github.com/jeremylongshore)


### PR DESCRIPTION
## What
Add `SUPPORT.md` — the only repo-dress governance file qmd-team-intent-kb was missing (it already has SECURITY + ISSUE/PR templates + TEST_AUDIT).

## Why
Closes the last governance-file drift gap in the Phase-4 estate sweep; matches the estate SUPPORT.md convention (sibling j-rig-binary-eval).

## Refs
Phase-4 governance sweep.

- Jeremy Longshore
intentsolutions.io