### PR TITLE
feat(search): rerank qmd-cited hits with freshness and category boost

### DIFF
--- a/apps/api/src/__tests__/search-qmd.test.ts
+++ b/apps/api/src/__tests__/search-qmd.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import type Database from 'better-sqlite3';
-import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
 import type { SearchScope } from '@qmd-team-intent-kb/schema';
 import { buildApp } from '../app.js';
 import type { QmdCiteHit, QmdQueryPort } from '../services/search-service.js';
+import { makeMemory } from './fixtures.js';
 
 /**
  * A controllable fake qmd port. Records the (query, scope) it was asked for so
@@ -174,5 +175,90 @@ describe('POST /api/search — qmd cited path', () => {
     const body = res.json();
     expect(body.hits[0].score).toBe(1); // 8/8
     expect(body.hits[1].score).toBe(0.5); // 4/8
+  });
+});
+
+// ─── R1: freshness + category rerank on the qmd path ─────────────────────────
+// (retrieval epic qmd-team-intent-kb-vps.1)
+
+describe('POST /api/search — qmd path freshness/category rerank', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  const STALE_ID = '11111111-1111-4111-8111-111111111111';
+  const FRESH_ID = '22222222-2222-4222-8222-222222222222';
+
+  beforeEach(() => {
+    db = createTestDatabase();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('reranks a fresh decision above a stale reference with equal qmd scores', async () => {
+    const repo = new MemoryRepository(db);
+    const yearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString();
+    repo.insert(
+      makeMemory({
+        id: STALE_ID,
+        title: 'Old reference',
+        category: 'reference',
+        updatedAt: yearAgo,
+        content: 'stale reference content',
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        id: FRESH_ID,
+        title: 'Fresh decision',
+        category: 'decision',
+        updatedAt: new Date().toISOString(),
+        content: 'fresh decision content',
+      }),
+    );
+
+    // qmd returns the stale memory FIRST with an identical raw score.
+    const qmd = new FakeQmd([
+      hit(`qmd://kb-guides/${STALE_ID}.md`, 5),
+      hit(`qmd://kb-decisions/${FRESH_ID}.md`, 5, 'snip', 'kb-decisions'),
+    ]);
+    app = buildApp({ db, qmdAdapter: qmd });
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { query: 'x', scope: 'curated' },
+    });
+    const body = res.json();
+    expect(body.hits[0].citation).toBe(`qmd://kb-decisions/${FRESH_ID}.md`);
+    expect(body.hits[0].score).toBeGreaterThan(body.hits[1].score);
+    // Resolved hits are enriched with the governed row's identity + category.
+    expect(body.hits[0].memoryId).toBe(FRESH_ID);
+    expect(body.hits[0].category).toBe('decision');
+    // Citations remain the anchor on every hit.
+    for (const h of body.hits) expect(h.citation).toMatch(/^qmd:\/\//);
+  });
+
+  it('leaves unresolvable citations in qmd order without enrichment', async () => {
+    const qmd = new FakeQmd([
+      hit('qmd://kb-curated/not-a-row.md', 0.9),
+      hit('qmd://kb-curated/also-gone.md', 0.6),
+    ]);
+    app = buildApp({ db, qmdAdapter: qmd });
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { query: 'x', scope: 'curated' },
+    });
+    const body = res.json();
+    expect(body.hits[0].citation).toBe('qmd://kb-curated/not-a-row.md');
+    expect(body.hits[0].memoryId).toBeUndefined();
+    expect(body.hits[0].category).toBeUndefined();
+    expect(body.hits[1].score).toBeCloseTo(0.6 / 0.9, 3);
   });
 });

--- a/apps/api/src/services/search-service.ts
+++ b/apps/api/src/services/search-service.ts
@@ -1,6 +1,6 @@
 import type { MemoryRepository } from '@qmd-team-intent-kb/store';
 import type { SearchQuery, SearchResult, SearchHit, SearchScope } from '@qmd-team-intent-kb/schema';
-import { rerankSearchHits } from '@qmd-team-intent-kb/common';
+import { rerankSearchHits, rerankCitedHits } from '@qmd-team-intent-kb/common';
 import { badRequest } from '../errors.js';
 
 /**
@@ -52,7 +52,9 @@ export class SearchService {
   /**
    * Search curated memories by text query.
    *
-   * qmd path: returns `qmd://`-cited hits ranked by qmd relevance.
+   * qmd path: returns `qmd://`-cited hits, qmd relevance normalised to [0,1]
+   * then reranked with the same exponential time decay + category boost as
+   * the fallback (citations resolve to store rows for the metadata).
    * SQLite fallback: title match = 0.9, content-only = 0.6, then exponential
    * time decay + category boost.
    */
