### PR TITLE
feat(store): enforce the lifecycle state graph in updateLifecycle

### DIFF
--- a/packages/store/src/__tests__/memory-repository-lifecycle-guard.test.ts
+++ b/packages/store/src/__tests__/memory-repository-lifecycle-guard.test.ts
@@ -1,0 +1,87 @@
+/**
+ * MemoryRepository.updateLifecycle state-graph guard tests (bead qmd-team-intent-kb-5bm.4).
+ *
+ * validateTransition (schema/lifecycle.ts) was enforced only at app entry
+ * points; updateLifecycle was a raw UPDATE, so an illegal transition
+ * (archived -> active, superseded -> deprecated, ...) could be written directly.
+ * These tests drive the real updateLifecycle and prove the repository now
+ * rejects transitions the state graph forbids, allows the legal ones, treats a
+ * same-state call as an idempotent no-op, and leaves a missing row as false.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { MemoryRepository, InvalidLifecycleTransitionError } from '../index.js';
+import { makeMemory } from './fixtures.js';
+
+const LATER = '2026-03-01T00:00:00.000Z';
+
+describe('MemoryRepository.updateLifecycle — state-graph guard', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  function seed(lifecycle: 'active' | 'deprecated' | 'superseded' | 'archived') {
+    // superseded requires supersession metadata in the schema; keep it simple by
+    // seeding non-superseded start states for the graph tests, and drive INTO
+    // superseded only where the transition is legal.
+    const memory = makeMemory({ lifecycle });
+    repo.insert(memory);
+    return memory;
+  }
+
+  it('allows a legal transition (active -> deprecated)', () => {
+    const m = seed('active');
+    expect(() => repo.updateLifecycle(m.id, 'deprecated', LATER)).not.toThrow();
+    expect(repo.findById(m.id)?.lifecycle).toBe('deprecated');
+  });
+
+  it('allows active -> archived', () => {
+    const m = seed('active');
+    expect(repo.updateLifecycle(m.id, 'archived', LATER)).toBe(true);
+    expect(repo.findById(m.id)?.lifecycle).toBe('archived');
+  });
+
+  it('rejects an illegal transition (archived -> active)', () => {
+    const m = seed('archived');
+    expect(() => repo.updateLifecycle(m.id, 'active', LATER)).toThrow(
+      InvalidLifecycleTransitionError,
+    );
+    expect(repo.findById(m.id)?.lifecycle).toBe('archived'); // unchanged
+  });
+
+  it('rejects deprecated -> superseded (not in the graph)', () => {
+    const m = seed('deprecated');
+    expect(() => repo.updateLifecycle(m.id, 'superseded', LATER)).toThrow(
+      InvalidLifecycleTransitionError,
+    );
+  });
+
+  it('treats a same-state call as an idempotent no-op', () => {
+    const m = seed('active');
+    expect(() => repo.updateLifecycle(m.id, 'active', LATER)).not.toThrow();
+    expect(repo.findById(m.id)?.lifecycle).toBe('active');
+  });
+
+  it('returns false for a missing memory (never throws)', () => {
+    expect(repo.updateLifecycle('00000000-0000-4000-8000-000000000000', 'archived', LATER)).toBe(
+      false,
+    );
+  });
+
+  it('names only the states, never content, in the error', () => {
+    const m = seed('archived');
+    try {
+      repo.updateLifecycle(m.id, 'deprecated', LATER);
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvalidLifecycleTransitionError);
+      expect((e as InvalidLifecycleTransitionError).from).toBe('archived');
+      expect((e as InvalidLifecycleTransitionError).to).toBe('deprecated');
+    }
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -6,7 +6,10 @@ export {
   assertEnumMembership,
   EnumConstraintViolationError,
 } from './repositories/enum-membership.js';
-export { MemoryRepository } from './repositories/memory-repository.js';
+export {
+  MemoryRepository,
+  InvalidLifecycleTransitionError,
+} from './repositories/memory-repository.js';
 export { PolicyRepository } from './repositories/policy-repository.js';
 export { AuditRepository } from './repositories/audit-repository.js';
 export type { AuditChainRow } from './repositories/audit-repository.js';

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -1,8 +1,23 @@
 import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { CuratedMemory, isTransitionAllowed } from '@qmd-team-intent-kb/schema';
 import type { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 import { assertMemoryEnumMembership } from './enum-membership.js';
+
+/**
+ * Thrown by {@link MemoryRepository.updateLifecycle} when a lifecycle change is
+ * not a legal transition in the state graph (5bm.4). Carries the from/to states
+ * (both are closed-vocabulary enum members, never free text, so no leak).
+ */
+export class InvalidLifecycleTransitionError extends Error {
+  constructor(
+    readonly from: MemoryLifecycleState,
+    readonly to: MemoryLifecycleState,
+  ) {
+    super(`Invalid lifecycle transition: "${from}" -> "${to}" is not allowed`);
+    this.name = 'InvalidLifecycleTransitionError';
+  }
+}
 
 /**
  * Zod schema for the raw SQLite row returned by better-sqlite3.
@@ -168,6 +183,7 @@ export class MemoryRepository {
   private readonly stmtTenantHashes: Database.Statement;
   private readonly stmtFindByLifecycle: Database.Statement;
   private readonly stmtUpdateLifecycle: Database.Statement;
+  private readonly stmtGetLifecycle: Database.Statement;
   private readonly stmtUpdate: Database.Statement;
   private readonly stmtCount: Database.Statement;
   private readonly stmtAllHashes: Database.Statement;
@@ -237,6 +253,10 @@ export class MemoryRepository {
 
     this.stmtUpdateLifecycle = db.prepare(`
       UPDATE curated_memories SET lifecycle = @lifecycle, updated_at = @updated_at WHERE id = @id
+    `);
+
+    this.stmtGetLifecycle = db.prepare(`
+      SELECT lifecycle FROM curated_memories WHERE id = ?
     `);
 
     this.stmtUpdate = db.prepare(`
@@ -370,6 +390,18 @@ export class MemoryRepository {
    * Returns true if a row was modified, false if the id was not found.
    */
   updateLifecycle(id: string, lifecycle: MemoryLifecycleState, updatedAt: string): boolean {
+    // State-graph guard at the repository layer (5bm.4): validateTransition was
+    // enforced only at app entry points, so this raw UPDATE was a back door for
+    // an illegal transition (e.g. archived -> active). Reject one that the state
+    // graph forbids. A same-state call is treated as an idempotent no-op (from ==
+    // to is not an "allowed transition" but is not a violation either). A missing
+    // row is not found -> false, unchanged from before (never a throw).
+    const row = this.stmtGetLifecycle.get(id) as { lifecycle: MemoryLifecycleState } | undefined;
+    if (row === undefined) return false;
+    const current = row.lifecycle;
+    if (current !== lifecycle && !isTransitionAllowed(current, lifecycle)) {
+      throw new InvalidLifecycleTransitionError(current, lifecycle);
+    }
     const result = this.stmtUpdateLifecycle.run({ id, lifecycle, updated_at: updatedAt });
     return result.changes > 0;
   }


