### PR TITLE
test(git-exporter): lock the category→directory mapper to the schema enum and tidy the fail-closed test

### DIFF
--- a/apps/git-exporter/src/__tests__/directory-mapper.test.ts
+++ b/apps/git-exporter/src/__tests__/directory-mapper.test.ts
@@ -6,6 +6,7 @@ import {
   UnknownCategoryError,
 } from '../formatter/directory-mapper.js';
 import { makeCuratedMemory, NOW } from './fixtures.js';
+import { MemoryCategory } from '@qmd-team-intent-kb/schema';
 import { randomUUID } from 'node:crypto';
 
 describe('getCategoryDirectory', () => {
@@ -39,15 +40,10 @@ describe('getCategoryDirectory', () => {
 
   it('throws UnknownCategoryError on an unmapped category (fail-closed, 5bm.5)', () => {
     // Previously an unknown category silently landed in curated/ — the
-    // governance-approved, default-searched bucket. It must now fail loud.
+    // governance-approved, default-searched bucket. It must now fail loud, and
+    // the error carries the offending category for diagnosis.
     expect(() => getCategoryDirectory('unknown-category')).toThrow(UnknownCategoryError);
-    try {
-      getCategoryDirectory('made-up');
-      expect.unreachable('should have thrown');
-    } catch (e) {
-      expect(e).toBeInstanceOf(UnknownCategoryError);
-      expect((e as UnknownCategoryError).category).toBe('made-up');
-    }
+    expect(() => getCategoryDirectory('made-up')).toThrow(new UnknownCategoryError('made-up'));
   });
 });
 
@@ -107,5 +103,17 @@ describe('getRelativePath', () => {
   it('guides memory path uses guides/', () => {
     const memory = makeCuratedMemory({ category: 'onboarding', lifecycle: 'active' });
     expect(getRelativePath(memory)).toBe(`guides/${memory.id}.md`);
+  });
+});
+
+describe('getCategoryDirectory ↔ schema enum lock-step (5bm.5 follow-up)', () => {
+  it('maps every MemoryCategory the schema defines without throwing', () => {
+    // Drift guard: if the schema enum grows, this fails until the mapper adds
+    // the new category — so a schema-valid memory can never hit the fail-closed
+    // default at export time (the operational regression the reviewer flagged).
+    for (const category of MemoryCategory.options) {
+      expect(() => getCategoryDirectory(category)).not.toThrow();
+      expect(['decisions', 'curated', 'guides']).toContain(getCategoryDirectory(category));
+    }
   });
 });


### PR DESCRIPTION
## What
Adds an exhaustiveness drift-guard test binding `getCategoryDirectory` to the schema's `MemoryCategory` enum, and tidies the fail-closed test.

## Why + one-line rationale
Follow-up to the MiniMax review on #269. **Finding 1 (drift):** the mapper hardcodes seven categories while the canonical set is the schema enum — a new enum value would make a schema-valid memory throw at export (an operational regression the old silent `curated/` fallback hid). **Finding 3:** the test used `expect.unreachable` + a redundant try/catch. Chose an exhaustiveness *test* over deriving the mapping from the enum because the switch stays readable and the test fails CI on any future drift.

## How it works
The new test iterates `MemoryCategory.options`, asserting each maps to one of `decisions`/`curated`/`guides` without throwing — so adding an enum value breaks CI here until the mapper handles it. The fail-closed test now asserts `toThrow(new UnknownCategoryError('made-up'))` (type + carried category in one assertion).

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2081/2081 tests** green (git-exporter 112, incl. the new lock-step guard).

## Risk assessment
None — tests only. Rollback = revert.

## Follow-up & deferred
`5bm.12` — per-memory quarantine instead of whole-run abort on a drifted category (finding 2; can't fire today since every live memory carries a valid category).

## Governance links
Bead `qmd-team-intent-kb-5bm.5` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io