### PR TITLE
feat(curator): persist the classified sensitivity at promotion instead of hardcoding internal

### DIFF
--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -755,3 +755,51 @@ describe('promote: cross-clone determinism on the supersession path (8da.5)', ()
     );
   });
 });
+
+describe('promote — persists classified sensitivity (5bm.3)', () => {
+  let memoryRepo: MemoryRepository;
+  let auditRepo: AuditRepository;
+  let db: ReturnType<typeof createTestDatabase>;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    auditRepo = new AuditRepository(db);
+  });
+  afterEach(() => db.close());
+
+  function promoteWith(content: string) {
+    const candidate = makeCandidate({ content });
+    const contentHash = computeContentHash(content);
+    return promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult({ candidateId: candidate.id }) },
+      memoryRepo,
+      auditRepo,
+    );
+  }
+
+  it('classifies clean prose as public (no longer hardcoded internal)', () => {
+    const memory = promoteWith(
+      'A perfectly ordinary technical note about deterministic pipelines.',
+    );
+    expect(memory.sensitivity).toBe('public');
+  });
+
+  it('classifies content with an internal absolute path as internal', () => {
+    const memory = promoteWith(
+      'The config lives at /home/jeremy/000-projects/foo/bar.yaml on the box.',
+    );
+    expect(memory.sensitivity).toBe('internal');
+  });
+
+  it('classifies content carrying PII as confidential', () => {
+    const memory = promoteWith('Reach the operator at operator.person@example.com for escalation.');
+    expect(memory.sensitivity).toBe('confidential');
+  });
+
+  it('persists the classified value to the store, not a constant', () => {
+    const memory = promoteWith('Ping ops.contact@example.com about the runbook.');
+    const stored = memoryRepo.findById(memory.id);
+    expect(stored?.sensitivity).toBe('confidential');
+  });
+});

--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -785,6 +785,17 @@ describe('promote — persists classified sensitivity (5bm.3)', () => {
     expect(memory.sensitivity).toBe('public');
   });
 
