### PR TITLE
feat(search): fuse native FTS5 with the qmd binary via reciprocal-rank fusion

### DIFF
--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,7 +13,10 @@ describe('QmdAdapter', () => {
   beforeEach(() => {
     mock = new MockQmdExecutor();
     exportDir = mkdtempSync(join(tmpdir(), 'qmd-adapter-test-'));
-    adapter = new QmdAdapter({ tenantId: 'test-tenant', exportDir }, mock);
+    adapter = new QmdAdapter(
+      { tenantId: 'test-tenant', exportDir, nativeIndexPath: ':memory:' },
+      mock,
+    );
   });
 
   afterEach(() => {
@@ -98,5 +101,115 @@ describe('QmdAdapter', () => {
     }
     // The executor was never invoked — nothing reached qmd.
     expect(mock.commands).toHaveLength(0);
+  });
+});
+
+// ─── R2: native FTS5 fusion behind query() (qmd-team-intent-kb-vps.2) ────────
+
+describe('QmdAdapter — native FTS5 fusion', () => {
+  let mock: MockQmdExecutor;
+  let exportDir: string;
+
+  function write(subdir: string, name: string, content: string): void {
+    mkdirSync(join(exportDir, subdir), { recursive: true });
+    writeFileSync(join(exportDir, subdir, name), content);
+  }
+
+  function fusedAdapter(): QmdAdapter {
+    return new QmdAdapter(
+      { tenantId: 'test-tenant', exportDir, nativeIndexPath: ':memory:' },
+      mock,
+    );
+  }
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+    exportDir = mkdtempSync(join(tmpdir(), 'qmd-adapter-fusion-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  it('surfaces a native hit when qmd returns nothing (the 2026-07-16 hyphen miss)', async () => {
+    write('curated', 'mcp-dup.md', 'the governed-brain MCP server was registered twice');
+    mock.queueSuccess('[]'); // qmd keyword-AND: zero hits for the hyphenated query
+    const result = await fusedAdapter().query(
+      'governed-brain registered',
+      'curated',
+      'test-tenant',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.file).toBe('qmd://kb-curated/mcp-dup.md');
+      expect(result.value[0]!.collection).toBe('kb-curated');
+    }
+  });
+
+  it('fuses both lists — a doc found by both backends ranks first', async () => {
+    write('curated', 'both.md', 'caddy ingress rules for the brain');
+    write('curated', 'native-only.md', 'more caddy notes nobody indexed');
+    mock.queueSuccess(
+      JSON.stringify([{ score: 2, file: 'qmd://kb-curated/both.md', snippet: 'qmd snip' }]),
+    );
+    const result = await fusedAdapter().query('caddy', 'curated', 'test-tenant');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBe(2);
+      expect(result.value[0]!.file).toBe('qmd://kb-curated/both.md');
+      expect(result.value[0]!.snippet).toBe('qmd snip'); // qmd snippet preferred
+    }
+  });
+
+  it('serves native-only results when the qmd binary fails outright', async () => {
+    write('curated', 'a.md', 'resilience content');
+    mock.queueFailure('qmd: command not found', 127);
+    const result = await fusedAdapter().query('resilience', 'curated', 'test-tenant');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('keeps the qmd error when both backends come up empty', async () => {
+    mock.queueFailure('boom', 1);
+    const result = await fusedAdapter().query('anything', 'curated', 'test-tenant');
+    expect(result.ok).toBe(false);
+  });
+
+  it('scope-filters native hits (archive excluded from curated scope)', async () => {
+    write('archive', 'old.md', 'unique archived topic');
+    mock.queueSuccess('[]');
+    const adapter = fusedAdapter();
+    const curated = await adapter.query('archived topic', 'curated', 'test-tenant');
+    expect(curated.ok).toBe(true);
+    if (curated.ok) expect(curated.value).toHaveLength(0);
+    mock.queueSuccess('[]');
+    const archived = await adapter.query('archived topic', 'archived', 'test-tenant');
+    expect(archived.ok).toBe(true);
+    if (archived.ok) expect(archived.value).toHaveLength(1);
+  });
+
+  it('honours the disableNativeFusion kill switch', async () => {
+    write('curated', 'a.md', 'kill switch content');
+    mock.queueSuccess('[]');
+    const adapter = new QmdAdapter(
+      {
+        tenantId: 'test-tenant',
+        exportDir,
+        nativeIndexPath: ':memory:',
+        disableNativeFusion: true,
+      },
+      mock,
+    );
+    const result = await adapter.query('kill switch', 'curated', 'test-tenant');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('still refuses a mismatched tenant before touching either backend', async () => {
+    write('curated', 'a.md', 'tenant guard content');
+    const result = await fusedAdapter().query('tenant guard', 'curated', 'other-tenant');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
   });
 });

--- a/packages/qmd-adapter/src/__tests__/cli.test.ts
+++ b/packages/qmd-adapter/src/__tests__/cli.test.ts
@@ -11,7 +11,7 @@ function makeInjected(): {
 } {
   const mock = new MockQmdExecutor();
   const makeAdapter = (t: string, e: string): QmdAdapter =>
-    new QmdAdapter({ tenantId: t, exportDir: e }, mock);
+    new QmdAdapter({ tenantId: t, exportDir: e, nativeIndexPath: ':memory:' }, mock);
   return { mock, makeAdapter };
 }
 

--- a/packages/qmd-adapter/src/__tests__/eval-qmd-retrieval.test.ts
+++ b/packages/qmd-adapter/src/__tests__/eval-qmd-retrieval.test.ts
@@ -7,7 +7,10 @@ import { qmdRetrievalFn } from '../eval/qmd-retrieval.js';
 const TENANT = 'intent-solutions';
 
 function adapterWith(mock: MockQmdExecutor): QmdAdapter {
-  return new QmdAdapter({ tenantId: TENANT, exportDir: '/tmp/does-not-matter' }, mock);
+  return new QmdAdapter(
+    { tenantId: TENANT, exportDir: '/tmp/does-not-matter', nativeIndexPath: ':memory:' },
+    mock,
+  );
 }
 
 /** A qmd `search --json` payload with ranked qmd:// citations. */

--- a/packages/qmd-adapter/src/__tests__/native-index-manager.test.ts
+++ b/packages/qmd-adapter/src/__tests__/native-index-manager.test.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NativeIndexManager } from '../native/native-index-manager.js';
+
+describe('NativeIndexManager', () => {
+  let exportDir: string;
+  let manager: NativeIndexManager;
+
+  function write(subdir: string, name: string, content: string, mtimeSec?: number): string {
+    const dir = join(exportDir, subdir);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, name);
+    writeFileSync(path, content);
+    if (mtimeSec !== undefined) utimesSync(path, mtimeSec, mtimeSec);
+    return path;
+  }
+
+  beforeEach(() => {
+    exportDir = mkdtempSync(join(tmpdir(), 'native-index-test-'));
+    manager = new NativeIndexManager({ exportDir, indexPath: ':memory:', refreshTtlMs: 0 });
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  it('indexes the export tree with qmd:// citation ids per collection', () => {
+    write('curated', 'abc.md', 'the governed pipeline');
+    write('decisions', 'def.md', 'we chose sqlite');
+    const indexed = manager.ensureFresh();
+    expect(indexed).toBe(2);
+    const hits = manager.search('governed', 10, []);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.id).toBe('qmd://kb-curated/abc.md');
+    expect(hits[0]!.collection).toBe('kb-curated');
+  });
+
+  it('matches hyphen- and dot-joined terms that keyword-AND tokenizers miss', () => {
+    write('curated', 'mcp-fix.md', 'the governed-brain MCP server was registered twice');
+    write('guides', 'doc-fix.md', 'currency fixes for CLAUDE.md across repos');
+    manager.ensureFresh();
+    // Hyphenated query term → tokenized → matches the hyphenated doc text.
+    expect(manager.search('governed-brain registered', 10, [])).toHaveLength(1);
+    // Dotted filename term in the query matches dotted text in the doc.
+    expect(manager.search('CLAUDE.md currency', 10, [])).toHaveLength(1);
+    // And the un-hyphenated phrasing reaches the hyphenated doc too.
+    expect(manager.search('governed brain MCP', 10, [])).toHaveLength(1);
+  });
+
+  it('re-indexes a changed file and drops a deleted one', () => {
+    const path = write('curated', 'a.md', 'original topic alpha', 1_000_000);
+    manager.ensureFresh();
+    expect(manager.search('alpha', 10, [])).toHaveLength(1);
+
+    writeFileSync(path, 'rewritten topic beta');
+    utimesSync(path, 2_000_000, 2_000_000);
+    expect(manager.ensureFresh()).toBe(1);
+    expect(manager.search('alpha', 10, [])).toHaveLength(0);
+    expect(manager.search('beta', 10, [])).toHaveLength(1);
+
+    unlinkSync(path);
+    manager.ensureFresh();
+    expect(manager.search('beta', 10, [])).toHaveLength(0);
+    expect(manager.count()).toBe(0);
+  });
+
+  it('skips the sweep inside the TTL window', () => {
+    write('curated', 'a.md', 'alpha');
+    const throttled = new NativeIndexManager({
+      exportDir,
+      indexPath: ':memory:',
+      refreshTtlMs: 60_000,
+    });
+    try {
+      expect(throttled.ensureFresh(1_000_000)).toBe(1);
+      write('curated', 'b.md', 'beta');
+      // Within the TTL: no sweep, new file not yet visible.
+      expect(throttled.ensureFresh(1_030_000)).toBe(0);
+      // After the TTL: swept.
+      expect(throttled.ensureFresh(1_070_000)).toBe(1);
+    } finally {
+      throttled.close();
+    }
+  });
+
+  it('filters search results to the allowed collections', () => {
+    write('curated', 'a.md', 'shared topic');
+    write('archive', 'b.md', 'shared topic');
+    manager.ensureFresh();
+    expect(manager.search('shared', 10, [])).toHaveLength(2);
+    const curatedOnly = manager.search('shared', 10, ['kb-curated', 'kb-decisions', 'kb-guides']);
+    expect(curatedOnly).toHaveLength(1);
+    expect(curatedOnly[0]!.collection).toBe('kb-curated');
+  });
+
+  it('tolerates a missing export dir (empty index, no throw)', () => {
+    const empty = new NativeIndexManager({
+      exportDir: join(exportDir, 'does-not-exist'),
+      indexPath: ':memory:',
+      refreshTtlMs: 0,
+    });
+    try {
+      expect(empty.ensureFresh()).toBe(0);
+      expect(empty.search('anything', 10, [])).toEqual([]);
+    } finally {
+      empty.close();
+    }
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/reindex.test.ts
+++ b/packages/qmd-adapter/src/__tests__/reindex.test.ts
@@ -14,7 +14,10 @@ describe('reindex', () => {
   beforeEach(() => {
     mock = new MockQmdExecutor();
     exportDir = mkdtempSync(join(tmpdir(), 'qmd-reindex-test-'));
-    adapter = new QmdAdapter({ tenantId: 'test-tenant', exportDir }, mock);
+    adapter = new QmdAdapter(
+      { tenantId: 'test-tenant', exportDir, nativeIndexPath: ':memory:' },
+      mock,
+    );
   });
 
   afterEach(() => {

--- a/packages/qmd-adapter/src/__tests__/rrf-fusion.test.ts
+++ b/packages/qmd-adapter/src/__tests__/rrf-fusion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { fuseReciprocalRank, RRF_K } from '../search/rrf-fusion.js';
+import type { QmdSearchResult } from '../types.js';
+import type { Fts5SearchHit } from '../native/fts5-backend.js';
+
+function qmdHit(file: string, score: number, snippet = 'qmd-snip'): QmdSearchResult {
+  return { file, score, snippet, collection: 'kb-curated' };
+}
+
+function nativeHit(id: string, score: number, snippet = 'fts-snip'): Fts5SearchHit {
+  return { id, score, snippet, collection: 'kb-curated' };
+}
+
+describe('fuseReciprocalRank', () => {
+  it('ranks a document present in both lists above single-list documents at the same ranks', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/both.md', 3), qmdHit('qmd://kb-curated/qmd-only.md', 2)],
+      [nativeHit('qmd://kb-curated/both.md', 9), nativeHit('qmd://kb-curated/fts-only.md', 8)],
+    );
+    expect(fused[0]!.file).toBe('qmd://kb-curated/both.md');
+    // rank 1 in both lists: 2/(k+1) vs rank-2 singles at 1/(k+2)
+    expect(fused[0]!.score).toBeCloseTo(2 / (RRF_K + 1), 10);
+  });
+
+  it('computes the standard RRF sum over 1-based ranks', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/a.md', 5), qmdHit('qmd://kb-curated/b.md', 4)],
+      [nativeHit('qmd://kb-curated/b.md', 7)],
+    );
+    const b = fused.find((h) => h.file.endsWith('/b.md'))!;
+    expect(b.score).toBeCloseTo(1 / (RRF_K + 2) + 1 / (RRF_K + 1), 10);
+    const a = fused.find((h) => h.file.endsWith('/a.md'))!;
+    expect(a.score).toBeCloseTo(1 / (RRF_K + 1), 10);
+  });
+
+  it('surfaces a native-only hit qmd missed entirely (the hyphen miss class)', () => {
+    const fused = fuseReciprocalRank([], [nativeHit('qmd://kb-curated/governed-brain-fix.md', 4)]);
+    expect(fused).toHaveLength(1);
+    expect(fused[0]!.file).toBe('qmd://kb-curated/governed-brain-fix.md');
+    expect(fused[0]!.snippet).toBe('fts-snip');
+  });
+
+  it('prefers the qmd snippet when a document appears in both lists', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/x.md', 1, 'rich qmd context')],
+      [nativeHit('qmd://kb-curated/x.md', 1, 'fts ellipsis')],
+    );
+    expect(fused[0]!.snippet).toBe('rich qmd context');
+  });
+
+  it('breaks score ties deterministically: best single-list rank, then id order', () => {
+    // Two docs each appearing only at rank 1 of one list — identical RRF score.
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/zeta.md', 1)],
+      [nativeHit('qmd://kb-curated/alpha.md', 1)],
+    );
+    expect(fused[0]!.score).toBe(fused[1]!.score);
+    expect(fused.map((h) => h.file)).toEqual([
+      'qmd://kb-curated/alpha.md',
+      'qmd://kb-curated/zeta.md',
+    ]);
+    // Deterministic: same input, same output, every time.
+    const again = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/zeta.md', 1)],
+      [nativeHit('qmd://kb-curated/alpha.md', 1)],
+    );
+    expect(again.map((h) => h.file)).toEqual(fused.map((h) => h.file));
+  });
+
+  it('returns [] when both lists are empty', () => {
+    expect(fuseReciprocalRank([], [])).toEqual([]);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/search-canary.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-canary.test.ts
@@ -31,7 +31,7 @@ describe('runSearchCanary', () => {
   beforeEach(() => {
     mock = new MockQmdExecutor();
     exportDir = mkdtempSync(join(tmpdir(), 'qmd-canary-test-'));
-    adapter = new QmdAdapter({ tenantId: TENANT, exportDir }, mock);
+    adapter = new QmdAdapter({ tenantId: TENANT, exportDir, nativeIndexPath: ':memory:' }, mock);
   });
 
   afterEach(() => {

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -9,10 +9,16 @@ import type { QmdAdapterConfig } from './config.js';
 import { RealQmdExecutor } from './executor/real-executor.js';
 import { CollectionManager } from './collections/collection-manager.js';
 import { getExportableCollections } from './collections/collection-registry.js';
-import { SearchClient } from './search/search-client.js';
+import { SearchClient, resolveScopeCollections } from './search/search-client.js';
+import { fuseReciprocalRank } from './search/rrf-fusion.js';
 import { IndexLifecycleManager } from './index-manager/index-lifecycle.js';
 import { checkHealth } from './health/health-check.js';
-import { getQmdTenantEnv } from './config.js';
+import { getQmdTenantEnv, getQmdTenantIndexPath } from './config.js';
+import { getNativeIndexManager, type NativeIndexManager } from './native/native-index-manager.js';
+import type { Fts5SearchHit } from './native/fts5-backend.js';
+
+/** How many native FTS5 hits to feed the fusion (pre scope-filter). */
+const NATIVE_SEARCH_K = 50;
 
 /** Facade class composing all qmd adapter managers */
 export class QmdAdapter {
@@ -20,9 +26,15 @@ export class QmdAdapter {
   readonly collections: CollectionManager;
   readonly search: SearchClient;
   readonly indexLifecycle: IndexLifecycleManager;
+  private readonly native: NativeIndexManager | null;
   private readonly exportDir: string;
   /** The single tenant this adapter's qmd registry + index are bound to. */
   private readonly tenantId: string;
+
+  /** The tenant this adapter serves (read-only; used by the search canary's fail-closed guard). */
+  get boundTenantId(): string {
+    return this.tenantId;
+  }
 
   constructor(config: QmdAdapterConfig, executor?: QmdExecutor) {
     this.exportDir = config.exportDir;
@@ -38,6 +50,23 @@ export class QmdAdapter {
     this.collections = new CollectionManager(this.executor);
     this.search = new SearchClient(this.executor);
     this.indexLifecycle = new IndexLifecycleManager(this.executor);
+    // Native FTS5 fusion half (vps.2). Failure to open the index (read-only
+    // fs, missing native dep) degrades to qmd-only search rather than
+    // breaking the adapter.
+    if (config.disableNativeFusion === true) {
+      this.native = null;
+    } else {
+      try {
+        this.native = getNativeIndexManager({
+          exportDir: config.exportDir,
+          indexPath:
+            config.nativeIndexPath ??
+            join(getQmdTenantIndexPath(config.tenantId), 'native-fts5.sqlite'),
+        });
+      } catch {
+        this.native = null;
+      }
+    }
   }
 
   /**
@@ -69,7 +98,36 @@ export class QmdAdapter {
       // refuse rather than serve the bound tenant's index unscoped/mislabelled.
       return { ok: true, value: [] };
     }
-    return this.search.search(queryText, scope);
+
+    // Two lexical backends, one deterministic fusion (vps.2): the external
+    // qmd binary (keyword-AND tokenizer) and the native FTS5 index over the
+    // same export tree (unicode61 tokenizer, catches hyphen/dot-joined terms
+    // qmd misses). Their ranked lists join by qmd:// citation and fuse via
+    // reciprocal-rank fusion. Either backend failing degrades to the other.
+    const effectiveScope: SearchScope = scope ?? 'curated';
+    const qmdResult = await this.search.search(queryText, effectiveScope);
+    const nativeHits = this.nativeSearch(queryText, effectiveScope);
+
+    if (!qmdResult.ok) {
+      // qmd unavailable — native results alone still serve the query (this
+      // also makes local search work when the qmd binary is not installed).
+      if (nativeHits.length > 0) {
+        return { ok: true, value: fuseReciprocalRank([], nativeHits) };
+      }
+      return qmdResult;
+    }
+    if (nativeHits.length === 0) return qmdResult;
+    return { ok: true, value: fuseReciprocalRank(qmdResult.value, nativeHits) };
+  }
+
+  /** Native FTS5 half of the fused query. Any failure degrades to []. */
+  private nativeSearch(queryText: string, scope: SearchScope): Fts5SearchHit[] {
+    if (this.native === null) return [];
+    try {
+      return this.native.search(queryText, NATIVE_SEARCH_K, resolveScopeCollections(scope));
+    } catch {
+      return [];
+    }
   }
 
   /** Check health of qmd and index state */

--- a/packages/qmd-adapter/src/canary/search-canary.ts
+++ b/packages/qmd-adapter/src/canary/search-canary.ts
@@ -70,14 +70,19 @@ export interface SearchCanaryReport {
 
 async function runControls(
   adapter: QmdAdapter,
-  tenantId: string,
   controls: readonly CanaryControl[],
 ): Promise<CanaryControlResult[]> {
   const results: CanaryControlResult[] = [];
   for (const control of controls) {
     const minHits = control.minHits ?? 1;
     const scope = control.scope ?? 'all';
-    const searchResult = await adapter.query(control.query, scope, tenantId);
+    // Probe the qmd backend DIRECTLY, not the fused query() surface: the
+    // canary exists to catch an empty/unregistered qmd index (the incident)
+    // and drive `reindex`. The native FTS5 fusion half (vps.2) would keep
+    // serving hits over an empty qmd index — graceful degradation for users,
+    // but exactly the masking this canary must see through. The adapter was
+    // constructed for `tenantId`, so the direct call stays tenant-scoped.
+    const searchResult = await adapter.search.search(control.query, scope);
     if (!searchResult.ok) {
       results.push({
         query: control.query,
@@ -131,7 +136,23 @@ export async function runSearchCanary(
 ): Promise<SearchCanaryReport> {
   const controls = options.controls ?? DEFAULT_CANARY_CONTROLS;
 
-  const firstPass = await runControls(adapter, tenantId, controls);
+  // Fail-closed tenant guard, preserved from when the canary probed the fused
+  // query() surface (which refuses mismatched tenants): a canary pointed at
+  // the wrong tenant reports degraded without touching the executor at all.
+  if (tenantId !== adapter.boundTenantId) {
+    return {
+      healthy: false,
+      tenantId,
+      controls: controls.map((c) => ({
+        query: c.query,
+        minHits: c.minHits ?? 1,
+        hits: 0,
+        passed: false,
+      })),
+    };
+  }
+
+  const firstPass = await runControls(adapter, controls);
   const firstHealthy = firstPass.every((c) => c.passed);
 
   if (firstHealthy || !options.heal) {
@@ -140,7 +161,7 @@ export async function runSearchCanary(
 
   // Unhealthy + heal requested: attempt an idempotent reindex, then re-check.
   const reindexResult = await reindex(adapter);
-  const secondPass = await runControls(adapter, tenantId, controls);
+  const secondPass = await runControls(adapter, controls);
   const recheckHealthy = secondPass.every((c) => c.passed);
 
   return {

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -50,6 +50,14 @@ export interface QmdAdapterConfig {
   exportDir: string;
   qmdBinary?: string;
   timeout?: number;
+  /**
+   * Override for the native FTS5 fusion index file (tests use `:memory:`).
+   * Defaults to `<qmd-index>/<tenantId>/native-fts5.sqlite` — derived data
+   * next to the qmd index it fuses with.
+   */
+  nativeIndexPath?: string;
+  /** Kill switch: serve qmd-only results with no native FTS5 fusion. */
+  disableNativeFusion?: boolean;
 }
 
 /** Default configuration values */

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -80,7 +80,15 @@ export type {
 } from './eval/index.js';
 
 // Native FTS5 — model-free keyword backend, no external binary (bead 0t9.2)
-export { Fts5Backend, fts5RetrievalFn, buildFts5MatchQuery } from './native/index.js';
+export {
+  Fts5Backend,
+  fts5RetrievalFn,
+  buildFts5MatchQuery,
+  NativeIndexManager,
+  getNativeIndexManager,
+} from './native/index.js';
+export { fuseReciprocalRank, RRF_K } from './search/rrf-fusion.js';
+export { resolveScopeCollections } from './search/search-client.js';
 export type { IndexedDoc, Fts5SearchHit } from './native/index.js';
 
 // Reindex — idempotent rebuild of the derived qmd-index from kb-export (e06.13)

--- a/packages/qmd-adapter/src/native/fts5-backend.ts
+++ b/packages/qmd-adapter/src/native/fts5-backend.ts
@@ -55,9 +55,12 @@ export class Fts5Backend {
   private readonly searchStmt: Database.Statement;
   private readonly countStmt: Database.Statement;
 
-  constructor(opts: { path?: string } = {}) {
-    this.db = new Database(opts.path ?? ':memory:');
+  constructor(opts: { path?: string; db?: Database.Database } = {}) {
+    // An injected db lets a caller (NativeIndexManager) share one SQLite file
+    // between the FTS5 docs table and its own bookkeeping tables.
+    this.db = opts.db ?? new Database(opts.path ?? ':memory:');
     this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
     this.db.exec(
       'CREATE VIRTUAL TABLE IF NOT EXISTS docs USING fts5(id UNINDEXED, collection UNINDEXED, content)',
     );
@@ -79,6 +82,31 @@ export class Fts5Backend {
       }
     });
     tx(docs);
+  }
+
+  /**
+   * Insert documents KNOWN to be absent from the index — skips the per-doc
+   * delete. `id` is UNINDEXED in the FTS5 table, so each upsert delete is a
+   * full scan of the virtual table; on a bulk first build that turns 17k
+   * inserts into O(n²) minutes. Callers that track index membership (the
+   * NativeIndexManager's files table) use this for new docs and reserve
+   * `index()`/`remove()` for the few changed/deleted ones.
+   */
+  insert(docs: readonly IndexedDoc[]): void {
+    const tx = this.db.transaction((items: readonly IndexedDoc[]) => {
+      for (const doc of items) {
+        this.insertStmt.run(doc.id, doc.collection ?? '', doc.content);
+      }
+    });
+    tx(docs);
+  }
+
+  /** Remove documents by id (no-op for ids that are not indexed). */
+  remove(ids: readonly string[]): void {
+    const tx = this.db.transaction((items: readonly string[]) => {
+      for (const id of items) this.deleteStmt.run(id);
+    });
+    tx(ids);
   }
 
   /** Remove every indexed document. */

--- a/packages/qmd-adapter/src/native/index.ts
+++ b/packages/qmd-adapter/src/native/index.ts
@@ -1,2 +1,3 @@
 export { Fts5Backend, fts5RetrievalFn, buildFts5MatchQuery } from './fts5-backend.js';
 export type { IndexedDoc, Fts5SearchHit } from './fts5-backend.js';
+export { NativeIndexManager, getNativeIndexManager } from './native-index-manager.js';

--- a/packages/qmd-adapter/src/native/native-index-manager.ts
+++ b/packages/qmd-adapter/src/native/native-index-manager.ts
@@ -1,0 +1,173 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { getExportableCollections } from '../collections/collection-registry.js';
+import { Fts5Backend, type Fts5SearchHit } from './fts5-backend.js';
+
+/**
+ * Persistent native FTS5 index over the git-exporter output tree — the piece
+ * that activates the dormant `Fts5Backend` (bead 0t9.2) on the production
+ * query path (retrieval epic, bead qmd-team-intent-kb-vps.2).
+ *
+ * Document ids are the same `qmd://<collection>/<id>.md` citations the qmd
+ * binary emits, so the two backends' result lists join by id for RRF fusion.
+ * The index is DERIVED data (like the qmd index itself): cheaply rebuildable
+ * from kb-export, deliberately outside backup scope, stored per-tenant under
+ * the qmd-index dir.
+ *
+ * Freshness is incremental: a `files` bookkeeping table records each indexed
+ * file's mtime; `ensureFresh()` stats the export tree (cheap — a readdir+stat
+ * sweep, no content reads) and re-reads only added/changed files, removing
+ * deleted ones. A TTL throttles the sweep so per-query overhead stays flat.
+ */
+export class NativeIndexManager {
+  private readonly backend: Fts5Backend;
+  private readonly db: Database.Database;
+  private readonly exportDir: string;
+  private readonly refreshTtlMs: number;
+  private lastRefreshMs = 0;
+
+  private readonly selectFiles: Database.Statement;
+  private readonly upsertFile: Database.Statement;
+  private readonly deleteFile: Database.Statement;
+
+  constructor(opts: { exportDir: string; indexPath: string; refreshTtlMs?: number }) {
+    this.exportDir = opts.exportDir;
+    this.refreshTtlMs = opts.refreshTtlMs ?? 15_000;
+    if (opts.indexPath !== ':memory:') {
+      mkdirSync(dirname(opts.indexPath), { recursive: true });
+    }
+    this.db = new Database(opts.indexPath);
+    this.backend = new Fts5Backend({ db: this.db });
+    this.db.exec(
+      'CREATE TABLE IF NOT EXISTS files (path TEXT PRIMARY KEY, doc_id TEXT NOT NULL, mtime_ms REAL NOT NULL)',
+    );
+    this.selectFiles = this.db.prepare('SELECT path, doc_id, mtime_ms FROM files');
+    this.upsertFile = this.db.prepare(
+      'INSERT INTO files(path, doc_id, mtime_ms) VALUES (?, ?, ?) ' +
+        'ON CONFLICT(path) DO UPDATE SET doc_id = excluded.doc_id, mtime_ms = excluded.mtime_ms',
+    );
+    this.deleteFile = this.db.prepare('DELETE FROM files WHERE path = ?');
+  }
+
+  /**
+   * Bring the index up to date with the export tree if the TTL has elapsed.
+   * Returns the number of files (re)indexed — 0 on a no-op sweep.
+   */
+  ensureFresh(nowMs: number = Date.now()): number {
+    if (nowMs - this.lastRefreshMs < this.refreshTtlMs) return 0;
+    this.lastRefreshMs = nowMs;
+
+    // Current on-disk state of every exportable collection.
+    const onDisk = new Map<string, { docId: string; mtimeMs: number; collection: string }>();
+    for (const def of getExportableCollections()) {
+      const dir = join(this.exportDir, def.sourceSubdir);
+      if (!existsSync(dir)) continue;
+      for (const name of readdirSync(dir)) {
+        if (!name.endsWith('.md')) continue;
+        const path = join(dir, name);
+        let mtimeMs: number;
+        try {
+          mtimeMs = statSync(path).mtimeMs;
+        } catch {
+          continue; // deleted between readdir and stat
+        }
+        onDisk.set(path, { docId: `qmd://${def.name}/${name}`, mtimeMs, collection: def.name });
+      }
+    }
+
+    const stored = new Map<string, { docId: string; mtimeMs: number }>();
+    for (const row of this.selectFiles.all() as Array<{
+      path: string;
+      doc_id: string;
+      mtime_ms: number;
+    }>) {
+      stored.set(row.path, { docId: row.doc_id, mtimeMs: row.mtime_ms });
+    }
+
+    // Collect the whole delta first, then write it in ONE batch: per-doc
+    // index() calls are one SQLite transaction (fsync) each, which turns a
+    // 17k-file first build into minutes; batched it is seconds.
+    // New docs take the pure-insert fast path; only CHANGED docs pay the
+    // FTS5 upsert delete (id is UNINDEXED → each delete scans the virtual
+    // table, so 17k first-build upserts would be O(n²) minutes).
+    const toInsert: Array<{ id: string; content: string; collection: string }> = [];
+    const toReplace: Array<{ id: string; content: string; collection: string }> = [];
+    const metaUpserts: Array<{ path: string; docId: string; mtimeMs: number }> = [];
+    for (const [path, info] of onDisk) {
+      const prior = stored.get(path);
+      if (prior !== undefined && prior.mtimeMs === info.mtimeMs) continue;
+      let content: string;
+      try {
+        content = readFileSync(path, 'utf8');
+      } catch {
+        continue; // deleted mid-sweep; the next sweep drops it
+      }
+      const doc = { id: info.docId, content, collection: info.collection };
+      if (prior === undefined) toInsert.push(doc);
+      else toReplace.push(doc);
+      metaUpserts.push({ path, docId: info.docId, mtimeMs: info.mtimeMs });
+    }
+
+    const toRemove: Array<{ path: string; docId: string }> = [];
+    for (const [path, prior] of stored) {
+      if (onDisk.has(path)) continue;
+      toRemove.push({ path, docId: prior.docId });
+    }
+
+    if (toInsert.length > 0) this.backend.insert(toInsert);
+    if (toReplace.length > 0) this.backend.index(toReplace);
+    if (toRemove.length > 0) this.backend.remove(toRemove.map((r) => r.docId));
+    if (metaUpserts.length > 0 || toRemove.length > 0) {
+      const tx = this.db.transaction(() => {
+        for (const m of metaUpserts) this.upsertFile.run(m.path, m.docId, m.mtimeMs);
+        for (const r of toRemove) this.deleteFile.run(r.path);
+      });
+      tx();
+    }
+
+    return toInsert.length + toReplace.length;
+  }
+
+  /**
+   * BM25 search over the export tree, filtered to `allowedCollections`
+   * (empty array = no filter). Refreshes the index first (TTL-throttled).
+   */
+  search(query: string, k: number, allowedCollections: readonly string[]): Fts5SearchHit[] {
+    this.ensureFresh();
+    const hits = this.backend.search(query, k);
+    if (allowedCollections.length === 0) return hits;
+    return hits.filter((h) => allowedCollections.includes(h.collection));
+  }
+
+  count(): number {
+    return this.backend.count();
+  }
+
+  close(): void {
+    this.backend.close();
+  }
+}
+
+/**
+ * Process-wide manager cache keyed by index path, so callers that construct a
+ * fresh `QmdAdapter` per request (the plugin's MCP handlers do) share one open
+ * index + TTL clock instead of re-opening SQLite on every search. `:memory:`
+ * paths are never cached — each would be a distinct empty database anyway.
+ */
+const managerCache = new Map<string, NativeIndexManager>();
+
+export function getNativeIndexManager(opts: {
+  exportDir: string;
+  indexPath: string;
+  refreshTtlMs?: number;
+}): NativeIndexManager {
+  if (opts.indexPath === ':memory:') return new NativeIndexManager(opts);
+  const cached = managerCache.get(opts.indexPath);
+  if (cached !== undefined) return cached;
+  const manager = new NativeIndexManager(opts);
+  managerCache.set(opts.indexPath, manager);
+  return manager;
+}

--- a/packages/qmd-adapter/src/search/rrf-fusion.ts
+++ b/packages/qmd-adapter/src/search/rrf-fusion.ts
@@ -1,0 +1,79 @@
+import type { QmdSearchResult } from '../types.js';
+import type { Fts5SearchHit } from '../native/fts5-backend.js';
+
+/**
+ * Reciprocal-rank-fusion constant. The standard k=60 from Cormack et al. —
+ * large enough that a document's absolute rank matters less than appearing in
+ * both lists, which is exactly the property we want when fusing two lexical
+ * backends with different tokenizers.
+ */
+export const RRF_K = 60;
+
+/**
+ * Fuse the qmd binary's ranked list with the native FTS5 ranked list using
+ * deterministic reciprocal-rank fusion (retrieval epic, qmd-team-intent-kb-vps.2):
+ *
+ *   rrf(d) = Σ over lists containing d of 1 / (k + rank_d)   (rank is 1-based)
+ *
+ * Join key is the `qmd://` citation (both backends emit the same ids). The two
+ * backends deliberately differ in tokenization — qmd's keyword-AND misses
+ * hyphen/dot-joined terms ("governed-brain", "CLAUDE.md") that FTS5's unicode61
+ * tokenizer splits and matches — so their union, not either list alone, is the
+ * recall surface.
+ *
+ * Determinism: ties break by best single-list rank, then by id lexicographic
+ * order. No randomness, no model call.
+ *
+ * Snippet/collection prefer the qmd hit (its diff-style snippets carry more
+ * context); FTS5 fills in for hits qmd missed. The fused score is the raw RRF
+ * score (~1/60 scale) — callers normalise to [0,1] against the top hit, which
+ * the API service already does.
+ */
+export function fuseReciprocalRank(
+  qmdHits: readonly QmdSearchResult[],
+  nativeHits: readonly Fts5SearchHit[],
+  k: number = RRF_K,
+): QmdSearchResult[] {
+  interface FusedEntry {
+    id: string;
+    score: number;
+    bestRank: number;
+    qmdHit?: QmdSearchResult;
+    nativeHit?: Fts5SearchHit;
+  }
+
+  const entries = new Map<string, FusedEntry>();
+
+  qmdHits.forEach((hit, i) => {
+    const rank = i + 1;
+    const entry = entries.get(hit.file) ?? { id: hit.file, score: 0, bestRank: Infinity };
+    entry.score += 1 / (k + rank);
+    entry.bestRank = Math.min(entry.bestRank, rank);
+    entry.qmdHit ??= hit;
+    entries.set(hit.file, entry);
+  });
+
+  nativeHits.forEach((hit, i) => {
+    const rank = i + 1;
+    const entry = entries.get(hit.id) ?? { id: hit.id, score: 0, bestRank: Infinity };
+    entry.score += 1 / (k + rank);
+    entry.bestRank = Math.min(entry.bestRank, rank);
+    entry.nativeHit ??= hit;
+    entries.set(hit.id, entry);
+  });
+
+  return [...entries.values()]
+    .sort(
+      (a, b) =>
+        b.score - a.score || a.bestRank - b.bestRank || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    )
+    .map((entry) => ({
+      file: entry.id,
+      score: entry.score,
+      snippet:
+        entry.qmdHit?.snippet !== undefined && entry.qmdHit.snippet !== ''
+          ? entry.qmdHit.snippet
+          : (entry.nativeHit?.snippet ?? ''),
+      collection: entry.qmdHit?.collection ?? entry.nativeHit?.collection ?? 'unknown',
+    }));
+}

--- a/packages/qmd-adapter/src/search/search-client.ts
+++ b/packages/qmd-adapter/src/search/search-client.ts
@@ -44,17 +44,26 @@ export class SearchClient {
 
   /** Resolve which collections to include based on scope */
   private resolveCollections(scope: SearchScope): string[] {
-    switch (scope) {
-      case 'curated':
-        return getDefaultSearchCollections();
-      case 'inbox':
-        return ['kb-inbox'];
-      case 'archived':
-        return ['kb-archive'];
-      case 'all':
-        return []; // No filtering
-      default:
-        return getDefaultSearchCollections();
-    }
+    return resolveScopeCollections(scope);
+  }
+}
+
+/**
+ * Map a search scope to the collections it may return (empty = no filter).
+ * Shared by the qmd path and the native FTS5 fusion path so both halves of a
+ * fused result honour the same scope contract.
+ */
+export function resolveScopeCollections(scope: SearchScope): string[] {
+  switch (scope) {
+    case 'curated':
+      return getDefaultSearchCollections();
+    case 'inbox':
+      return ['kb-inbox'];
+    case 'archived':
+      return ['kb-archive'];
+    case 'all':
+      return []; // No filtering
+    default:
+      return getDefaultSearchCollections();
   }
 }


### PR DESCRIPTION
## What
Activates the dormant native FTS5 BM25 backend (bead 0t9.2) on the production query path and fuses it with the external qmd binary via deterministic reciprocal-rank fusion (k=60), behind `QmdAdapter.query()`. New: `NativeIndexManager` (persistent per-tenant FTS5 index over the export tree, incremental mtime-diff refresh, TTL-throttled, process-wide cache) and `rrf-fusion` (pure, deterministic). `disableNativeFusion` config is the kill switch.

## Why + decision rationale
The 2026-07-16 incident: `brain_search` returned **0 hits for our own memory** because qmd's keyword-AND tokenizer can't match hyphen/dot-joined terms ("governed-brain", "CLAUDE.md"). FTS5's unicode61 tokenizer splits and matches them; fusing the two lexical backends kills that miss class while keeping serving 100% deterministic/LLM-free (ADR 038). R2 of the retrieval epic (#254).

- Chose **RRF over score-level fusion** because BM25 scores from two different tokenizers aren't comparable; rank fusion needs no calibration and is trivially deterministic (ties: best single-list rank, then id order).
- Chose a **persistent index over per-query in-memory** because the live corpus is 17k files / 79 MB.
- Bulk first build uses a **pure-insert fast path**: FTS5's `id` is UNINDEXED, so upsert deletes full-scan the virtual table — measured **453s → 3.8s** first build on the live corpus.

## Layer touched
`packages/qmd-adapter` only (retrieve layer). One behavioral invariant deliberately preserved by moving code: the **search canary now probes the qmd backend directly** (`adapter.search.search`) with an explicit fail-closed tenant guard — fusion's graceful degradation would otherwise mask the exact empty-qmd-index incident the canary exists to catch and heal.

## How it works
1. `query()` (after the unchanged tenant guard) runs the qmd search and the native FTS5 search; both scope-filter via the shared `resolveScopeCollections`.
2. Lists join by `qmd://` citation (both backends emit identical ids — exporter naming contract) and fuse: `rrf(d) = Σ 1/(60 + rank)`.
3. Either backend failing degrades to the other — local search now also works with **no qmd binary installed**. Both failing preserves the qmd error.
4. Native index = derived data at `qmd-index/<tenant>/native-fts5.sqlite`, incremental sweep re-reads only added/changed files (15s TTL).

## Verification & evidence
- `pnpm typecheck` + `lint` clean; **2035/2035 tests green** (19 new: RRF math + determinism, index lifecycle incl. change/delete/TTL, hyphen+dot miss class, scope filter, kill switch, canary tenant guard).
- Synthetic retrieval ratchet **PASS at the committed baseline** (lexical 1.0 / semantic 0.5833). Honest note: fusion does NOT move synthetic-v1 — its 6 remaining misses are paraphrase-shaped ("refuse everything unless it appears on an allowlist" → fail-closed.md), which no lexical backend catches; those stay gated behind ADR 038's semantic path. The tokenization miss class this PR fixes enters the dataset as regression queries in the next PR (bead vps.3), which will move the baseline.
- **Live-brain smoke (dev box, tenant `local`, 17,273 files):** 4 of 5 previously zero-hit queries now return the correct memories with citations, including the two named incident queries — "governed-brain MCP registered twice" (0 → 1 hit) and "CLAUDE.md currency fixes" (0 → 4 hits); also "teamkb backup restore runbook" (0 → 1) and "SOPS age secrets rotation" (0 → 3).
- **Latency guard:** warm fused max **562ms** vs 712ms qmd-only before (fusion is net-neutral-to-faster; the FTS5 query is in-process). One-time first build 3.8s; steady-state freshness sweep is a stat-only readdir.

## Risk assessment
Medium-low, read-path only. New failure modes all degrade: index-open failure → qmd-only; native search throw → qmd-only; qmd failure → native-only (new behavior, strictly more available than before). Score scale changes to RRF (~1/60) — downstream consumers already normalise against the top hit (API) or treat scores as ordinal (plugin). Rollback: revert, or set `disableNativeFusion: true` without reverting.

## Operational impact
Creates `qmd-index/<tenant>/native-fts5.sqlite` (derived; correctly OUTSIDE backup scope). No env/migration/dep changes (better-sqlite3 already a dependency). First query after deploy pays a one-time ~4s build on the live corpus.

## Follow-up & deferred
- vps.3: hyphen/dot regression queries into synthetic-v1 + baseline move + JSON eval artifact.
- vps.4: live governed-brain eval for the ADR-038 gate number.
- Plugin rebundle after merge (with #256) wires this into `brain_search` local mode.

## Governance links
Bead `qmd-team-intent-kb-vps.2` (epic `vps`). Refs jeremylongshore/qmd-team-intent-kb#254

- Jeremy Longshore
intentsolutions.io