### PR TITLE
feat(eval): guard the hyphen/dot miss class with a tokenization stratum and emit a JSON eval artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,15 @@ jobs:
         run: pnpm build
       - name: Retrieval ratchet (stratified Recall@10 over the committed synthetic corpus)
         run: pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:retrieval:ci
+      - name: Upload eval artifact (JSON metrics + per-query outcomes, vps.3)
+        # if: always() — the artifact is written on ratchet FAIL too; a red run's
+        # numbers are exactly the ones worth keeping.
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: retrieval-eval-synthetic-v1
+          path: packages/qmd-adapter/eval-results/synthetic-v1.json
+          if-no-files-found: warn
 
   integration:
     # L4 integration tests via testcontainers. Pulls real Docker images

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ secrets/*.private.hex
 !secrets/*.sops.env
 !keys/*.pub
 .worktrees/
+
+# Retrieval eval JSON artifacts (vps.3) — emitted per run, uploaded by CI, never committed
+packages/qmd-adapter/eval-results/

--- a/packages/qmd-adapter/src/eval/ci-retrieval-ratchet.ts
+++ b/packages/qmd-adapter/src/eval/ci-retrieval-ratchet.ts
@@ -35,7 +35,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -164,9 +164,11 @@ export async function runRetrievalRatchet(): Promise<number> {
 
     const lexical = sr.byKind.find((s) => s.stratum === 'lexical');
     const semantic = sr.byKind.find((s) => s.stratum === 'semantic');
+    const tokenization = sr.byKind.find((s) => s.stratum === 'tokenization');
     const checks = [
       checkStratum(lexical, 'lexical', SYNTHETIC_V1_BASELINE.lexicalRecallAtK),
       checkStratum(semantic, 'semantic', SYNTHETIC_V1_BASELINE.semanticRecallAtK),
+      checkStratum(tokenization, 'tokenization', SYNTHETIC_V1_BASELINE.tokenizationRecallAtK),
     ];
 
     console.log(`\n=== ratchet (per-stratum Recall@10 ≥ baseline − ${RATCHET_EPSILON}) ===`);
@@ -177,6 +179,11 @@ export async function runRetrievalRatchet(): Promise<number> {
           `${c.held ? 'OK' : 'REGRESSED'}`,
       );
     }
+
+    // Emit the machine-readable eval artifact (vps.3) — written on PASS and
+    // FAIL alike so CI always uploads a tracked history of the numbers, not
+    // just a green/red bit. Path overridable for local runs.
+    writeEvalArtifact(sr, checks, report.perQuery);
 
     const regressed = checks.filter((c) => !c.held);
     if (regressed.length > 0) {
@@ -205,6 +212,55 @@ export async function runRetrievalRatchet(): Promise<number> {
     return 0;
   } finally {
     rmSync(tmpBase, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Write the JSON eval artifact (vps.3): the stratified metrics, the ratchet
+ * verdicts, and the per-query outcomes. CI uploads this as a build artifact so
+ * eval history is a tracked series of numbers rather than console scrollback.
+ * Default path is `eval-results/synthetic-v1.json` under the package dir;
+ * override with RETRIEVAL_EVAL_JSON_PATH.
+ */
+function writeEvalArtifact(
+  sr: ReturnType<typeof stratify>,
+  checks: RatchetCheck[],
+  perQuery: ReadonlyArray<{
+    id: string;
+    kind?: string;
+    query: string;
+    recallAtK: number;
+    retrieved: readonly string[];
+  }>,
+): void {
+  const hereDir = dirname(fileURLToPath(import.meta.url));
+  const defaultPath = join(hereDir, '..', '..', 'eval-results', 'synthetic-v1.json');
+  const outPath = process.env['RETRIEVAL_EVAL_JSON_PATH'] ?? defaultPath;
+  const artifact = {
+    dataset: sr.dataset,
+    backend: sr.backend,
+    k: sr.k,
+    generatedAt: new Date().toISOString(),
+    overall: sr.overall,
+    byKind: sr.byKind,
+    ratchet: { epsilon: RATCHET_EPSILON, checks, pass: checks.every((c) => c.held) },
+    perQuery: perQuery.map((q) => ({
+      id: q.id,
+      kind: q.kind ?? 'untagged',
+      query: q.query,
+      hit: q.recallAtK > 0,
+      recallAtK: q.recallAtK,
+      retrievedTop3: q.retrieved.slice(0, 3),
+    })),
+  };
+  try {
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`);
+    console.log(`\neval artifact written: ${outPath}`);
+  } catch (err: unknown) {
+    // The artifact is evidence, not the gate — never let a write failure flip
+    // the ratchet verdict.
+    console.error(`WARN could not write eval artifact to ${outPath}:`, err);
   }
 }
 

--- a/packages/qmd-adapter/src/eval/datasets/README-synthetic.md
+++ b/packages/qmd-adapter/src/eval/datasets/README-synthetic.md
@@ -23,7 +23,7 @@ corpus is dual-usable as a public showcase. The id space is exactly what
 `qmd search` returns for a locally-built index over these files:
 `qmd://kb-{curated,decisions,guides}/<file-basename>.md`.
 
-## The queries (stratified, semantic-weighted: 8 lexical, 12 semantic)
+## The queries (stratified: 8 lexical, 12 semantic, 5 tokenization)
 
 The split is the whole point — a blended average hides a semantic collapse.
 
@@ -34,6 +34,13 @@ The split is the whole point — a blended average hides a semantic collapse.
   _synonym / low-overlap_ paraphrases that restate the concept in words the doc
   never uses (the genuine BM25 recall wall → miss). Real misses are **kept**, not
   reworded away — that is the signal.
+- **tokenization (5)** are the 2026-07-16 incident class (retrieval epic
+  vps.3): hyphen/dot-joined query terms ("governed-brain", "CLAUDE.md",
+  "bd-sync", "settings.json") that appear VERBATIM in the target doc but that
+  the qmd binary's keyword-AND tokenizer returns 0 hits for. The fused path
+  (vps.2: RRF over qmd + native FTS5) hits all 5; measured qmd-alone
+  (`disableNativeFusion: true`) hits only 2/5. These are permanent regression
+  guards for the fusion.
 
 ## The ratchet
 
@@ -46,11 +53,17 @@ Baselines are **measured, not guessed** — the numbers this corpus + query set
 actually produce against the pinned `@tobilu/qmd` (see `SYNTHETIC_V1_BASELINE`
 in `synthetic-v1.ts`):
 
-| Stratum  | Hits  | Recall@10 |
-| -------- | ----- | --------- |
-| lexical  | 8/8   | 1.0       |
-| semantic | 7/12  | ≈ 0.5833  |
-| overall  | 15/20 | 0.75      |
+| Stratum      | Hits  | Recall@10 |
+| ------------ | ----- | --------- |
+| lexical      | 8/8   | 1.0       |
+| semantic     | 7/12  | ≈ 0.5833  |
+| tokenization | 5/5   | 1.0       |
+| overall      | 20/25 | 0.80      |
+
+The ratchet also writes a machine-readable artifact
+(`eval-results/synthetic-v1.json`: stratified metrics, ratchet verdicts,
+per-query outcomes) which CI uploads on pass AND fail, so eval history is a
+tracked series of numbers rather than console scrollback.
 
 The ratchet guards the retrieval we already ship against regression. It does
 **not** gate on the absolute 0.85 BM25-sufficiency bar — that is the

--- a/packages/qmd-adapter/src/eval/datasets/synthetic-v1.ts
+++ b/packages/qmd-adapter/src/eval/datasets/synthetic-v1.ts
@@ -187,6 +187,51 @@ export const SYNTHETIC_V1_DATASET: EvalDataset = {
       notes:
         'Single-tasking concept in fresh words (concentrate/lone objective/interruptions). MISS.',
     },
+
+    // --- tokenization (5) — hyphen/dot-joined terms (retrieval epic vps.3).
+    //     The 2026-07-16 incident class: qmd's keyword-AND tokenizer returns 0
+    //     hits when a query term is hyphen- or dot-joined ("governed-brain",
+    //     "CLAUDE.md"), even though the term appears VERBATIM in the doc. The
+    //     native FTS5 fusion half (vps.2) tokenizes these and matches. These
+    //     queries are regression guards for that miss class — labeled against
+    //     the FUSED production path. ---
+    {
+      id: 'q-tok-01',
+      kind: 'tokenization',
+      query: 'governed-brain MCP registered twice',
+      relevant: ['qmd://kb-curated/governed-brain-mcp.md'],
+      notes: 'The literal incident query (2026-07-16). qmd-alone: MISS (hyphen). Fused: HIT.',
+    },
+    {
+      id: 'q-tok-02',
+      kind: 'tokenization',
+      query: 'CLAUDE.md currency fixes',
+      relevant: ['qmd://kb-guides/claudemd-currency.md'],
+      notes:
+        'The second incident query — dotted filename term. On the small synthetic corpus qmd-alone happens to HIT; on the 17k-file live brain it returned 0 hits. Fused: HIT.',
+    },
+    {
+      id: 'q-tok-03',
+      kind: 'tokenization',
+      query: 'bd-sync three-layer mirror',
+      relevant: ['qmd://kb-guides/bd-sync-mirror.md'],
+      notes: 'Two hyphenated terms in one query. qmd-alone: MISS. Fused: HIT.',
+    },
+    {
+      id: 'q-tok-04',
+      kind: 'tokenization',
+      query: 'settings.json attribution drift',
+      relevant: ['qmd://kb-guides/claudemd-currency.md'],
+      notes: 'Dotted config-file term in the query body. qmd-alone: MISS. Fused: HIT.',
+    },
+    {
+      id: 'q-tok-05',
+      kind: 'tokenization',
+      query: 'governed brain MCP duplicate registration',
+      relevant: ['qmd://kb-curated/governed-brain-mcp.md'],
+      notes:
+        'Cross-form control: un-hyphenated query phrasing must still reach the hyphenated doc.',
+    },
   ],
 };
 
