### PR TITLE
feat(schema): validate the spool schemaVersion so a v2 line is rejected, not silently downgraded

### DIFF
--- a/apps/curator/src/__tests__/spool-intake-ico-contract.test.ts
+++ b/apps/curator/src/__tests__/spool-intake-ico-contract.test.ts
@@ -103,17 +103,32 @@ describe('cross-repo contract: ICO emission → INTKB ingestFromSpool', () => {
     expect(candidateRepo.count()).toBe(1);
   });
 
-  it('silently strips the ICO-only schemaVersion field', async () => {
+  it("preserves ICO's schemaVersion '1' rather than stripping it (5bm.6)", async () => {
     const emission = makeIcoEmission();
     await writeIcoSpoolFile(spoolDir, '2026-05-24T030100Z', [emission]);
 
     const result = await ingestFromSpool(candidateRepo, spoolDir);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      // INTKB's Zod schema doesn't define schemaVersion — z.object() strips it.
-      // Confirm the stored candidate doesn't carry an unknown surface field.
-      expect((result.value[0] as Record<string, unknown>)['schemaVersion']).toBeUndefined();
+      // INTKB now defines schemaVersion (z.literal('1')), so the version is a
+      // validated, retained field — not a silently-stripped unknown. This is the
+      // gate that lets a v2 line be rejected (next test) instead of downgraded.
+      expect(result.value[0]?.schemaVersion).toBe('1');
     }
+    expect(candidateRepo.count()).toBe(1);
+  });
+
+  it('rejects a v2 spool line instead of ingesting it as v1 (5bm.6)', async () => {
+    // A future ICO v2 sets schemaVersion:'2'. The literal-'1' schema fails
+    // safeParse on that line, so readSpoolFile skips it — the line is NOT
+    // silently downgraded to v1 with its new fields dropped.
+    const v2 = { ...makeIcoEmission(), schemaVersion: '2' };
+    await writeIcoSpoolFile(spoolDir, '2026-05-24T030200Z', [v2]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    // The v2 line was rejected, so nothing was ingested.
+    expect(candidateRepo.count()).toBe(0);
   });
 
   it('handles ICO timestamp-granular spool filenames (spool-YYYY-MM-DDTHHMMSSZ.jsonl)', async () => {

--- a/apps/curator/src/import/import-pipeline.ts
+++ b/apps/curator/src/import/import-pipeline.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { basename } from 'node:path';
 import { deriveCandidateId } from '@qmd-team-intent-kb/common';
 import type { MemoryCandidate, MemoryCategory } from '@qmd-team-intent-kb/schema';
+import { MEMORY_CANDIDATE_SCHEMA_VERSION } from '@qmd-team-intent-kb/schema';
 import type {
   CandidateRepository,
   MemoryRepository,
@@ -201,6 +202,7 @@ export async function executeImport(
     const tags: string[] = Array.isArray(fmTags) ? fmTags.filter((t) => typeof t === 'string') : [];
 
     const candidate: MemoryCandidate = {
+      schemaVersion: MEMORY_CANDIDATE_SCHEMA_VERSION,
       id: candidateId,
       status: 'inbox',
       source: 'import',

--- a/apps/mcp-server/src/tools/import.ts
+++ b/apps/mcp-server/src/tools/import.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { join, basename, extname } from 'node:path';
 import fg from 'fast-glob';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { MEMORY_CANDIDATE_SCHEMA_VERSION } from '@qmd-team-intent-kb/schema';
 import { writeToSpool } from '@qmd-team-intent-kb/claude-runtime';
 import { categorizeFromPath } from '../categorize.js';
 import type { McpServerConfig } from '../config.js';
@@ -86,6 +87,7 @@ export async function importFiles(
     }
 
     const candidate: MemoryCandidate = {
+      schemaVersion: MEMORY_CANDIDATE_SCHEMA_VERSION,
       id: candidateId,
       status: 'inbox',
       source: 'import',

--- a/apps/mcp-server/src/tools/propose.ts
+++ b/apps/mcp-server/src/tools/propose.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { MemoryCandidate, MemoryCategory } from '@qmd-team-intent-kb/schema';
+import { MEMORY_CANDIDATE_SCHEMA_VERSION } from '@qmd-team-intent-kb/schema';
 import { writeToSpool } from '@qmd-team-intent-kb/claude-runtime';
 import type { McpServerConfig } from '../config.js';
 
@@ -31,6 +32,7 @@ export async function propose(
   const candidateId = randomUUID();
 
   const candidate: MemoryCandidate = {
+    schemaVersion: MEMORY_CANDIDATE_SCHEMA_VERSION,
     id: candidateId,
     status: 'inbox',
     source: 'mcp',

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -29,7 +29,11 @@ export {
   ContentMetadata,
 } from './common.js';
 
-export { PrePolicyFlags, MemoryCandidate } from './memory-candidate.js';
+export {
+  PrePolicyFlags,
+  MemoryCandidate,
+  MEMORY_CANDIDATE_SCHEMA_VERSION,
+} from './memory-candidate.js';
 export { PolicyEvaluation, SupersessionLink, CuratedMemory } from './curated-memory.js';
 export type { ActiveMemory, SupersededMemory } from './curated-memory.js';
 export { PolicyRule, GovernancePolicy } from './governance-policy.js';

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -10,8 +10,21 @@ export const PrePolicyFlags = z.object({
 });
 export type PrePolicyFlags = z.infer<typeof PrePolicyFlags>;
 
+/**
+ * The spool-candidate schema version INTKB accepts (5bm.6). ICO's emitter stamps
+ * `schemaVersion: '1'` on every spool line; a future ICO v2 sets `'2'`. Pinning
+ * the literal here means a v2 line FAILS `MemoryCandidate.safeParse` and is
+ * rejected, rather than being silently stripped by `z.object()` and ingested as
+ * v1 with its new fields dropped. The `.default` keeps constructors and legacy
+ * lines that omit the field valid at v1.
+ */
+export const MEMORY_CANDIDATE_SCHEMA_VERSION = '1' as const;
+
 /** A raw memory proposal captured from a Claude Code session, before governance */
 export const MemoryCandidate = z.object({
+  schemaVersion: z
+    .literal(MEMORY_CANDIDATE_SCHEMA_VERSION)
+    .default(MEMORY_CANDIDATE_SCHEMA_VERSION),
   id: Uuid,
   status: CandidateStatus,
   source: MemorySource,


### PR DESCRIPTION
## What
Adds `schemaVersion: z.literal('1').default('1')` (const `MEMORY_CANDIDATE_SCHEMA_VERSION`) to `MemoryCandidate`, so a v2 spool line is rejected instead of silently stripped and ingested as v1.

## Why + decision rationale
The audit found INTKB's `MemoryCandidate` had no `schemaVersion` field, so `z.object()` silently stripped the version ICO stamps on every line — the contract test literally asserted *"silently strips the ICO-only schemaVersion field."* A future ICO v2 would then be ingested as v1 with new fields dropped. ICO's `spool.ts` already documents the assumption that "a v1 INTKB will reject those lines via safeParse"; this makes it true. Bead `qmd-team-intent-kb-5bm.6`. **Chose literal-'1' + `.default` over `.strict()`** on the whole object, so a bumped version is rejected precisely while the additive metadata `z.object` legitimately ignores still passes, and every existing constructor/fixture stays valid via the default.

## Layer touched
`packages/schema` (the ICO↔INTKB spool contract). Cross-layer: the spool trust boundary now validates version. Three capture-path constructors (mcp import/propose, curator import-pipeline) set the const.

## How it works
v1 line — and any legacy line omitting the field — parses at v1 via the default; a `schemaVersion:'2'` line fails `safeParse`, so `readSpoolFile` skips it (never downgrades).

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2081/2081 tests** green — the contract test flipped from "silently strips" to "preserves v1 schemaVersion", plus a new test that a `schemaVersion:'2'` line is rejected (`candidateRepo.count() === 0`). Confirmed against the live spool: lines carry `"schemaVersion":"1"`.

## Risk assessment
Low, backward-compatible. Existing v1 spools + legacy lines without the field parse fine (default). No live data change. A genuine v2 spool would be skipped until INTKB adds v2 handling — the intended fail-closed behavior.

## Operational impact
None on current spools. When ICO ships v2, INTKB must add a v2 branch (this literal is the tripwire that forces it).

## Follow-up & deferred
Rest of epic `5bm`: `5bm.7` recategorize tool, `5bm.8` bulk-import source. (Skipped-line telemetry — a v2/malformed line is currently skipped without a counter — is a separate intake-observability concern.)

## Governance links
Bead `qmd-team-intent-kb-5bm.6` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io