### PR TITLE
feat(ci): emit signed gate-result evidence for the labs dashboard

### DIFF
--- a/.github/workflows/emit-evidence.yml
+++ b/.github/workflows/emit-evidence.yml
@@ -1,0 +1,175 @@
+# ── Signed-evidence emit: run the three real CI evals, publish signed evidence ──
+#
+# PURELY ADDITIVE workflow: no existing workflow (ci.yml, nightly.yml,
+# release.yml, security.yml), gate, or branch-protection context changes. It
+# is NOT a PR check and never reports a status context.
+#
+# On every push to main (plus a main-only manual dispatch) it:
+#   1. installs + builds the workspace, puts the pinned workspace `qmd` bin on
+#      PATH (same discipline as ci.yml's retrieval-eval job);
+#   2. runs the repo's three REAL CI-blocking evals as subprocesses —
+#      provenance-integrity (provenance:ci), govern-decision (govern:ci), and
+#      the retrieval ratchet (eval:retrieval:ci) — and shapes one kernel
+#      gate-result/v1 row per gate (honest: the ratchet's documented exit 2 =
+#      qmd unavailable becomes gate_decision:"error", never a fake verdict),
+#      wrapped in kernel EvidenceBundles validated against
+#      @intentsolutions/core@0.9.0 — the EXACT version the labs dashboard
+#      verifies with (ci/emit-evidence/);
+#   3. keyless-signs each bundle's canonical bytes with cosign (Fulcio OIDC +
+#      production Rekor), then verifies every signature back in-repo;
+#   4. assembles report-manifest.json and uploads it onto the rolling
+#      `evidence-latest` prerelease (--clobber).
+#
+# The dashboard fetches:
+#   releases/download/evidence-latest/report-manifest.json
+# and pins these OIDC claims for the `qmd` row:
+#   issuer      https://token.actions.githubusercontent.com
+#   subject     repo:jeremylongshore/qmd-team-intent-kb:ref:refs/heads/main
+#   workflowRef jeremylongshore/qmd-team-intent-kb/.github/workflows/emit-evidence.yml@refs/heads/main
+name: Emit signed evidence (labs dashboard)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # activation / re-run without waiting for a push
+
+concurrency:
+  group: emit-evidence
+  cancel-in-progress: true
+
+permissions: {} # default-deny; the job grants exactly what it needs
+
+jobs:
+  emit-sign-publish:
+    name: Run the CI evals and emit signed evidence
+    # Claims must pin refs/heads/main — a dispatch from any other ref would
+    # produce an unverifiable manifest, so guard instead of emitting one.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # create/upload the rolling evidence-latest release
+      id-token: write # cosign keyless (Fulcio OIDC)
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          # Node >= 22.6 — the emit scripts run under --experimental-strip-types.
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace (the compiled gates import workspace packages via dist)
+        run: pnpm build
+
+      - name: Put workspace bins on PATH (pinned @tobilu/qmd)
+        # The retrieval ratchet's baseline is measured against the pinned
+        # workspace qmd, so the gate must run against that same binary, not a
+        # stray system qmd. Same step as ci.yml's retrieval-eval job.
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      # Standalone install (NOT a workspace member): pins the kernel validators
+      # to the exact version the dashboard verifies with, via the committed
+      # ci/emit-evidence/pnpm-lock.yaml. Root workspace untouched.
+      - name: Install kernel validators (standalone, frozen lockfile)
+        working-directory: ci/emit-evidence
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Emit-evidence self-check (kernel-valid + canonical-stable)
+        run: node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --self-check
+
+      - name: Run the three CI evals and emit gate-result/v1 EvidenceBundles
+        run: node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --out build/evidence --ref "${GITHUB_REF}"
+
+      - name: Sign each EvidenceBundle (cosign keyless -> production Rekor)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          signed=0
+          for bundle in build/evidence/bundle-*.json; do
+            case "$bundle" in *.sigstore.json) continue;; esac
+            sig="${bundle%.json}.sigstore.json"
+            echo "::group::cosign sign-blob $bundle"
+            cosign sign-blob --yes --new-bundle-format --bundle "$sig" "$bundle"
+            echo "::endgroup::"
+            signed=$((signed + 1))
+          done
+          if [ "$signed" -eq 0 ]; then
+            echo "::error::no EvidenceBundles were produced to sign"
+            exit 1
+          fi
+          echo "signed $signed bundle(s)"
+
+      # Verify each signature back, in-repo, before publishing — a signature
+      # nobody in the producing pipeline checks is not a verified chain. The
+      # pinned identity is the SAME claim pair the manifest skeleton records
+      # and the dashboard re-checks at ingest.
+      - name: Verify each EvidenceBundle signature (cosign verify-blob; fail-closed)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          cert_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/emit-evidence.yml@${GITHUB_REF}"
+          cert_issuer="https://token.actions.githubusercontent.com"
+          echo "verifying against identity: ${cert_identity}"
+          verified=0
+          for bundle in build/evidence/bundle-*.json; do
+            case "$bundle" in *.sigstore.json) continue;; esac
+            sig="${bundle%.json}.sigstore.json"
+            if [ ! -s "$sig" ]; then
+              echo "::error::expected signature ${sig} for ${bundle} but it is missing/empty"
+              exit 1
+            fi
+            echo "::group::cosign verify-blob $bundle"
+            cosign verify-blob \
+              --new-bundle-format \
+              --bundle "$sig" \
+              --certificate-identity "$cert_identity" \
+              --certificate-oidc-issuer "$cert_issuer" \
+              "$bundle"
+            echo "::endgroup::"
+            verified=$((verified + 1))
+          done
+          if [ "$verified" -eq 0 ]; then
+            echo "::error::no signed EvidenceBundles were found to verify"
+            exit 1
+          fi
+          echo "verified $verified signed bundle(s) — emit->sign->verify chain closed in-repo"
+
+      - name: Assemble report-manifest.json (fail-closed on shape mismatch)
+        run: node --experimental-strip-types ci/emit-evidence/assemble-manifest.ts --dir build/evidence --out build/evidence/report-manifest.json
+
+      # Fixed rolling prerelease: created once (idempotent), then only the
+      # attached manifest asset moves. Prerelease => never shadows the repo's
+      # `latest` (which release.yml owns).
+      - name: Ensure rolling evidence-latest prerelease exists (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view evidence-latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "evidence-latest release already exists"
+          else
+            gh release create evidence-latest \
+              --repo "${GITHUB_REPOSITORY}" \
+              --prerelease \
+              --title "Signed CI-eval evidence (rolling)" \
+              --notes "Rolling signed-evidence manifest for the labs.intentsolutions.io reports hub (repo row key: qmd). One gate-result/v1 row per real CI eval (provenance-integrity, govern-decision, retrieval-ratchet), produced by .github/workflows/emit-evidence.yml on every push to main, re-uploaded (--clobber) each run. Verify: cosign verify-blob against the OIDC identity pinned in the manifest's signing block."
+          fi
+
+      - name: Publish report-manifest.json onto evidence-latest (--clobber)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload evidence-latest build/evidence/report-manifest.json \
+            --repo "${GITHUB_REPOSITORY}" --clobber
+          echo "report-manifest.json published to the evidence-latest rolling prerelease"

--- a/ci/emit-evidence/assemble-manifest.ts
+++ b/ci/emit-evidence/assemble-manifest.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * ci/emit-evidence/assemble-manifest.ts — combine the emit skeleton with the
+ * cosign-produced sigstore bundles into the final `report-manifest.json` the
+ * intent-eval-dashboard fetches for the `qmd` row.
+ *
+ * Runs AFTER `ci/emit-evidence/emit-evidence.ts` (which wrote the skeleton +
+ * canonical bundle files) and AFTER CI has signed each `bundle-<i>.json` with
+ * `cosign sign-blob --bundle bundle-<i>.sigstore.json`. For each skeleton row
+ * it reads back the canonical bundle object + its sigstore bundle and
+ * assembles:
+ *
+ *   { repo, signing, rows: [ { bundle, sigstoreBundle, sourceSha, gateResults } ] }
+ *
+ * This is EXACTLY the shape the dashboard's `isReportManifestShape` accepts:
+ * each row carries `bundle` + `sigstoreBundle` + a string `sourceSha`. The
+ * extra `gateResults` field is additive — the current ingest ignores it; the
+ * gate-row resolver consumes it.
+ *
+ * Fail-closed: a missing bundle file, a missing sigstore bundle, or a
+ * structural mismatch aborts (exit 1) rather than publishing a half-built
+ * manifest.
+ *
+ * Usage:
+ *   node --experimental-strip-types ci/emit-evidence/assemble-manifest.ts \
+ *     [--dir build/evidence] [--out build/evidence/report-manifest.json]
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+interface SkeletonRow {
+  readonly bundleFile: string;
+  readonly gateResults: readonly unknown[];
+  readonly sourceSha: string;
+}
+interface Skeleton {
+  readonly repo: string;
+  readonly signing: {
+    readonly issuer: string;
+    readonly subject: string;
+    readonly workflowRef: string;
+  };
+  readonly rows: readonly SkeletonRow[];
+}
+
+interface ManifestRow {
+  readonly bundle: unknown;
+  readonly sigstoreBundle: unknown;
+  readonly sourceSha: string;
+  readonly gateResults: readonly unknown[];
+}
+interface ReportManifest {
+  readonly repo: string;
+  readonly signing: Skeleton['signing'];
+  readonly rows: readonly ManifestRow[];
+}
+
+/** Mirror of the dashboard's `isReportManifestShape` (kept in sync by review). */
+function isReportManifestShape(value: unknown): value is ReportManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v['repo'] !== 'string') return false;
+  const signing = v['signing'];
+  if (typeof signing !== 'object' || signing === null) return false;
+  const s = signing as Record<string, unknown>;
+  if (typeof s['issuer'] !== 'string') return false;
+  if (typeof s['subject'] !== 'string') return false;
+  if (typeof s['workflowRef'] !== 'string') return false;
+  if (!Array.isArray(v['rows'])) return false;
+  return v['rows'].every((r) => {
+    if (typeof r !== 'object' || r === null) return false;
+    const row = r as Record<string, unknown>;
+    return 'bundle' in row && 'sigstoreBundle' in row && typeof row['sourceSha'] === 'string';
+  });
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function assemble(dir: string): ReportManifest {
+  const skeletonPath = join(dir, 'manifest-skeleton.json');
+  if (!existsSync(skeletonPath)) {
+    throw new Error(`missing ${skeletonPath} — run ci/emit-evidence/emit-evidence.ts first`);
+  }
+  const skeleton = readJson(skeletonPath) as Skeleton;
+
+  const rows: ManifestRow[] = skeleton.rows.map((row) => {
+    const bundlePath = join(dir, row.bundleFile);
+    const sigPath = join(dir, `${basename(row.bundleFile, '.json')}.sigstore.json`);
+    if (!existsSync(bundlePath)) throw new Error(`missing bundle file ${bundlePath}`);
+    if (!existsSync(sigPath)) {
+      throw new Error(
+        `missing sigstore bundle ${sigPath} — was cosign sign-blob run for ${row.bundleFile}?`,
+      );
+    }
+    return {
+      bundle: readJson(bundlePath),
+      sigstoreBundle: readJson(sigPath),
+      sourceSha: row.sourceSha,
+      gateResults: row.gateResults,
+    };
+  });
+
+  const manifest: ReportManifest = { repo: skeleton.repo, signing: skeleton.signing, rows };
+  if (!isReportManifestShape(manifest)) {
+    throw new Error(
+      'assembled manifest failed the report-manifest shape check (would be rejected at ingest)',
+    );
+  }
+  return manifest;
+}
+
+function parseArgs(argv: readonly string[]): { dir: string; out: string } {
+  let dir = 'build/evidence';
+  let out = '';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--dir') {
+      dir = argv[i + 1] ?? dir;
+      i++;
+    } else if (argv[i] === '--out') {
+      out = argv[i + 1] ?? out;
+      i++;
+    }
+  }
+  if (out === '') out = join(dir, 'report-manifest.json');
+  return { dir, out };
+}
+
+const invokedDirectly = process.argv[1]?.endsWith('assemble-manifest.ts') === true;
+if (invokedDirectly) {
+  try {
+    const { dir, out } = parseArgs(process.argv.slice(2));
+    const manifest = assemble(dir);
+    writeFileSync(out, JSON.stringify(manifest), 'utf8');
+    console.log(`assemble-manifest OK: ${manifest.rows.length} signed row(s) -> ${out}`);
+    process.exit(0);
+  } catch (err: unknown) {
+    console.error(
+      'assemble-manifest FAILED (fail-closed):',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  }
+}

--- a/ci/emit-evidence/assemble-manifest.ts
+++ b/ci/emit-evidence/assemble-manifest.ts
@@ -79,12 +79,41 @@ function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
+/** Fail-closed shape check for the sibling emitter's skeleton (data boundary). */
+function isSkeleton(value: unknown): value is Skeleton {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v['repo'] !== 'string') return false;
+  const signing = v['signing'];
+  if (typeof signing !== 'object' || signing === null) return false;
+  const s = signing as Record<string, unknown>;
+  if (typeof s['issuer'] !== 'string') return false;
+  if (typeof s['subject'] !== 'string') return false;
+  if (typeof s['workflowRef'] !== 'string') return false;
+  if (!Array.isArray(v['rows'])) return false;
+  return v['rows'].every((r) => {
+    if (typeof r !== 'object' || r === null) return false;
+    const row = r as Record<string, unknown>;
+    return (
+      typeof row['bundleFile'] === 'string' &&
+      Array.isArray(row['gateResults']) &&
+      typeof row['sourceSha'] === 'string'
+    );
+  });
+}
+
 export function assemble(dir: string): ReportManifest {
   const skeletonPath = join(dir, 'manifest-skeleton.json');
   if (!existsSync(skeletonPath)) {
     throw new Error(`missing ${skeletonPath} — run ci/emit-evidence/emit-evidence.ts first`);
   }
-  const skeleton = readJson(skeletonPath) as Skeleton;
+  const skeletonRaw = readJson(skeletonPath);
+  if (!isSkeleton(skeletonRaw)) {
+    throw new Error(
+      `${skeletonPath} failed the skeleton shape check — was it written by this repo's emit-evidence.ts?`,
+    );
+  }
+  const skeleton: Skeleton = skeletonRaw;
 
   const rows: ManifestRow[] = skeleton.rows.map((row) => {
     const bundlePath = join(dir, row.bundleFile);

--- a/ci/emit-evidence/emit-evidence.ts
+++ b/ci/emit-evidence/emit-evidence.ts
@@ -478,10 +478,10 @@ function gitSha(): string {
   }
 }
 
-function packageVersion(): string {
+function packageVersion(repoRoot: string): string {
   try {
     const pkg = JSON.parse(
-      readFileSync(join(process.cwd(), 'ci', 'emit-evidence', 'package.json'), 'utf8'),
+      readFileSync(join(repoRoot, 'ci', 'emit-evidence', 'package.json'), 'utf8'),
     ) as { version?: string };
     return pkg.version ?? '0.0.0';
   } catch {
@@ -490,12 +490,15 @@ function packageVersion(): string {
 }
 
 function ciCtx(repoRoot: string): EmitContext {
+  // One Date instance: the uuidv7 timestamp bits and created_at/evaluated_at
+  // must agree — separate Date.now()/toISOString() calls could straddle a tick.
+  const now = new Date();
   return {
-    nowIso: new Date().toISOString(),
-    nowMs: Date.now(),
+    nowIso: now.toISOString(),
+    nowMs: now.getTime(),
     commitSha: gitSha(),
     policyHashHex: computePolicyHashHex(repoRoot),
-    runnerVersion: packageVersion(),
+    runnerVersion: packageVersion(repoRoot),
     rand16: () => Uint8Array.from(randomBytes(16)),
   };
 }

--- a/ci/emit-evidence/emit-evidence.ts
+++ b/ci/emit-evidence/emit-evidence.ts
@@ -1,0 +1,552 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * ci/emit-evidence/emit-evidence.ts — run this repo's three REAL CI-blocking
+ * evals and shape their verdicts into signed-ready evidence for the
+ * intent-eval-dashboard reports hub (labs.intentsolutions.io, repo row key
+ * `qmd`).
+ *
+ * ── Why this lives in `ci/emit-evidence/`, NOT a workspace package ──
+ *
+ * This emitter is a CI-only artifact producer with its own pinned dependency
+ * (`@intentsolutions/core` — the kernel validators, pinned to the EXACT
+ * version the dashboard verifies with). It has its own private, non-workspace
+ * `package.json` + lockfile so the workspace packages are untouched — in
+ * particular `packages/eval-surface` stays PURE (it measures; it does not
+ * emit or sign). Nothing under `ci/` ships anywhere. The pattern (and the
+ * canonicalisation contract) mirrors the proven emitters in
+ * claude-code-plugins and j-rig-skill-binary-eval.
+ *
+ * ── What it attests (honest, no fake evidence) ──
+ *
+ * One gate-result/v1 row PER CI GATE, produced by actually RUNNING each gate
+ * as a subprocess (the same commands ci.yml runs) after the workspace is
+ * installed + built:
+ *
+ *   provenance-integrity — pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
+ *   govern-decision      — pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
+ *   retrieval-ratchet    — pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci
+ *                          (needs the pinned workspace `qmd` bin on PATH; this
+ *                          script prepends <repo>/node_modules/.bin exactly
+ *                          like ci.yml's retrieval-eval job)
+ *
+ * Exit 0 → pass; nonzero → fail (first lines of output become gate_reasons).
+ * The ratchet's documented exit 2 (qmd unavailable / index answered nothing)
+ * becomes an HONEST `gate_decision: "error"` row with failure_mode
+ * `eval-runner-unavailable` — never a fake pass or fail.
+ *
+ * The policy a row attests under is the evaluator entry-point source set:
+ * `policy_hash` is the sha256 over the concatenated bytes of the three gate
+ * sources (POLICY_SOURCE_FILES, fixed order), so any auditor can recompute it
+ * from the tree at `commit_sha` (`sha256(cat f1 f2 f3)`).
+ *
+ * Outputs:
+ *   build/evidence/bundle-<i>.json          — CANONICAL EvidenceBundle bytes
+ *   build/evidence/gate-result-<i>.json     — the gate-result/v1 predicate body
+ *   build/evidence/manifest-skeleton.json   — for ci/emit-evidence/assemble-manifest.ts
+ *
+ * Signing + Rekor + final report-manifest.json assembly happen in CI
+ * (.github/workflows/emit-evidence.yml). This script does NO crypto and
+ * writes only to the gitignored `build/` dir. Run it from the repo root.
+ *
+ * Usage:
+ *   node --experimental-strip-types ci/emit-evidence/emit-evidence.ts \
+ *     [--out build/evidence] [--ref refs/heads/main] [--self-check]
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import {
+  GateResultV1Schema,
+  GATE_RESULT_V1_URI,
+} from '@intentsolutions/core/validators/v1/gate-result-v1';
+import { EvidenceBundleSchema } from '@intentsolutions/core/validators/v1/evidence-bundle';
+
+const GITHUB_REPO = 'jeremylongshore/qmd-team-intent-kb';
+const REPO_KEY = 'qmd';
+const WORKFLOW_FILE = 'emit-evidence.yml';
+
+/**
+ * The evaluator entry-point sources the emitted rows attest under, in FIXED
+ * order. policy_hash = sha256 of these files' bytes concatenated in this
+ * order — recomputable by any auditor from the tree at commit_sha.
+ */
+const POLICY_SOURCE_FILES = [
+  'packages/eval-surface/scripts/ci-provenance-integrity.ts',
+  'packages/eval-surface/scripts/ci-govern-decision.ts',
+  'packages/qmd-adapter/src/eval/ci-retrieval-ratchet.ts',
+] as const;
+
+interface GateSpec {
+  readonly gateName: string;
+  /** argv the gate runs as (identical to the ci.yml invocation). */
+  readonly command: readonly string[];
+  /** Single coverage dimension this gate measures. */
+  readonly dimension: string;
+  /** Exit codes with a documented non-fail meaning (ratchet exit 2). */
+  readonly unavailableExitCode?: number;
+}
+
+const GATES: readonly GateSpec[] = [
+  {
+    gateName: 'provenance-integrity',
+    command: ['pnpm', '--filter', '@qmd-team-intent-kb/eval-surface', 'provenance:ci'],
+    dimension: 'provenance-integrity',
+  },
+  {
+    gateName: 'govern-decision',
+    command: ['pnpm', '--filter', '@qmd-team-intent-kb/eval-surface', 'govern:ci'],
+    dimension: 'govern-decision-efficacy',
+  },
+  {
+    gateName: 'retrieval-ratchet',
+    command: ['pnpm', '--filter', '@qmd-team-intent-kb/qmd-adapter', 'eval:retrieval:ci'],
+    dimension: 'retrieval-recall',
+    // ci-retrieval-ratchet.ts documents exit 2 = qmd unavailable / empty
+    // index (misconfig) — an honest `error`, never a fake pass/fail.
+    unavailableExitCode: 2,
+  },
+];
+
+interface GateOutcome {
+  readonly gateName: string;
+  readonly gateVersion: string;
+  readonly decision: 'pass' | 'fail' | 'advisory' | 'error';
+  readonly reasons: readonly string[];
+  readonly dimensionsEvaluated: readonly string[];
+  readonly dimensionsSkipped: readonly string[];
+  readonly advisorySeverity?: 'info' | 'warn' | 'error';
+  readonly failureMode?: string;
+}
+
+interface EmitContext {
+  readonly nowIso: string;
+  readonly nowMs: number;
+  readonly commitSha: string;
+  readonly policyHashHex: string;
+  readonly runnerVersion: string;
+  readonly rand16: () => Uint8Array;
+}
+
+// ── Canonicalisation (MUST match the dashboard's content-address.ts) ──
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => [k, sortDeep(v)] as const);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+/** Canonical JSON string (sorted keys, no whitespace) — dashboard-identical. */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+
+function sha256Hex(s: string | Buffer): string {
+  return createHash('sha256')
+    .update(typeof s === 'string' ? Buffer.from(s, 'utf8') : s)
+    .digest('hex');
+}
+
+/** Generate a kernel-valid UUIDv7 from a 16-byte source + ms timestamp. */
+export function uuidv7(nowMs: number, rand: Uint8Array): string {
+  const b = Buffer.from(rand.slice(0, 16));
+  const ts = BigInt(nowMs);
+  b[0] = Number((ts >> 40n) & 0xffn);
+  b[1] = Number((ts >> 32n) & 0xffn);
+  b[2] = Number((ts >> 24n) & 0xffn);
+  b[3] = Number((ts >> 16n) & 0xffn);
+  b[4] = Number((ts >> 8n) & 0xffn);
+  b[5] = Number(ts & 0xffn);
+  b[6] = (b[6]! & 0x0f) | 0x70; // version 7
+  b[8] = (b[8]! & 0x3f) | 0x80; // variant 10
+  const h = b.toString('hex');
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+}
+
+/** A built row: the kernel-valid bundle + its canonical bytes + the gate body. */
+export interface EmitRow {
+  readonly bundle: unknown;
+  readonly canonicalBundle: string;
+  readonly gateResult: unknown;
+  readonly sourceSha: string;
+}
+
+function policyRef(ctx: EmitContext): string {
+  return `sha256:${ctx.policyHashHex}:${POLICY_SOURCE_FILES.join(',')}`;
+}
+
+/**
+ * Build + kernel-validate a gate-result/v1 body for one gate outcome. Throws
+ * (fail closed) if the result is not kernel-schema-valid.
+ */
+export function buildGateResult(o: GateOutcome, ctx: EmitContext): Record<string, unknown> {
+  const gateId = `${REPO_KEY}:ci:${o.gateName}`;
+  const policyHash = `sha256:${ctx.policyHashHex}`;
+  const inputHash = `sha256:${sha256Hex(`${ctx.commitSha}:${o.gateName}:${policyHash}`)}`;
+  const body: Record<string, unknown> = {
+    gate_id: gateId,
+    gate_name: o.gateName,
+    gate_version: o.gateVersion,
+    gate_decision: o.decision,
+    gate_reasons: [...o.reasons],
+    coverage: {
+      dimensions_evaluated: [...o.dimensionsEvaluated],
+      dimensions_skipped: [...o.dimensionsSkipped],
+    },
+    policy_ref: policyRef(ctx),
+    policy_hash: policyHash,
+    input_hash: inputHash,
+    evaluated_at: ctx.nowIso,
+    runner: `qmd-emit@${ctx.runnerVersion}`,
+    commit_sha: ctx.commitSha,
+    ...(o.advisorySeverity !== undefined ? { advisory_severity: o.advisorySeverity } : {}),
+    ...(o.failureMode !== undefined ? { failure_mode: o.failureMode } : {}),
+  };
+  GateResultV1Schema.parse(body); // fail-closed
+  return body;
+}
+
+/**
+ * Wrap a gate-result body in a kernel EvidenceBundle. Throws if the bundle is
+ * not kernel-schema-valid.
+ */
+export function buildEvidenceBundle(
+  gateResult: Record<string, unknown>,
+  ctx: EmitContext,
+): Record<string, unknown> {
+  const grHashHex = sha256Hex(stableStringify(gateResult));
+  const inputHash = String(gateResult['input_hash']);
+  const subjectDigest = inputHash.startsWith('sha256:')
+    ? inputHash.slice('sha256:'.length)
+    : inputHash;
+  const bundle: Record<string, unknown> = {
+    id: uuidv7(ctx.nowMs, ctx.rand16()),
+    eval_run_id: uuidv7(ctx.nowMs, ctx.rand16()),
+    created_at: ctx.nowIso,
+    predicate_uri_set: [GATE_RESULT_V1_URI],
+    row_count: 1,
+    subject_set: [{ name: String(gateResult['gate_id']), digest: { sha256: subjectDigest } }],
+    storage_key: `sha256:${grHashHex}`,
+    signing_mode: 'rekor_production',
+    rekor_log_indices: [], // real index lives in the sigstore Bundle
+    verification_status: 'unverified', // the dashboard re-verifies; we don't self-attest
+    verification_last_checked_at: ctx.nowIso,
+  };
+  EvidenceBundleSchema.parse(bundle); // fail-closed
+  return bundle;
+}
+
+/** Build all rows from outcomes. */
+export function buildRows(outcomes: readonly GateOutcome[], ctx: EmitContext): EmitRow[] {
+  return outcomes.map((o) => {
+    const gateResult = buildGateResult(o, ctx);
+    const bundle = buildEvidenceBundle(gateResult, ctx);
+    return {
+      bundle,
+      canonicalBundle: stableStringify(bundle),
+      gateResult,
+      sourceSha: ctx.commitSha,
+    };
+  });
+}
+
+/** The manifest skeleton CI signs + assembles into the final report-manifest.json. */
+export interface ManifestSkeleton {
+  readonly repo: string;
+  readonly signing: {
+    readonly issuer: string;
+    readonly subject: string;
+    readonly workflowRef: string;
+  };
+  readonly rows: readonly {
+    readonly bundleFile: string;
+    readonly gateResults: readonly unknown[];
+    readonly sourceSha: string;
+  }[];
+}
+
+/**
+ * The OIDC signing claims this CI run will assert. The emit workflow runs on
+ * push-to-main plus a main-only dispatch guard, so `ref` is always
+ * `refs/heads/main` in CI — exactly the claims the dashboard pins for the
+ * `qmd` row.
+ */
+export function signingClaims(ref: string): ManifestSkeleton['signing'] {
+  return {
+    issuer: 'https://token.actions.githubusercontent.com',
+    subject: `repo:${GITHUB_REPO}:ref:${ref}`,
+    workflowRef: `${GITHUB_REPO}/.github/workflows/${WORKFLOW_FILE}@${ref}`,
+  };
+}
+
+/** Write all emit artifacts under `outDir`. Returns the skeleton written. */
+export function writeEmit(rows: readonly EmitRow[], ref: string, outDir: string): ManifestSkeleton {
+  mkdirSync(outDir, { recursive: true });
+  const skeletonRows = rows.map((row, i) => {
+    const bundleFile = `bundle-${i}.json`;
+    writeFileSync(join(outDir, bundleFile), row.canonicalBundle, 'utf8');
+    writeFileSync(join(outDir, `gate-result-${i}.json`), stableStringify(row.gateResult), 'utf8');
+    return { bundleFile, gateResults: [row.gateResult], sourceSha: row.sourceSha };
+  });
+  const skeleton: ManifestSkeleton = {
+    repo: REPO_KEY,
+    signing: signingClaims(ref),
+    rows: skeletonRows,
+  };
+  writeFileSync(join(outDir, 'manifest-skeleton.json'), JSON.stringify(skeleton, null, 2), 'utf8');
+  return skeleton;
+}
+
+// ── Gate execution (subprocess-level, same commands as ci.yml) ──
+
+/** Non-empty, non-pnpm-echo output lines, each bounded to 300 chars. */
+function meaningfulLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('>'))
+    .map((l) => l.slice(0, 300));
+}
+
+/** First meaningful output lines — the diagnostic head for fail/error rows. */
+function headLines(output: string, max: number): string[] {
+  return meaningfulLines(output).slice(0, max);
+}
+
+/** Last meaningful output lines — the result summary for pass rows. */
+function tailLines(output: string, max: number): string[] {
+  return meaningfulLines(output).slice(-max);
+}
+
+/**
+ * Run one CI gate as a subprocess and map its exit code to an honest verdict:
+ * 0 → pass; the gate's documented "unavailable" exit code → error with
+ * failure_mode `eval-runner-unavailable`; any other nonzero → fail; spawn
+ * failure → error. Never fabricates a pass.
+ */
+export function runGate(spec: GateSpec, repoRoot: string): GateOutcome {
+  const binPath = join(repoRoot, 'node_modules', '.bin');
+  // Same discipline as ci.yml's retrieval-eval job: the pinned workspace
+  // bins (notably `qmd`) resolve ahead of any stray system copy.
+  const env = { ...process.env, PATH: `${binPath}${delimiter}${process.env['PATH'] ?? ''}` };
+  const res = spawnSync(spec.command[0]!, spec.command.slice(1), {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 10 * 60 * 1000,
+  });
+  const output = `${res.stdout ?? ''}\n${res.stderr ?? ''}`;
+  const base = {
+    gateName: spec.gateName,
+    gateVersion: '1.0.0',
+    dimensionsEvaluated: [spec.dimension],
+    dimensionsSkipped: [] as string[],
+  };
+  if (res.error !== undefined || res.status === null) {
+    return {
+      ...base,
+      decision: 'error',
+      reasons: [
+        `gate runner failed to execute: ${res.error?.message ?? 'terminated by signal'}`,
+        ...headLines(output, 3),
+      ],
+      dimensionsEvaluated: [],
+      dimensionsSkipped: [spec.dimension],
+      failureMode: 'eval-runner-error',
+    };
+  }
+  if (res.status === 0) {
+    // The evals print their result summary last — that is the pass evidence.
+    return {
+      ...base,
+      decision: 'pass',
+      reasons: tailLines(output, 3),
+    };
+  }
+  if (spec.unavailableExitCode !== undefined && res.status === spec.unavailableExitCode) {
+    return {
+      ...base,
+      decision: 'error',
+      reasons: [
+        `eval runner unavailable (exit ${res.status}): the gate could not run — not a pass, not a fail`,
+        ...headLines(output, 4),
+      ],
+      dimensionsEvaluated: [],
+      dimensionsSkipped: [spec.dimension],
+      failureMode: 'eval-runner-unavailable',
+    };
+  }
+  return {
+    ...base,
+    decision: 'fail',
+    reasons: [`gate exited ${res.status}`, ...headLines(output, 5)],
+    failureMode: 'ci-gate-fail',
+  };
+}
+
+export function runGates(repoRoot: string): GateOutcome[] {
+  return GATES.map((spec) => {
+    console.log(`── running gate ${spec.gateName}: ${spec.command.join(' ')}`);
+    const outcome = runGate(spec, repoRoot);
+    console.log(`   → ${outcome.decision}`);
+    return outcome;
+  });
+}
+
+// ── Policy hash (auditor-recomputable from the tree at commit_sha) ──
+
+export function computePolicyHashHex(repoRoot: string): string {
+  const h = createHash('sha256');
+  for (const rel of POLICY_SOURCE_FILES) {
+    h.update(readFileSync(join(repoRoot, rel)));
+  }
+  return h.digest('hex');
+}
+
+// ── Self-check (locally-runnable correctness proof) ──
+
+function selfCheck(): void {
+  const ctx = synthCtx();
+  const outcomes: GateOutcome[] = [
+    {
+      gateName: 'provenance-integrity',
+      gateVersion: '1.0.0',
+      decision: 'pass',
+      reasons: ['provenance-integrity smoke passed on the throwaway brain'],
+      dimensionsEvaluated: ['provenance-integrity'],
+      dimensionsSkipped: [],
+    },
+    {
+      gateName: 'govern-decision',
+      gateVersion: '1.0.0',
+      decision: 'fail',
+      reasons: ['gate exited 1', 'undocumented false-negative: split-key case'],
+      dimensionsEvaluated: ['govern-decision-efficacy'],
+      dimensionsSkipped: [],
+      failureMode: 'ci-gate-fail',
+    },
+    {
+      gateName: 'retrieval-ratchet',
+      gateVersion: '1.0.0',
+      decision: 'error',
+      reasons: [
+        'eval runner unavailable (exit 2): the gate could not run — not a pass, not a fail',
+      ],
+      dimensionsEvaluated: [],
+      dimensionsSkipped: ['retrieval-recall'],
+      failureMode: 'eval-runner-unavailable',
+    },
+  ];
+  const rows = buildRows(outcomes, ctx); // throws if any artifact is kernel-invalid
+  for (const row of rows) {
+    if (stableStringify(JSON.parse(row.canonicalBundle)) !== row.canonicalBundle) {
+      throw new Error('canonical bundle is not stable under re-canonicalisation');
+    }
+  }
+  if (rows.length !== 3) throw new Error('expected 3 rows');
+  console.log(`self-check OK: ${rows.length} kernel-valid, canonical-stable rows built`);
+}
+
+function synthCtx(): EmitContext {
+  let n = 0;
+  return {
+    nowIso: '2026-07-16T00:00:00.000Z',
+    nowMs: 1783900800000,
+    commitSha: 'a'.repeat(40),
+    policyHashHex: 'c'.repeat(64),
+    runnerVersion: '0.1.0',
+    // Deterministic, non-random 16-byte source so self-check output is stable.
+    rand16: () => {
+      n += 1;
+      return Uint8Array.from(Array.from({ length: 16 }, (_v, i) => (n * 31 + i) & 0xff));
+    },
+  };
+}
+
+function gitSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return '0'.repeat(40);
+  }
+}
+
+function packageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), 'ci', 'emit-evidence', 'package.json'), 'utf8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function ciCtx(repoRoot: string): EmitContext {
+  return {
+    nowIso: new Date().toISOString(),
+    nowMs: Date.now(),
+    commitSha: gitSha(),
+    policyHashHex: computePolicyHashHex(repoRoot),
+    runnerVersion: packageVersion(),
+    rand16: () => Uint8Array.from(randomBytes(16)),
+  };
+}
+
+function parseArgs(argv: readonly string[]): { out: string; ref: string; selfCheck: boolean } {
+  let out = 'build/evidence';
+  let ref = process.env['GITHUB_REF'] ?? 'refs/heads/main';
+  let sc = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--out') {
+      out = argv[i + 1] ?? out;
+      i++;
+    } else if (argv[i] === '--ref') {
+      ref = argv[i + 1] ?? ref;
+      i++;
+    } else if (argv[i] === '--self-check') {
+      sc = true;
+    }
+  }
+  return { out, ref, selfCheck: sc };
+}
+
+function main(argv: readonly string[]): number {
+  const args = parseArgs(argv);
+  if (args.selfCheck) {
+    selfCheck();
+    return 0;
+  }
+  const repoRoot = process.cwd();
+  const ctx = ciCtx(repoRoot);
+  const outcomes = runGates(repoRoot);
+  const rows = buildRows(outcomes, ctx);
+  writeEmit(rows, args.ref, args.out);
+  console.log(
+    `emit-evidence OK: ${rows.length} kernel-valid gate-result/v1 row(s) written to ${args.out}\n` +
+      `  decisions: ${outcomes.map((o) => `${o.gateName}=${o.decision}`).join(', ')}\n` +
+      `  next (CI): cosign sign-blob each bundle-<i>.json -> assemble-manifest.ts -> report-manifest.json`,
+  );
+  return 0;
+}
+
+// Only run when invoked directly (not when imported by a sibling assembler).
+const invokedDirectly = process.argv[1]?.endsWith('emit-evidence.ts') === true;
+if (invokedDirectly) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (err: unknown) {
+    console.error(
+      'emit-evidence FAILED (fail-closed):',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  }
+}