@@ -98,10 +100,34 @@ export class SearchService {
     const ranked = result.value;
     const maxScore = ranked.reduce((m, h) => (h.score > m ? h.score : m), 0);
 
-    const allHits: SearchHit[] = ranked.map((hit, index) => ({
+    // Normalise BEFORE the freshness rerank: qmd exact hits can all score 0,
+    // where normaliseScore falls back to a rank-derived score — reranking the
+    // raw zeros instead would multiply freshness into 0 and erase the ranking.
+    const normalised = ranked.map((hit, index) => ({
+      ...hit,
+      score: normaliseScore(hit.score, maxScore, index, ranked.length),
+    }));
+
+    // Freshness + category rerank (same policy as the SQLite fallback, R1 of
+    // the retrieval epic). Citations resolve back to store rows by id — the
+    // exporter names files `{memoryId}.md` — purely for ranking metadata; the
+    // qmd index itself is already tenant-scoped, and ids are globally unique.
+    const reranked = rerankCitedHits(
+      normalised,
+      (memoryId) => {
+        const memory = this.memoryRepo.findById(memoryId);
+        return memory === null ? null : { category: memory.category, updatedAt: memory.updatedAt };
+      },
+      nowIso,
+    );
+
+    const allHits: SearchHit[] = reranked.map((hit) => ({
+      memoryId: hit.memoryId ?? undefined,
       title: titleFromCitation(hit.file),
       snippet: hit.snippet,
-      score: normaliseScore(hit.score, maxScore, index, ranked.length),
+      score: Math.min(hit.finalScore, 1),
+      // Category came off a governed store row, so it is a valid MemoryCategory.
+      category: hit.memoryId !== null ? (hit.category as SearchHit['category']) : undefined,
       citation: hit.file,
       collection: hit.collection,
       matchedAt: nowIso,

--- a/packages/common/src/__tests__/freshness.test.ts
+++ b/packages/common/src/__tests__/freshness.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { computeFreshnessScore, CATEGORY_BOOST, rerankSearchHits } from '../freshness.js';
+import {
+  computeFreshnessScore,
+  CATEGORY_BOOST,
+  rerankSearchHits,
+  extractMemoryIdFromCitation,
+  rerankCitedHits,
+} from '../freshness.js';
 
 const NOW = '2026-03-19T00:00:00.000Z';
 
@@ -107,5 +113,69 @@ describe('rerankSearchHits', () => {
   it('returns an empty array when given an empty input', () => {
     const result = rerankSearchHits([], NOW);
     expect(result).toEqual([]);
+  });
+});
+
+// ─── R1: cited-hit rerank (retrieval epic qmd-team-intent-kb-vps.1) ──────────
+
+describe('extractMemoryIdFromCitation', () => {
+  it('extracts the id from a qmd:// URI with a collection path', () => {
+    expect(
+      extractMemoryIdFromCitation('qmd://kb-curated/6f1a2b3c-4d5e-6789-abcd-ef0123456789.md'),
+    ).toBe('6f1a2b3c-4d5e-6789-abcd-ef0123456789');
+  });
+
+  it('extracts the id from a nested exported path', () => {
+    expect(extractMemoryIdFromCitation('decisions/abc-123.md')).toBe('abc-123');
+  });
+
+  it('handles a bare filename with no directory', () => {
+    expect(extractMemoryIdFromCitation('abc-123.md')).toBe('abc-123');
+  });
+
+  it('only strips the final extension, preserving dots in the id', () => {
+    expect(extractMemoryIdFromCitation('qmd://kb-guides/CLAUDE.md.md')).toBe('CLAUDE.md');
+  });
+
+  it('returns null for an empty basename', () => {
+    expect(extractMemoryIdFromCitation('qmd://kb-curated/')).toBeNull();
+    expect(extractMemoryIdFromCitation('')).toBeNull();
+  });
+});
+
+describe('rerankCitedHits', () => {
+  const NOW = '2026-07-17T12:00:00.000Z';
+  const STALE = '2025-07-17T12:00:00.000Z'; // one year old ≈ 4 half-lives
+
+  it('reorders a fresh decision above a stale reference with equal raw scores', () => {
+    const hits = [
+      { file: 'qmd://kb-guides/stale-ref.md', score: 1 },
+      { file: 'qmd://kb-decisions/fresh-dec.md', score: 1 },
+    ];
+    const meta: Record<string, { category: string; updatedAt: string }> = {
+      'stale-ref': { category: 'reference', updatedAt: STALE },
+      'fresh-dec': { category: 'decision', updatedAt: NOW },
+    };
+    const reranked = rerankCitedHits(hits, (id) => meta[id] ?? null, NOW);
+    expect(reranked[0]!.file).toBe('qmd://kb-decisions/fresh-dec.md');
+    expect(reranked[0]!.finalScore).toBeGreaterThan(reranked[1]!.finalScore);
+    expect(reranked[0]!.memoryId).toBe('fresh-dec');
+  });
+
+  it('leaves an unresolved citation unboosted and unpenalized', () => {
+    const hits = [{ file: 'qmd://kb-curated/gone.md', score: 0.8 }];
+    const reranked = rerankCitedHits(hits, () => null, NOW);
+    expect(reranked[0]!.finalScore).toBe(0.8);
+    expect(reranked[0]!.memoryId).toBeNull();
+    expect(reranked[0]!.category).toBe('');
+  });
+
+  it('preserves qmd order between hits with identical metadata and scores', () => {
+    const hits = [
+      { file: 'qmd://kb-curated/a.md', score: 0.5 },
+      { file: 'qmd://kb-curated/b.md', score: 0.5 },
+    ];
+    const reranked = rerankCitedHits(hits, () => null, NOW);
+    expect(reranked.map((h) => h.file)).toEqual(hits.map((h) => h.file));
   });
 });

--- a/packages/common/src/freshness.ts
+++ b/packages/common/src/freshness.ts
@@ -45,3 +45,50 @@ export function rerankSearchHits<T extends { score: number; category: string; up
     })
     .sort((a, b) => b.finalScore - a.finalScore);
 }
+
+/**
+ * Extract the memory id from a qmd citation URI or exported file path.
+ * The git-exporter names every file `{memoryId}.md`, so the basename minus
+ * its extension IS the memory id. Returns null for an empty basename.
+ */
+export function extractMemoryIdFromCitation(citation: string): string | null {
+  const lastSlash = citation.lastIndexOf('/');
+  const base = lastSlash === -1 ? citation : citation.slice(lastSlash + 1);
+  const stripped = base.replace(/\.[^.]+$/, '');
+  return stripped.length > 0 ? stripped : null;
+}
+
+/** Metadata needed to freshness-rerank a cited hit. */
+export interface CitedHitMetadata {
+  category: string;
+  updatedAt: string;
+}
+
+/**
+ * Rerank qmd-cited hits with freshness + category boost by resolving each
+ * citation back to its governed memory's metadata.
+ *
+ * A hit whose citation cannot be resolved (memory removed from the store, or
+ * a non-standard filename) is treated as fresh and unboosted — freshness 1.0
+ * (updatedAt = now) and category boost 1.0 — so resolution failure never
+ * penalizes a hit; it just doesn't get boosted. Resolved hits carry their
+ * memoryId so callers can enrich the response.
+ */
+export function rerankCitedHits<T extends { file: string; score: number }>(
+  hits: T[],
+  resolveMetadata: (memoryId: string) => CitedHitMetadata | null,
+  nowIso: string,
+  halfLifeDays: number = 90,
+): Array<T & { finalScore: number; category: string; updatedAt: string; memoryId: string | null }> {
+  const enriched = hits.map((h) => {
+    const id = extractMemoryIdFromCitation(h.file);
+    const meta = id === null ? null : resolveMetadata(id);
+    return {
+      ...h,
+      memoryId: meta === null ? null : id,
+      category: meta?.category ?? '',
+      updatedAt: meta?.updatedAt ?? nowIso,
+    };
+  });
+  return rerankSearchHits(enriched, nowIso, halfLifeDays);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,7 +13,14 @@ export {
 export { DEFAULT_TEAMKB_BASE, getTeamKbBasePath, resolveTeamKbPath } from './paths.js';
 export { isPathSafe } from './path-safety.js';
 export type { PathSafetyResult } from './path-safety.js';
-export { computeFreshnessScore, CATEGORY_BOOST, rerankSearchHits } from './freshness.js';
+export {
+  computeFreshnessScore,
+  CATEGORY_BOOST,
+  rerankSearchHits,
+  extractMemoryIdFromCitation,
+  rerankCitedHits,
+} from './freshness.js';
+export type { CitedHitMetadata } from './freshness.js';
 export {
   scanForDisclosure,
   scanDisclosureFields,


### PR DESCRIPTION
## What
Wires the existing freshness + category rerank onto the production qmd search path. Adds `extractMemoryIdFromCitation` + `rerankCitedHits` to `@qmd-team-intent-kb/common` and applies them in `SearchService.searchViaQmd` after score normalisation. Resolved hits are enriched with `memoryId` + `category`; unresolvable citations keep their normalised score.

## Why + decision rationale
`rerankSearchHits` existed but only reranked the SQLite fallback — the governed production path (qmd) returned raw BM25 order, so a year-old reference doc could outrank last week's decision. This is R1 of the Cerebras-informed retrieval epic (#254): recency + category fused into ranking, serving stays deterministic/LLM-free.

Chose a resolver-callback helper in `common` over giving `qmd-adapter` a store dependency: the adapter stays a pure qmd facade and the same helper serves both the API and the plugin local path (follow-up plugin PR).

## Layer touched
`packages/common` (new pure functions) + `apps/api` search service. No schema change — `SearchHit.memoryId`/`category` were already optional. No invariant change: every hit still carries its `qmd://` citation.

## How it works
1. qmd hits → `normaliseScore` to [0,1] (rank-derived fallback when all raw scores are 0 — normalising **before** the rerank so freshness never multiplies into raw zeros and erases the ranking).
2. `rerankCitedHits` maps each citation basename (`{memoryId}.md`, the exporter's naming contract) → `MemoryRepository.findById` → `finalScore = score × freshness(e^-λ·age, 90d half-life) × categoryBoost`.
3. Unresolved citation ⇒ freshness 1.0, boost 1.0 — never penalized, just not boosted.

## Verification & evidence
- `pnpm typecheck` clean; `pnpm lint` clean; `pnpm test` **2016/2016 green** (168 files) — includes new unit tests (id extraction incl. dotted ids like `CLAUDE.md.md`, fresh-decision-over-stale-reference reorder, unresolved-hit neutrality, stable order on ties) and API tests against the injected fake qmd port + real test DB.
- The retrieval-eval CI ratchet is unaffected by design: the eval harness scores backends directly; this change is at the service layer above them.

## Risk assessment
Low. Ranking-only change on the read path; scores remain in [0,1] (clamped); resolution failure degrades to today's behavior (qmd order). Rollback = revert one commit.

## Operational impact
None — no env, migration, dep, or deploy-order change. The live brain API picks this up at its next versioned release/deploy.

## Follow-up & deferred
- Plugin local path wiring + rebundle (bead `qmd-team-intent-kb-vps.1` completes there; plugin repo PR after this merges).
- R2 RRF fusion with the native FTS5 backend (`vps.2`) builds directly on this seam.

## Governance links
Bead `qmd-team-intent-kb-vps.1` (epic `vps`). Refs jeremylongshore/qmd-team-intent-kb#254

- Jeremy Longshore
intentsolutions.io