### PR TITLE
feat(git-exporter): fail closed on an unmapped category instead of laundering it into curated

### DIFF
--- a/apps/git-exporter/src/__tests__/directory-mapper.test.ts
+++ b/apps/git-exporter/src/__tests__/directory-mapper.test.ts
@@ -3,6 +3,7 @@ import {
   getDirectory,
   getCategoryDirectory,
   getRelativePath,
+  UnknownCategoryError,
 } from '../formatter/directory-mapper.js';
 import { makeCuratedMemory, NOW } from './fixtures.js';
 import { randomUUID } from 'node:crypto';
@@ -36,8 +37,17 @@ describe('getCategoryDirectory', () => {
     expect(getCategoryDirectory('onboarding')).toBe('guides');
   });
 
-  it('maps unknown category → curated (fallback)', () => {
-    expect(getCategoryDirectory('unknown-category')).toBe('curated');
+  it('throws UnknownCategoryError on an unmapped category (fail-closed, 5bm.5)', () => {
+    // Previously an unknown category silently landed in curated/ — the
+    // governance-approved, default-searched bucket. It must now fail loud.
+    expect(() => getCategoryDirectory('unknown-category')).toThrow(UnknownCategoryError);
+    try {
+      getCategoryDirectory('made-up');
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnknownCategoryError);
+      expect((e as UnknownCategoryError).category).toBe('made-up');
+    }
   });
 });
 

--- a/apps/git-exporter/src/formatter/directory-mapper.ts
+++ b/apps/git-exporter/src/formatter/directory-mapper.ts
@@ -1,6 +1,20 @@
 import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
 
 /**
+ * Thrown when a category has no export-directory mapping (5bm.5). A memory that
+ * reaches the exporter with an off-vocabulary category is schema drift or a
+ * bypassed write path — failing loud is correct, because the previous silent
+ * fallback filed it under `curated/` (the governance-approved, default-searched
+ * collection), laundering an unknown value into the most-trusted bucket.
+ */
+export class UnknownCategoryError extends Error {
+  constructor(readonly category: string) {
+    super(`No export-directory mapping for category "${category}"`);
+    this.name = 'UnknownCategoryError';
+  }
+}
+
+/**
  * Resolve the export subdirectory for a memory.
  *
  * Lifecycle takes precedence over category:
@@ -10,7 +24,7 @@ import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
  * - `decision`                                → `decisions/`
  * - `pattern`, `convention`, `architecture`  → `curated/`
  * - `troubleshooting`, `reference`, `onboarding` → `guides/`
- * - unknown / fallback                        → `curated/`
+ * - unknown                                   → throws {@link UnknownCategoryError}
  */
 export function getDirectory(memory: CuratedMemory): string {
   if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
@@ -20,8 +34,9 @@ export function getDirectory(memory: CuratedMemory): string {
 }
 
 /**
- * Map a category string to its export subdirectory name.
- * Does not consider lifecycle — use {@link getDirectory} for that.
+ * Map a category to its export subdirectory name. Does not consider lifecycle —
+ * use {@link getDirectory} for that. FAIL-CLOSED: an unmapped category throws
+ * {@link UnknownCategoryError} rather than silently landing in `curated/`.
  */
 export function getCategoryDirectory(category: string): string {
   switch (category) {
@@ -36,7 +51,7 @@ export function getCategoryDirectory(category: string): string {
     case 'onboarding':
       return 'guides';
     default:
-      return 'curated';
+      throw new UnknownCategoryError(category);
   }
 }
 

--- a/apps/git-exporter/src/index.ts
+++ b/apps/git-exporter/src/index.ts
@@ -4,6 +4,7 @@ export { formatMemoryAsMarkdown, getFilename } from './formatter/markdown-format
 export {
   getDirectory,
   getCategoryDirectory,
+  UnknownCategoryError,
   getRelativePath,
 } from './formatter/directory-mapper.js';
 export { detectChanges } from './diff/change-detector.js';


### PR DESCRIPTION
## What
`getCategoryDirectory`'s `default` case now throws `UnknownCategoryError` instead of silently returning `curated/`.

## Why + decision rationale
The audit found an unknown category was silently filed into `curated/` — the governance-approved, default-searched collection — laundering an off-vocabulary value into the most-trusted export bucket. Bead `qmd-team-intent-kb-5bm.5`. **Chose fail-closed over the silent fallback** because with the write-side enum backstop (5bm.1) already blocking bad categories at promotion, this default is now purely a drift/bug detector and should behave like one.

## Layer touched
`apps/git-exporter` (the compiled-Markdown export path). No schema change. The seven valid categories map exactly as before.

## How it works
`default → throw new UnknownCategoryError(category)` (error carries the category string, exported for callers). Valid categories are unaffected.

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2080/2080 tests** green — the old "unknown → curated fallback" test is rewritten to assert the throw + carried category; all seven valid mappings unchanged.

## Risk assessment
Low. All live memories carry valid enum categories (they pass `CuratedMemorySchema.parse` at promotion + the 5bm.1 backstop), so real export runs are unaffected. A future drift now halts the run loudly instead of mis-filing — the intended fail-closed behavior. Rollback = revert.

## Operational impact
None on current data. If a drifted category ever appears, the exporter surfaces it instead of hiding it in `curated/`.

## Follow-up & deferred
Rest of epic `5bm`: `5bm.6` schemaVersion, `5bm.7` recategorize tool, `5bm.8` bulk-import source. (The dead `inbox` search scope noted in the bead is tracked separately — search-client concern, not the exporter.)

## Governance links
Bead `qmd-team-intent-kb-5bm.5` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io