--- a/ci/emit-evidence/package.json
+++ b/ci/emit-evidence/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "qmd-emit-evidence-ci",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CI-only signed-evidence emitter for the intent-eval-dashboard reports hub (repo row key: qmd). Not a workspace package, never published; installed standalone in .github/workflows/emit-evidence.yml via `pnpm install --ignore-workspace`.",
+  "type": "module",
+  "dependencies": {
+    "@intentsolutions/core": "0.9.0"
+  }
+}

--- a/ci/emit-evidence/pnpm-lock.yaml
+++ b/ci/emit-evidence/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@intentsolutions/core':
+        specifier: 0.9.0
+        version: 0.9.0
+
+packages:
+
+  '@intentsolutions/core@0.9.0':
+    resolution: {integrity: sha512-XGF3rR/FFgRz1qkiXMEXLijmPX3/9layH9e2wqykMitkl2gX/JREpS6ilRXB1tVnkdcHnDdfAxWstpW/UoGKsA==}
+    engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@intentsolutions/core@0.9.0':
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -10,8 +10,11 @@
  *                           decision over an adversarial labeled set (is the moat
  *                           merely deterministic, or actually EFFECTIVE?)
  *
- * This package MEASURES. It does not emit or sign Evidence Bundles — wiring the
- * results into a signed bundle at promotion time is bead tr08.19. Keeping
+ * This package MEASURES. It does not emit or sign Evidence Bundles — the
+ * emit wiring (bead tr08.19) now exists at ci/emit-evidence/, which runs the
+ * CI eval gates as subprocesses and shapes their verdicts into signed
+ * gate-result/v1 bundles for the labs dashboard (subprocess-level v1; an
+ * EvaluatorResult-level in-package emitter remains future work). Keeping
  * measurement pure (no I/O beyond the repositories/data handed in) makes each
  * evaluator independently testable and side-effect-free.
  */

