### PR TITLE
ci(changelog): dispatch changelog-updated to the umbrella on merge

### DIFF
--- a/.github/workflows/notify-umbrella-changelog.yml
+++ b/.github/workflows/notify-umbrella-changelog.yml
@@ -1,0 +1,40 @@
+name: Notify umbrella changelog aggregator
+
+# Sender side of the umbrella's pull-based changelog aggregation.
+#
+# When CHANGELOG.md changes on main (i.e. a PR touching it merges), POST a
+# repository_dispatch (event_type=changelog-updated) to
+# intent-solutions-io/bobs-big-brain-umbrella. Its aggregate-changelogs.yml
+# listens for that event and refreshes changelogs/<this-repo>.md, so the
+# umbrella mirror updates within minutes of a release instead of waiting for
+# the weekly Monday cron.
+#
+# Requires the UMBRELLA_DISPATCH_TOKEN secret (a PAT able to write the
+# umbrella repo). If unset, this job warn-skips — the weekly cron still
+# refreshes the mirror, so nothing breaks.
+
+on:
+  push:
+    branches: [main]
+    paths: [CHANGELOG.md]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST changelog-updated to the umbrella
+        env:
+          TOKEN: ${{ secrets.UMBRELLA_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::warning::UMBRELLA_DISPATCH_TOKEN not set — skipping dispatch (the umbrella's weekly cron will still refresh)."
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/intent-solutions-io/bobs-big-brain-umbrella/dispatches \
+            -d "{\"event_type\":\"changelog-updated\",\"client_payload\":{\"repo\":\"${GITHUB_REPOSITORY}\",\"sha\":\"${GITHUB_SHA}\"}}"


### PR DESCRIPTION
## What
Add `.github/workflows/notify-umbrella-changelog.yml`: on a push to `main` that touches `CHANGELOG.md` (i.e. a merged PR), POST a `repository_dispatch` (`event_type=changelog-updated`) to `intent-solutions-io/bobs-big-brain-umbrella`.

## Why + decision rationale
The umbrella's `aggregate-changelogs.yml` already listens for exactly this event but nothing ever sent it — the `changelogs/` mirror only refreshed on the weekly Monday cron. Chose `repository_dispatch` over widening the umbrella's cron (or polling) because the receiver side already exists; this sender was the only missing half.

## Layer(s) touched
CI only — one new workflow file. No runtime, schema, or product surface.

## How it works
Path-filtered `push` trigger on `main` → `curl` POST `/dispatches` on the umbrella with `UMBRELLA_DISPATCH_TOKEN` (repo secret, set 2026-07-16). Warn-skips cleanly if the secret is absent, so it can never fail CI.

## Verification & evidence
A manual dispatch with the same token scope triggered the umbrella's aggregate run: `repository_dispatch` run created 2026-07-16T20:50:41Z on `intent-solutions-io/bobs-big-brain-umbrella` (aggregate-changelogs.yml). End-to-end re-verified after merge.

## Risk assessment
Minimal: `permissions: {}`, no checkout, no third-party actions; the token is only exposed to this repo's Actions. Worst case is a no-op warn-skip.

## Operational impact
Requires the `UMBRELLA_DISPATCH_TOKEN` secret (already set). Follow-up recommendation: replace the classic-scope PAT with a fine-grained PAT limited to the umbrella repo.

## Follow-up & deferred
Fine-grained PAT swap (all four sub-repos at once).

## Refs
Umbrella receiver: `intent-solutions-io/bobs-big-brain-umbrella` `.github/workflows/aggregate-changelogs.yml`