### PR DESCRIPTION
## What
`MemoryRepository.updateLifecycle` now rejects transitions the lifecycle state graph forbids, via a new `InvalidLifecycleTransitionError`.

## Why + decision rationale
The audit found `validateTransition` was enforced only at app entry points; `updateLifecycle` was an unguarded raw UPDATE, so `archived→active` / `superseded→deprecated` could be written straight into durable state — the edge-daemon staleness sweep was "legal only by coincidence of `findStale`'s WHERE clause." Bead `qmd-team-intent-kb-5bm.4`.

**Chose `isTransitionAllowed` (the graph check) over the full `validateTransition`** because `updateLifecycle` has no `TransitionRequest` context (reason/actor/supersededBy) — the superseded-requires-supersededBy rule stays at the app entry points that carry it; this adds the missing state-graph backstop. A SQLite CHECK can't express a stateful transition, so the guard is necessarily in code.

## Layer touched
`packages/store` (govern durable state). New invariant: every lifecycle write through the repository is a legal graph transition or a same-state no-op.

## How it works
Read current lifecycle → if `current !== target` and `!isTransitionAllowed(current, target)`, throw (error carries the from/to enum members only, no content leak). Same-state = idempotent no-op. Missing row → `false`, unchanged from before (never throws).

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2080/2080 tests** green — 7 new (legal `active→deprecated`/`active→archived` pass; illegal `archived→active`/`deprecated→superseded` throw and leave the row unchanged; same-state no-op; missing row → false; error names states only). The three existing callers (API transition, MCP transition tool, edge-daemon staleness `active→deprecated`) all make legal transitions — full suite unaffected.

## Risk assessment
Low. Only illegal transitions (never valid) are newly rejected. `findStale` returns only `active` rows and the sweep does `active→deprecated` (allowed), so no live path breaks. Rollback = revert.

## Operational impact
None — no migration, no data change. A caller attempting an illegal transition now gets a clear error instead of silent corruption.

## Follow-up & deferred
Rest of epic `5bm`: `5bm.5` export mapper fail-closed, `5bm.6` schemaVersion, `5bm.7` recategorize tool, `5bm.8` bulk-import source.

## Governance links
Bead `qmd-team-intent-kb-5bm.4` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io