--- a/packages/eval-surface/src/types.ts
+++ b/packages/eval-surface/src/types.ts
@@ -3,10 +3,13 @@
  *
  * These shapes are deliberately Evidence-Bundle-friendly: each evaluator yields
  * an `EvaluatorResult` with a stable `name`, a binary `passed`, a numeric
- * `score` in [0,1], a `threshold`, and a `details` map. The wiring bead
- * (tr08.19) rolls a set of these into a canonical Evidence Bundle via
- * @intentsolutions/core, naming each subject `qmd:<name>` and hashing the
- * verdict. This package stays pure: it measures, it does not emit or sign.
+ * `score` in [0,1], a `threshold`, and a `details` map. The emit wiring
+ * (bead tr08.19) now lives at ci/emit-evidence/: it runs the CI eval gates as
+ * subprocesses and rolls their verdicts into canonical Evidence Bundles via
+ * @intentsolutions/core, naming each subject `qmd:ci:<gate>` and hashing the
+ * verdict (subprocess-level v1; rolling EvaluatorResult objects directly into
+ * bundles in-package remains future work). This package stays pure: it
+ * measures, it does not emit or sign.
  */
 
 /** A single evaluator's verdict. */


### PR DESCRIPTION
## What

Adds a CI-only signed-evidence emitter (`ci/emit-evidence/`) and one purely additive workflow (`.github/workflows/emit-evidence.yml`) so this repo's three REAL CI-blocking evals reach the labs.intentsolutions.io reports hub as cosign-signed kernel `gate-result/v1` EvidenceBundles (repo row key: `qmd`), published onto a rolling `evidence-latest` prerelease on every push to main (+ main-only manual dispatch). Also updates the two stale tr08.19 code comments in `packages/eval-surface/src/{index,types}.ts` to point at the wiring that now exists.