+  it('falls back to public for content matching no sensitivity signal', () => {
+    // classifyContent has no "unclassifiable" crash path — it defaults to the
+    // valid enum member 'public' — so an input with no credential/PII/path
+    // signal always yields a parseable sensitivity, never a Zod throw in
+    // promote(). (Empty/whitespace content is rejected earlier by the schema's
+    // NonEmptyString guard, a separate concern.)
+    expect(promoteWith('routine note about queue backpressure and retries').sensitivity).toBe(
+      'public',
+    );
+  });
+
   it('classifies content with an internal absolute path as internal', () => {
     const memory = promoteWith(
       'The config lives at /home/jeremy/000-projects/foo/bar.yaml on the box.',

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -19,8 +19,7 @@ import type {
   AuditRepository,
   MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
-import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
-import { classifyContent } from '@qmd-team-intent-kb/claude-runtime';
+import { classifyContent, type PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import type { SupersessionMatch } from '../supersession/supersession-detector.js';
 import { extractWikiLinks } from '../import/wikilink-parser.js';
 
@@ -141,8 +140,10 @@ export function promote(
   );
 
   // Persist the CLASSIFIED sensitivity (5bm.3), not a hardcoded 'internal'. The
-  // deterministic content classifier — the same one the sensitivity-gate policy
-  // rule already runs and then discarded — derives the level from the content
+  // deterministic content classifier (pure sync regex — no LLM/network/clock —
+  // imported via the govern package policy-engine, never claude-runtime, to keep
+  // this write path's dependency LLM-free) is the same one the sensitivity-gate
+  // policy rule already runs and then discarded. It derives the level from content
   // (restricted=credentials, confidential=PII, internal=internal paths, else
   // public). Persisting it makes the git-exporter's pre-existing
   // confidential/restricted skip effective (dead code while every memory was

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -20,6 +20,7 @@ import type {
   MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { classifyContent } from '@qmd-team-intent-kb/claude-runtime';
 import type { SupersessionMatch } from '../supersession/supersession-detector.js';
 import { extractWikiLinks } from '../import/wikilink-parser.js';
 
@@ -139,6 +140,17 @@ export function promote(
     }),
   );
 
+  // Persist the CLASSIFIED sensitivity (5bm.3), not a hardcoded 'internal'. The
+  // deterministic content classifier — the same one the sensitivity-gate policy
+  // rule already runs and then discarded — derives the level from the content
+  // (restricted=credentials, confidential=PII, internal=internal paths, else
+  // public). Persisting it makes the git-exporter's pre-existing
+  // confidential/restricted skip effective (dead code while every memory was
+  // 'internal') so PII-bearing memories are not written into the general
+  // searchable corpus. Existing rows are unaffected; this classifies new
+  // promotions only.
+  const sensitivity = classifyContent(input.candidate.content).sensitivityLevel;
+
   const memory = CuratedMemorySchema.parse({
     id: memoryId,
     candidateId: input.candidate.id,
@@ -147,7 +159,7 @@ export function promote(
     title: input.candidate.title,
     category: input.candidate.category,
     trustLevel: input.candidate.trustLevel,
-    sensitivity: 'internal',
+    sensitivity,
     author: input.candidate.author,
     tenantId: input.candidate.tenantId,
     metadata: input.candidate.metadata,

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -15,3 +15,14 @@ export {
   findUncoveredRuleTypes,
   assertPolicyCompleteness,
 } from './recommended-policy.js';
+/**
+ * Deterministic content classifier, re-exported from the govern layer so the
+ * deterministic write path (curator's promoter) depends on policy-engine — a
+ * govern package — rather than importing `@qmd-team-intent-kb/claude-runtime`
+ * directly. The function itself is pure sync regex today; routing it through
+ * here keeps the govern path's declared dependency LLM-free by layering, so a
+ * future model call in `claude-runtime` cannot silently reach the write path
+ * without also changing this deliberate re-export.
+ */
+export { classifyContent } from '@qmd-team-intent-kb/claude-runtime';
+export type { ContentClassification } from '@qmd-team-intent-kb/claude-runtime';


### PR DESCRIPTION
## What
The promoter now derives `sensitivity` from the deterministic content classifier (`classifyContent`) and persists it, instead of hardcoding `'internal'`.

## Why + decision rationale
The audit found the promoter hardcoded `sensitivity: 'internal'` while `sensitivity-gate-rule` computed the real classification and **discarded** it — so all 17k memories were `'internal'` and the git-exporter's confidential/restricted skip was dead code. Bead `qmd-team-intent-kb-5bm.3`. **Chose the deterministic classifier** (reused from the policy rule, single-sourced) **over any model call** because governance stays LLM-free.

## Layer touched
`apps/curator` (govern). No schema change. Cross-layer effect: activates the git-exporter's existing confidential/restricted skip — an intended governance path that was inert while every memory was `'internal'`.

## How it works
`classifyContent(content).sensitivityLevel` → `restricted` (credentials) / `confidential` (PII) / `internal` (internal paths) / `public`. Persisted on the CuratedMemory. Existing rows are **not** reclassified; only new promotions carry a real level.

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2072/2072 tests** green — 4 new (clean prose→public, internal-path→internal, PII→confidential, classified value persisted to the store not a constant).

## Risk assessment
Low-moderate, forward-only. New PII-bearing promotions are classified confidential → excluded from the general qmd export (correct governance). No existing row changes. No read-path change here. Rollback = revert.

## Operational impact
None on existing data. Going forward, a newly-promoted memory with PII won't be written to the searchable corpus — the exporter skip doing its job. Note: content with actual credentials is already rejected upstream by `secret_detection` before promotion.

## Follow-up & deferred
- `5bm.11` — read-time sensitivity enforcement in the search service + MCP surface (a behavior change that hides confidential hits; approval-gated with a dry-run).

## Governance links
Bead `qmd-team-intent-kb-5bm.3` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io