### PR TITLE
feat(policy-engine): define the recommended full-coverage policy and an anti-dormancy gate

### DIFF
--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -38,6 +38,13 @@ export interface CuratorDependencies {
  * All operations are synchronous. Only `ingestFromSpool` (file I/O) is async.
  */
 export class Curator {
+  /**
+   * Policy ids already warned about for dormant rules (5bm.2), so the runtime
+   * completeness check fires ONCE per policy rather than per candidate — a
+   * digestion batch must not emit 17k identical warnings.
+   */
+  private readonly warnedDormantPolicies = new Set<string>();
+
   constructor(
     private readonly deps: CuratorDependencies,
     private readonly config: CuratorConfig,
@@ -83,6 +90,19 @@ export class Curator {
     }
 
     const pipeline = new PolicyPipeline(policy);
+    // Runtime completeness check (5bm.2): fire the anti-dormancy gate against the
+    // LIVE policy, not only in CI. Warn (never throw — a throw here would refuse
+    // to govern on a dormant policy and stall the whole brain) once per policy so
+    // an operator sees which registered rules gate nothing on the running store.
+    if (pipeline.dormantRuleTypes.length > 0 && !this.warnedDormantPolicies.has(policy.id)) {
+      this.warnedDormantPolicies.add(policy.id);
+      console.warn(
+        `[curator] governance policy "${policy.name}" (${policy.id}) leaves ` +
+          `${pipeline.dormantRuleTypes.length} registered rule(s) dormant: ` +
+          `${pipeline.dormantRuleTypes.join(', ')}. They gate nothing on this store. ` +
+          `See buildRecommendedPolicy / bead qmd-team-intent-kb-5bm.10.`,
+      );
+    }
     // Tenant-scoped existing-hash set (B1) — mirrors the API promotion-service so
     // the policy dedup rule sees only this tenant's memories.
     const hashSet =

--- a/packages/policy-engine/src/__tests__/recommended-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/recommended-policy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Recommended-policy + completeness-gate tests (bead qmd-team-intent-kb-5bm.2).
+ *
+ * The load-bearing test is `covers every registered rule type` — it is the
+ * anti-dormancy gate. If someone adds a rule to RULE_REGISTRY without adding it
+ * to RECOMMENDED_POLICY_RULES, this fails in CI, forcing a deliberate
+ * enable/waive decision instead of a silently-inert rule (the exact failure mode
+ * the ontology audit found in the live policy: 6 of 8 rules dormant).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RULE_REGISTRY,
+  RECOMMENDED_POLICY_RULES,
+  buildRecommendedPolicy,
+  findUncoveredRuleTypes,
+  assertPolicyCompleteness,
+} from '../index.js';
+import { GovernancePolicy, type PolicyRuleType } from '@qmd-team-intent-kb/schema';
+
+const NOW = '2026-07-17T00:00:00.000Z';
+
+describe('RECOMMENDED_POLICY_RULES', () => {
+  it('covers every registered rule type (anti-dormancy gate)', () => {
+    const recommended = new Set(RECOMMENDED_POLICY_RULES.map((r) => r.type));
+    const registered = Object.keys(RULE_REGISTRY) as PolicyRuleType[];
+    const missing = registered.filter((t) => !recommended.has(t));
+    expect(
+      missing,
+      `registered rules missing from RECOMMENDED_POLICY_RULES: ${missing.join(', ')}`,
+    ).toEqual([]);
+    // And no phantom types that are not registered.
+    const registeredSet = new Set(registered);
+    for (const r of RECOMMENDED_POLICY_RULES) expect(registeredSet.has(r.type)).toBe(true);
+  });
+
+  it('keeps the three hard boundaries as reject and the rest as flag', () => {
+    const byType = new Map(RECOMMENDED_POLICY_RULES.map((r) => [r.type, r.action]));
+    expect(byType.get('secret_detection')).toBe('reject');
+    expect(byType.get('content_length')).toBe('reject');
+    expect(byType.get('tenant_match')).toBe('reject');
+    for (const t of [
+      'source_trust',
+      'relevance_score',
+      'sensitivity_gate',
+      'dedup_check',
+      'content_sanitization',
+    ] as const) {
+      expect(byType.get(t)).toBe('flag');
+    }
+  });
+
+  it('has unique rule ids and every rule enabled', () => {
+    const ids = RECOMMENDED_POLICY_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(RECOMMENDED_POLICY_RULES.every((r) => r.enabled)).toBe(true);
+  });
+});
+
+describe('buildRecommendedPolicy', () => {
+  it('produces a valid GovernancePolicy covering all rules', () => {
+    const policy = buildRecommendedPolicy('team-alpha', NOW);
+    expect(() => GovernancePolicy.parse(policy)).not.toThrow();
+    expect(findUncoveredRuleTypes(policy)).toEqual([]);
+    expect(policy.tenantId).toBe('team-alpha');
+  });
+});
+
+describe('findUncoveredRuleTypes + assertPolicyCompleteness', () => {
+  it('reports the dormant rules of the audited 2-rule live policy shape', () => {
+    const twoRule = GovernancePolicy.parse({
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'Audited live shape',
+      tenantId: 'team-alpha',
+      rules: [
+        {
+          id: 'a',
+          type: 'secret_detection',
+          action: 'reject',
+          enabled: true,
+          priority: 0,
+          parameters: {},
+        },
+        {
+          id: 'b',
+          type: 'content_length',
+          action: 'reject',
+          enabled: true,
+          priority: 1,
+          parameters: { min: 25 },
+        },
+      ],
+      enabled: true,
+      version: 1,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    expect(findUncoveredRuleTypes(twoRule)).toEqual(
+      [
+        'content_sanitization',
+        'dedup_check',
+        'relevance_score',
+        'sensitivity_gate',
+        'source_trust',
+        'tenant_match',
+      ].sort(),
+    );
+    expect(() => assertPolicyCompleteness(twoRule)).toThrow(/dormant/);
+  });
+
+  it('treats a disabled rule as uncovered', () => {
+    const policy = buildRecommendedPolicy('t', NOW);
+    const withDisabled = {
+      ...policy,
+      rules: policy.rules.map((r) => (r.type === 'dedup_check' ? { ...r, enabled: false } : r)),
+    };
+    expect(findUncoveredRuleTypes(withDisabled)).toEqual(['dedup_check']);
+  });
+
+  it('passes when gaps are explicitly waived', () => {
+    const twoRule = buildRecommendedPolicy('t', NOW);
+    const stripped = {
+      ...twoRule,
+      rules: twoRule.rules.filter((r) => ['secret_detection', 'content_length'].includes(r.type)),
+    };
+    expect(() =>
+      assertPolicyCompleteness(stripped, [
+        'source_trust',
+        'relevance_score',
+        'sensitivity_gate',
+        'dedup_check',
+        'tenant_match',
+        'content_sanitization',
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/packages/policy-engine/src/__tests__/recommended-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/recommended-policy.test.ts
@@ -134,3 +134,66 @@ describe('findUncoveredRuleTypes + assertPolicyCompleteness', () => {
     ).not.toThrow();
   });
 });
+
+describe('PolicyPipeline.dormantRuleTypes (runtime completeness gate, 5bm.2)', () => {
+  it('is empty for a full-coverage recommended policy', async () => {
+    const { PolicyPipeline } = await import('../pipeline.js');
+    const policy = buildRecommendedPolicy('t', NOW, '00000000-0000-4000-8000-000000000001');
+    expect(new PolicyPipeline(policy).dormantRuleTypes).toEqual([]);
+  });
+
+  it('lists the 6 dormant rules of the audited 2-rule live shape', async () => {
+    const { PolicyPipeline } = await import('../pipeline.js');
+    const twoRule = GovernancePolicy.parse({
+      id: '22222222-2222-4222-8222-222222222222',
+      name: 'Audited live shape',
+      tenantId: 't',
+      rules: [
+        {
+          id: 'a',
+          type: 'secret_detection',
+          action: 'reject',
+          enabled: true,
+          priority: 0,
+          parameters: {},
+        },
+        {
+          id: 'b',
+          type: 'content_length',
+          action: 'reject',
+          enabled: true,
+          priority: 1,
+          parameters: { min: 25 },
+        },
+      ],
+      enabled: true,
+      version: 1,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    expect(new PolicyPipeline(twoRule).dormantRuleTypes).toEqual(
+      [
+        'content_sanitization',
+        'dedup_check',
+        'relevance_score',
+        'sensitivity_gate',
+        'source_trust',
+        'tenant_match',
+      ].sort(),
+    );
+  });
+});
+
+describe('buildRecommendedPolicy determinism', () => {
+  it('is fully deterministic when id is supplied', () => {
+    const a = buildRecommendedPolicy('t', NOW, '33333333-3333-4333-8333-333333333333');
+    const b = buildRecommendedPolicy('t', NOW, '33333333-3333-4333-8333-333333333333');
+    expect(a).toEqual(b);
+  });
+
+  it('produces distinct ids when id is omitted', () => {
+    const a = buildRecommendedPolicy('t', NOW);
+    const b = buildRecommendedPolicy('t', NOW);
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -9,3 +9,9 @@ export { evaluateTenantMatch } from './rules/tenant-match-rule.js';
 export { evaluateSensitivityGate } from './rules/sensitivity-gate-rule.js';
 export { evaluateContentSanitization } from './rules/content-sanitization-rule.js';
 export { PolicyPipeline } from './pipeline.js';
+export {
+  RECOMMENDED_POLICY_RULES,
+  buildRecommendedPolicy,
+  findUncoveredRuleTypes,
+  assertPolicyCompleteness,
+} from './recommended-policy.js';

--- a/packages/policy-engine/src/pipeline.ts
+++ b/packages/policy-engine/src/pipeline.ts
@@ -1,6 +1,7 @@
-import type { GovernancePolicy, MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { GovernancePolicy, MemoryCandidate, PolicyRuleType } from '@qmd-team-intent-kb/schema';
 import type { EvaluationContext, PipelineResult, RuleResult } from './types.js';
 import { createRule } from './rules/index.js';
+import { findUncoveredRuleTypes } from './recommended-policy.js';
 
 /**
  * Executes the full governance policy pipeline against a memory candidate.
@@ -16,8 +17,18 @@ import { createRule } from './rules/index.js';
 export class PolicyPipeline {
   private readonly policy: GovernancePolicy;
 
+  /**
+   * Registered rule types this policy does NOT actively enforce (5bm.2).
+   * Computed once at construction so the completeness gate is available at
+   * RUNTIME, not only in CI — a caller (e.g. the curator) can surface which
+   * rules are silently dormant on the loaded policy. Empty when the policy
+   * covers the full registry.
+   */
+  readonly dormantRuleTypes: PolicyRuleType[];
+
   constructor(policy: GovernancePolicy) {
     this.policy = policy;
+    this.dormantRuleTypes = findUncoveredRuleTypes(policy);
   }
 
   evaluate(

--- a/packages/policy-engine/src/recommended-policy.ts
+++ b/packages/policy-engine/src/recommended-policy.ts
@@ -119,12 +119,17 @@ export const RECOMMENDED_POLICY_RULES: readonly PolicyRule[] = [
 
 /**
  * Build a full {@link GovernancePolicy} from {@link RECOMMENDED_POLICY_RULES} for a
- * given tenant. `now` is injected (no ambient clock) so the result is
- * deterministic and testable.
+ * given tenant. `now` is injected (no ambient clock). Pass `id` to make the
+ * result fully deterministic (e.g. in tests); it defaults to a fresh UUID, so
+ * calls that omit it produce distinct policy ids.
  */
-export function buildRecommendedPolicy(tenantId: string, now: string): GovernancePolicy {
+export function buildRecommendedPolicy(
+  tenantId: string,
+  now: string,
+  id: string = randomUUID(),
+): GovernancePolicy {
   return GovernancePolicy.parse({
-    id: randomUUID(),
+    id,
     name: 'Recommended Governance Policy',
     tenantId,
     rules: RECOMMENDED_POLICY_RULES,

--- a/packages/policy-engine/src/recommended-policy.ts
+++ b/packages/policy-engine/src/recommended-policy.ts
@@ -1,0 +1,170 @@
+/**
+ * The canonical RECOMMENDED governance policy and a completeness gate
+ * (bead qmd-team-intent-kb-5bm.2).
+ *
+ * ## Why this exists
+ *
+ * The ontology audit (2026-07-17) found the LIVE policy enabled only 2 of the 8
+ * registered rules — `secret_detection` and `content_length`. The other six
+ * (`source_trust`, `sensitivity_gate`, `relevance_score`, `dedup_check`,
+ * `tenant_match`, `content_sanitization`) exist in {@link RULE_REGISTRY} and are
+ * fully implemented, but the pipeline only runs the rules a policy names, so they
+ * gated NOTHING in production. That silent dormancy is a direct contributor to the
+ * 2026-07-16 whole-machine digestion promoting ~15k unfiltered candidates.
+ *
+ * This module makes "a complete policy" a code-level source of truth, and adds a
+ * gate so a rule can never again sit registered-but-dormant unnoticed:
+ *
+ *   - {@link RECOMMENDED_POLICY_RULES} names EVERY registered rule type. A rule
+ *     added to the registry with no entry here fails {@link findUncoveredRuleTypes}
+ *     (asserted in CI), so the author must make a deliberate enable/waive choice.
+ *   - Actions are conservative: the three hard boundaries — `secret_detection`,
+ *     `content_length`, `tenant_match` — `reject`; everything else `flag` (records
+ *     signal and continues, never blocks a legitimate promotion). This is the
+ *     "flag at minimum" the audit recommended; an operator can tighten a flag to a
+ *     reject deliberately.
+ *
+ * Applying this to the LIVE brain is a separate, reversible operational step
+ * (it changes what gets flagged/rejected on the running store) — this module only
+ * defines the recommended shape and the gate; it does not mutate any live policy.
+ *
+ * @module recommended-policy
+ */
+import { randomUUID } from 'node:crypto';
+import { GovernancePolicy, type PolicyRule, type PolicyRuleType } from '@qmd-team-intent-kb/schema';
+import { RULE_REGISTRY } from './rules/index.js';
+
+/**
+ * The recommended rule set — one entry per registered {@link PolicyRuleType}.
+ *
+ * Ordered by priority: hard security/quality boundaries first (lower priority
+ * number runs first and can short-circuit on reject), advisory flags after.
+ * Parameters left `{}` fall back to each rule's built-in defaults
+ * (`content_length` pins `min: 25`, the value the live policy already used).
+ */
+export const RECOMMENDED_POLICY_RULES: readonly PolicyRule[] = [
+  {
+    id: 'rec-secret-detection',
+    type: 'secret_detection',
+    action: 'reject',
+    enabled: true,
+    priority: 0,
+    parameters: {},
+    description: 'Reject candidates containing secrets/credentials.',
+  },
+  {
+    id: 'rec-content-length',
+    type: 'content_length',
+    action: 'reject',
+    enabled: true,
+    priority: 1,
+    parameters: { min: 25 },
+    description: 'Reject candidates below the minimum meaningful length.',
+  },
+  {
+    id: 'rec-tenant-match',
+    type: 'tenant_match',
+    action: 'reject',
+    enabled: true,
+    priority: 2,
+    parameters: {},
+    description: 'Reject a candidate whose tenant does not match its target.',
+  },
+  {
+    id: 'rec-source-trust',
+    type: 'source_trust',
+    action: 'flag',
+    enabled: true,
+    priority: 3,
+    parameters: {},
+    description: 'Flag candidates below the minimum source trust level.',
+  },
+  {
+    id: 'rec-relevance-score',
+    type: 'relevance_score',
+    action: 'flag',
+    enabled: true,
+    priority: 4,
+    parameters: {},
+    description: 'Flag low-relevance candidates for review.',
+  },
+  {
+    id: 'rec-sensitivity-gate',
+    type: 'sensitivity_gate',
+    action: 'flag',
+    enabled: true,
+    priority: 5,
+    parameters: {},
+    description: 'Flag candidates whose classified sensitivity warrants review.',
+  },
+  {
+    id: 'rec-dedup-check',
+    type: 'dedup_check',
+    action: 'flag',
+    enabled: true,
+    priority: 6,
+    parameters: {},
+    description: 'Flag likely-duplicate candidates.',
+  },
+  {
+    id: 'rec-content-sanitization',
+    type: 'content_sanitization',
+    action: 'flag',
+    enabled: true,
+    priority: 7,
+    parameters: {},
+    description: 'Flag content that required sanitization.',
+  },
+];
+
+/**
+ * Build a full {@link GovernancePolicy} from {@link RECOMMENDED_POLICY_RULES} for a
+ * given tenant. `now` is injected (no ambient clock) so the result is
+ * deterministic and testable.
+ */
+export function buildRecommendedPolicy(tenantId: string, now: string): GovernancePolicy {
+  return GovernancePolicy.parse({
+    id: randomUUID(),
+    name: 'Recommended Governance Policy',
+    tenantId,
+    rules: RECOMMENDED_POLICY_RULES,
+    enabled: true,
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+/**
+ * Return every registered {@link PolicyRuleType} that the given policy does NOT
+ * actively enforce (absent, or present but `enabled: false`). An empty result
+ * means the policy covers the full registry — no rule is silently dormant.
+ *
+ * This is the anti-dormancy gate: CI asserts the RECOMMENDED policy leaves none
+ * uncovered, and an operator can run it against the live policy to see exactly
+ * which rules are inert.
+ */
+export function findUncoveredRuleTypes(policy: GovernancePolicy): PolicyRuleType[] {
+  const enabled = new Set(policy.rules.filter((r) => r.enabled).map((r) => r.type));
+  return (Object.keys(RULE_REGISTRY) as PolicyRuleType[]).filter((t) => !enabled.has(t)).sort();
+}
+
+/**
+ * Assert a policy actively enforces every registered rule, or the caller has
+ * EXPLICITLY waived the gaps. Throws listing the dormant rules otherwise. Use in
+ * a doctor/health check or a policy-load path so a new registered rule can never
+ * silently gate nothing.
+ */
+export function assertPolicyCompleteness(
+  policy: GovernancePolicy,
+  waived: readonly PolicyRuleType[] = [],
+): void {
+  const uncovered = findUncoveredRuleTypes(policy).filter((t) => !waived.includes(t));
+  if (uncovered.length > 0) {
+    throw new Error(
+      `Policy "${policy.name}" leaves ${uncovered.length} registered rule(s) dormant ` +
+        `(not enabled, not waived): ${uncovered.join(', ')}. Enable them in the policy ` +
+        `or waive them explicitly.`,
+    );
+  }
+}


### PR DESCRIPTION
## What
Adds `RECOMMENDED_POLICY_RULES` (one entry per registered rule type) + `buildRecommendedPolicy` + the completeness gate `findUncoveredRuleTypes` / `assertPolicyCompleteness`, with a CI test asserting the recommended set covers the full `RULE_REGISTRY`.

## Why + decision rationale
The ontology audit found the live policy enabled only **2 of 8** registered rules; the other six (`source_trust`, `sensitivity_gate`, `relevance_score`, `dedup_check`, `tenant_match`, `content_sanitization`) are fully implemented but the pipeline only runs the rules a policy names, so they **gated nothing** — a direct contributor to the 2026-07-16 digestion promoting ~15k unfiltered candidates. Bead `qmd-team-intent-kb-5bm.2`.

**Chose a code-level recommended-policy + completeness gate over silently seeding a default**, because there is no code default policy to edit (the live policy is operational data) and the real failure was a *missing gate*, not a missing seed. The gate makes silent dormancy impossible going forward: a rule added to the registry with no recommended-policy entry fails CI.

## Layer touched
`packages/policy-engine` only (new module + 4 exports). No pipeline/schema change. New invariant: the recommended policy must cover every registered rule (CI-enforced).

## How it works
- `RECOMMENDED_POLICY_RULES`: three hard boundaries (`secret_detection`, `content_length`, `tenant_match`) → `reject`; the rest → `flag` (the pipeline records a flag and **continues** — no legitimate promotion is blocked; this is the "flag at minimum" the audit recommended).
- `findUncoveredRuleTypes(policy)` → registered types not actively enabled (absent or `enabled:false`).
- `assertPolicyCompleteness(policy, waived[])` → throws listing dormant rules unless explicitly waived. Usable in a doctor/health check or a policy-load path.

## Verification & evidence
- `pnpm typecheck` + `lint` clean; **2064/2064 tests** green — 7 new: anti-dormancy coverage of the full registry, reject-vs-flag actions, the gate detecting the audited 2-rule live shape's 6 dormant rules, disabled-rule = uncovered, explicit-waive passes.

## Risk assessment
None to runtime — this PR mutates **no live policy** and changes no pipeline behavior. It only adds a definition + gate + a CI test. Rollback = revert.

## Operational impact
None here. **Deferred, approval-gated** (bead `5bm.10`): applying `buildRecommendedPolicy` to the live `governance_policies` row starts *flagging* on the running brain (rejecting only the 3 hard boundaries) — reversible, and worth a dry-run flag-count first. Also deferred: wiring `findUncoveredRuleTypes` into a runtime status/health surface. Note: `source_trust`/`sensitivity_gate` give limited signal until trust/sensitivity carry real values (ICO trust work + `5bm.3`).

## Follow-up & deferred
- `5bm.10` — apply the recommended policy to the live brain + surface live-policy dormancy in status/health (both gated on approval).
- `5bm.3` (persist sensitivity) makes `sensitivity_gate` meaningful.

## Governance links
Bead `qmd-team-intent-kb-5bm.2` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io