@@ -215,6 +260,13 @@ export const SYNTHETIC_V1_BASELINE = {
   lexicalRecallAtK: 1.0,
   /** 7/12 semantic queries hit. */
   semanticRecallAtK: 7 / 12,
+  /**
+   * 5/5 tokenization queries hit on the FUSED path (vps.2 RRF fusion of qmd +
+   * native FTS5). Measured with `disableNativeFusion: true` this stratum is
+   * 2/5 (the three multi-hyphen/dot queries miss) — the 2026-07-16 miss class
+   * this ratchet now permanently guards.
+   */
+  tokenizationRecallAtK: 1.0,
 } as const;
 
 /** Float-noise tolerance for the ratchet; a genuine regression is far larger. */

--- a/packages/qmd-adapter/src/eval/eval-types.ts
+++ b/packages/qmd-adapter/src/eval/eval-types.ts
@@ -14,7 +14,7 @@ export interface EvalQuery {
   /** Gold-relevant doc identifiers (same id space as RetrievalFn output). */
   relevant: string[];
   /** Which class this query stresses — lexical (exact terms) vs semantic (paraphrase). */
-  kind?: 'lexical' | 'semantic';
+  kind?: 'lexical' | 'semantic' | 'tokenization';
   notes?: string;
 }
 
@@ -33,7 +33,7 @@ export type RetrievalFn = (query: string, k: number) => Promise<string[]>;
 export interface QueryEvalResult {
   id: string;
   query: string;
-  kind?: 'lexical' | 'semantic';
+  kind?: 'lexical' | 'semantic' | 'tokenization';
   retrieved: string[];
   recallAtK: number;
   ndcgAtK: number;

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/governed-brain-mcp.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/curated/governed-brain-mcp.md
@@ -1,0 +1,11 @@
+# Governed-Brain MCP Server Registration
+
+The governed-brain MCP server is the plugin's stdio entry point. A recurring
+misconfiguration is registering governed-brain twice — once from the plugin
+manifest and once hand-added to the user scope — which makes every tool appear
+duplicated in the client's tool list.
+
+The fix is to keep exactly one registration: remove the hand-added user-scope
+entry and let the plugin manifest own the governed-brain server. After the
+duplicate registration is removed, restart the session and verify the tool
+list shows a single brain_search.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/bd-sync-mirror.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/bd-sync-mirror.md
@@ -1,0 +1,10 @@
+# bd-sync Three-Layer Mirror
+
+bd-sync is the only tool that mirrors bead state outward: a bead, its GitHub
+issue, and its Plane issue form a three-layer mirror where every record carries
+the other two ids. Notes and closes flow through bd-sync so no layer silently
+drifts.
+
+Raw bd close is mirror-blind — the bead goes terminal but the linked GitHub
+issue never hears about it. Every settle therefore uses bd-sync close, and a
+periodic bd-sync status sweep surfaces any drift the mirror missed.

--- a/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/claudemd-currency.md
+++ b/packages/qmd-adapter/src/eval/fixtures/synthetic-corpus/guides/claudemd-currency.md
@@ -1,0 +1,11 @@
+# CLAUDE.md Currency Fixes
+
+CLAUDE.md files drift: a stack note goes stale, a decommissioned service stays
+documented, a path moves. Currency fixes are the small, dated edits that keep
+every CLAUDE.md aligned with reality, applied the moment a drift is noticed
+rather than batched.
+
+The sweep also covers settings.json references — the attribution block and
+hook paths named in CLAUDE.md must match what settings.json actually
+configures. A currency fix that touches one file without the other reintroduces
+the drift it was meant to close.


### PR DESCRIPTION
> **Stacked on #257** (RRF fusion) — the tokenization baseline is measured against the fused path. Merge #257 first; GitHub will retarget this to main.

## What
R3 of the retrieval epic (#254, bead `qmd-team-intent-kb-vps.3`): the 2026-07-16 incident class becomes a permanent CI-gated regression stratum, and the retrieval ratchet now emits a machine-readable eval artifact.

- 3 new committed corpus docs + 5 `tokenization` queries in synthetic-v1, including the two literal incident queries ("governed-brain MCP registered twice", "CLAUDE.md currency fixes").
- Third per-stratum ratchet check with a **measured** baseline: fused 5/5 = 1.0; counterfactual with `disableNativeFusion: true` measured **2/5** (the three multi-hyphen/dot queries miss) — recorded in the baseline docstring and README-synthetic.
- JSON artifact `eval-results/synthetic-v1.json` (stratified metrics, ratchet verdicts, per-query outcomes) written on pass AND fail; the `retrieval-eval` CI job uploads it with `if: always()` so eval history is a tracked series of numbers.

## Why + decision rationale
Fusion (#257) fixes the miss class but nothing guarded it against regressing. Chose a separate stratum over folding these into `lexical` because the ratchet gates per-stratum: a fusion breakage must fail loudly on its own line, not be averaged away by 8 green lexical queries.

## Layer touched
Eval harness + CI only (`packages/qmd-adapter/src/eval`, `ci.yml`, `.gitignore`). No serving-path code.

## How it works
Dataset gains `kind: 'tokenization'` (union widened in eval-types); `stratify` already groups by observed kind; the ratchet adds the third `checkStratum` and `writeEvalArtifact` (path overridable via `RETRIEVAL_EVAL_JSON_PATH`; a write failure warns but never flips the gate verdict).

## Verification & evidence
- `pnpm typecheck` + `lint` clean; full suite 170 files / 2025 tests green.
- Ratchet local run: lexical 1.0 / semantic 0.5833 / tokenization 1.0 — PASS, artifact written. Existing strata byte-identical to their committed baselines (the 3 new corpus docs displaced nothing). Blended rises 0.75 → 0.80 purely from the new stratum.
- Counterfactual script run (fusion disabled): tokenization 2/5 — MISS on "governed-brain MCP registered twice", "bd-sync three-layer mirror", "settings.json attribution drift".

## Risk assessment
Low — eval/CI only. The new gate can fail future PRs that break fusion: that is its job. Rollback = revert.

## Operational impact
None at runtime. CI gains one artifact upload (~2 KB/run). `eval-results/` is gitignored.

## Follow-up & deferred
- vps.4: expand governed-brain-v1 into a real labeled live set and record the ADR-038 gate number as this same JSON artifact shape.
- vps.5: summary-first indexing.

## Governance links
Bead `qmd-team-intent-kb-vps.3` (epic `vps`). Refs jeremylongshore/qmd-team-intent-kb#254

- Jeremy Longshore
intentsolutions.io