Three rows per run, one per real gate:

| gate_id | command | honest mapping |
|---|---|---|
| `qmd:ci:provenance-integrity` | `pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci` | exit 0 → pass, nonzero → fail |
| `qmd:ci:govern-decision` | `pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci` | exit 0 → pass, nonzero → fail |
| `qmd:ci:retrieval-ratchet` | `pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci` | exit 0 → pass, exit 2 (qmd unavailable, per the ratchet's documented exit codes) → `gate_decision:"error"` with `failure_mode:eval-runner-unavailable`, other nonzero → fail |

## Why + decision rationale

The eval-surface package measures but deliberately never emits or signs — the wiring bead (tr08.19 lineage; current bead: "Wire the qmd eval-surface evidence emitter", `bd_000-projects-sbs7.1`) is what puts the governed brain's eval results on the public scoreboard. **Chose subprocess-level v1 over an in-package EvaluatorResult emitter because it ships the row live without touching the pure measurement packages** — `@intentsolutions/core` is NOT added to eval-surface; the emitter runs the exact `ci.yml` gate commands and attests their verdicts. The pattern is a faithful adaptation of the review-hardened j-rig/ccp emitter (dashboard-identical canonicalisation, standalone pinned kernel, in-repo sign→verify chain).

## Layers touched

Additive only: new `ci/emit-evidence/` (non-workspace, private, never published — `pnpm-workspace.yaml` globs are `apps/*`/`packages/*` so it is not a workspace member) + one new workflow. No existing workflow (`ci.yml`, `nightly.yml`, `release.yml`, `security.yml`), gate, or branch-protection context changes. The only source edits are two doc comments in eval-surface. `build/` and `node_modules/` are already gitignored.

## How it works

1. Workflow (push→main guard, `permissions: {}` top-level, job gets `contents:write` + `id-token:write`, 20-min timeout, concurrency `emit-evidence`): workspace install + build, pinned workspace `qmd` bin on PATH (same step as `ci.yml`'s retrieval-eval job), then a standalone `pnpm install --frozen-lockfile --ignore-workspace` in `ci/emit-evidence` pins `@intentsolutions/core` EXACT `0.9.0` — the version the dashboard verifies with.
2. `emit-evidence.ts` runs the three gates as subprocesses, maps exit codes honestly, and builds one `gate-result/v1` row per gate — `GateResultV1Schema.parse` + `EvidenceBundleSchema.parse` fail-closed; `stableStringify` (sorted keys, no whitespace) is byte-identical to the dashboard's re-canonicalisation; `policy_hash` = sha256 over the three evaluator entry-point sources in fixed order (recomputable from the tree at `commit_sha`); `input_hash` = sha256(`commitSha:gateName:policyHash`); bundles carry `signing_mode:rekor_production`, `rekor_log_indices: []`, `verification_status:unverified`, `row_count:1`.
3. CI cosign keyless sign-blob (`--yes --new-bundle-format`) each canonical bundle, then cosign verify-blob each against `https://github.com/${GITHUB_REPOSITORY}/.github/workflows/emit-evidence.yml@${GITHUB_REF}` + the GitHub OIDC issuer — the same claim pair the manifest skeleton records for the dashboard pin.
4. `assemble-manifest.ts` (fail-closed) combines bundles + sigstore bundles into `report-manifest.json`, uploaded with `--clobber` onto the idempotent `evidence-latest` prerelease.

## Verification & evidence (local, this branch)

Self-check:

```
$ node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --self-check
self-check OK: 3 kernel-valid, canonical-stable rows built
```

Full real emit (after `pnpm install` + `pnpm build`) — all three gates executed for real on this box (the pinned workspace `@tobilu/qmd` was available, so the ratchet genuinely ran; had `qmd` been unavailable the row would honestly read `error`/`eval-runner-unavailable`, which is the designed behavior):

```
$ node --experimental-strip-types ci/emit-evidence/emit-evidence.ts --out build/evidence --ref refs/heads/main
── running gate provenance-integrity … → pass
── running gate govern-decision … → pass
── running gate retrieval-ratchet … → pass
emit-evidence OK: 3 kernel-valid gate-result/v1 row(s) written to build/evidence
  decisions: provenance-integrity=pass, govern-decision=pass, retrieval-ratchet=pass
```

Sample pass evidence captured in `gate_reasons` (retrieval row): `lexical measured=1.0000 baseline=1.0000 floor=0.9990 OK · semantic measured=0.5833 baseline=0.5833 floor=0.5823 OK · RATCHET PASS`. Written bundle bytes re-canonicalise identically (`canonical-stable: true`). `assemble-manifest.ts` without sigstore bundles fails closed (exit 1: "missing sigstore bundle … was cosign sign-blob run?").

Repo gates: `pnpm validate` green — format:check + lint + typecheck + **168 test files / 2006 tests passed**.

## Risk

Additive-only; fail-closed everywhere (kernel Zod parse, stub-free honest exit-code mapping, assemble shape check, sign/verify loop aborts on zero bundles). Not a PR check; cannot block merges. Worst case is a missing/stale manifest asset, which the dashboard treats as no-data.

## Operational impact

No new secrets — `GITHUB_TOKEN` + GitHub OIDC (`id-token:write`) only. No env/migration/deploy-order changes. The dashboard-side pin for the `qmd` row lands separately with `operatorConfirmed:false`.

## Follow-up & deferred

- EvaluatorResult-level in-package emitter (roll `EvaluatorResult` objects directly into bundles at promotion time) — future work; eval-surface stays pure in this PR.
- Recall@10 metrics row (publish the measured stratified numbers, not just the ratchet verdict).
- Dashboard pin + scorecard row flip: bead `bd_000-projects-sbs7.2`.

## Governance links

Bead: `bd_000-projects-sbs7.1` (Wire the qmd eval-surface evidence emitter) under epic `bd_000-projects-sbs7`. Pattern source: j-rig-skill-binary-eval `ci/emit-evidence/` + `nightly-skill-evals.yml`.

Refs jeremylongshore/qmd-team-intent-kb#251

- Jeremy Longshore
intentsolutions.io