### PR TITLE
feat(govern): add a governed in-place recategorization transition (tool + API + audit)

### DIFF
--- a/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
+++ b/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
@@ -91,6 +91,11 @@ exports[`OpenAPI contract > publishes a stable apps/api surface (snapshot) 1`] =
         "get",
       ],
     },
+    "/api/memories/{id}/recategorize": {
+      "methods": [
+        "post",
+      ],
+    },
     "/api/memories/{id}/transition": {
       "methods": [
         "post",

--- a/apps/api/src/__tests__/services.test.ts
+++ b/apps/api/src/__tests__/services.test.ts
@@ -278,6 +278,72 @@ describe('MemoryService', () => {
     expect(events[0]?.action).toBe('archived');
     expect(events[0]?.tenantId).toBe('team-audit');
   });
+
+  // --- governed recategorization (5bm.7) --------------------------------------
+
+  it('recategorize corrects the category in place and returns the updated memory', () => {
+    const memory = makeMemory({ category: 'reference' });
+    memoryRepo.insert(memory);
+
+    const result = service.recategorize(memory.id, {
+      category: 'decision',
+      reason: 'Miscompiled — this is a decision record',
+      actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    });
+
+    expect(result.category).toBe('decision');
+    expect(memoryRepo.findById(memory.id)?.category).toBe('decision');
+  });
+
+  it('recategorize writes a receipted audit event with from/to categories', () => {
+    const memory = makeMemory({ category: 'reference', tenantId: 'team-recat' });
+    memoryRepo.insert(memory);
+
+    service.recategorize(memory.id, {
+      category: 'architecture',
+      reason: 'Belongs in architecture',
+      actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    });
+
+    const events = auditRepo.findByMemory(memory.id);
+    expect(events.length).toBe(1);
+    expect(events[0]?.action).toBe('recategorized');
+    expect(events[0]?.tenantId).toBe('team-recat');
+    expect(events[0]?.details).toMatchObject({
+      fromCategory: 'reference',
+      toCategory: 'architecture',
+    });
+  });
+
+  it('recategorize rejects a same-category no-op with 400', () => {
+    const memory = makeMemory({ category: 'pattern' });
+    memoryRepo.insert(memory);
+    expect(() =>
+      service.recategorize(memory.id, {
+        category: 'pattern',
+        reason: 'no change',
+        actor: { type: 'human', id: 'user-1' },
+      }),
+    ).toThrow(ApiError);
+    // No spurious audit event on a rejected no-op.
+    expect(auditRepo.findByMemory(memory.id).length).toBe(0);
+  });
+
+  it('recategorize throws 404 for a missing memory', () => {
+    expect(() =>
+      service.recategorize('00000000-0000-4000-8000-000000000000', {
+        category: 'decision',
+        reason: 'x',
+        actor: { type: 'human', id: 'user-1' },
+      }),
+    ).toThrow(ApiError);
+  });
+
+  it('recategorize rejects an invalid request body with 400', () => {
+    const memory = makeMemory();
+    memoryRepo.insert(memory);
+    expect(() => service.recategorize(memory.id, { category: 'not-a-category' })).toThrow(ApiError);
+  });
 });
 
 describe('PolicyService', () => {

--- a/apps/api/src/routes/memories.ts
+++ b/apps/api/src/routes/memories.ts
@@ -149,4 +149,29 @@ export function registerMemoryRoutes(
       }
     },
   );
+
+  // POST /api/memories/:id/recategorize — governed in-place category correction (5bm.7)
+  app.post(
+    '/api/memories/:id/recategorize',
+    {
+      schema: {
+        tags: ['memories'],
+        summary: 'Correct a memory’s category in place with a receipted audit event',
+        description:
+          'Governed recategorization: updates category without supersession, writing a `recategorized` audit event with {fromCategory, toCategory}. Body: { category, reason, actor }.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const memory = service.recategorize(id, request.body);
+        return reply.send(memory);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
 }

--- a/apps/api/src/services/memory-service.ts
+++ b/apps/api/src/services/memory-service.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import type { MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
-import { AuditEvent, TransitionRequest, validateTransition } from '@qmd-team-intent-kb/schema';
+import {
+  AuditEvent,
+  TransitionRequest,
+  RecategorizeRequest,
+  validateTransition,
+} from '@qmd-team-intent-kb/schema';
 import type { CuratedMemory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 import { badRequest, notFound } from '../errors.js';
 
@@ -91,5 +96,47 @@ export class MemoryService {
 
     // Return the updated memory without a second DB fetch
     return { ...memory, lifecycle: to, updatedAt: now };
+  }
+
+  /**
+   * Governed in-place recategorization (5bm.7): correct a memory's category
+   * without the supersede-and-recreate churn. Validates the request, rejects a
+   * no-op (same category), writes the corrected row (the repository re-asserts
+   * enum membership), and appends a `recategorized` audit event carrying
+   * {fromCategory, toCategory} so the correction is on the append-only chain.
+   * Changing the category also moves the memory's export collection on the next
+   * exporter run (getDirectory keys on category).
+   *
+   * Throws 400 on a bad body or a same-category no-op; 404 when the memory does
+   * not exist.
+   */
+  recategorize(id: string, requestBody: unknown): CuratedMemory {
+    const parsed = RecategorizeRequest.safeParse(requestBody);
+    if (!parsed.success) {
+      throw badRequest(`Invalid recategorize request: ${parsed.error.message}`);
+    }
+
+    const memory = this.getById(id); // throws 404 if missing
+    if (memory.category === parsed.data.category) {
+      throw badRequest(`Memory ${id} is already category "${memory.category}"`);
+    }
+
+    const now = new Date().toISOString();
+    const updated: CuratedMemory = { ...memory, category: parsed.data.category, updatedAt: now };
+    this.memoryRepo.update(updated);
+
+    const auditEvent = AuditEvent.parse({
+      id: randomUUID(),
+      action: 'recategorized',
+      memoryId: id,
+      tenantId: memory.tenantId,
+      actor: parsed.data.actor,
+      reason: parsed.data.reason,
+      details: { fromCategory: memory.category, toCategory: parsed.data.category },
+      timestamp: now,
+    });
+    this.auditRepo.insert(auditEvent);
+
+    return updated;
   }
 }

--- a/apps/mcp-server/src/__tests__/recategorize.test.ts
+++ b/apps/mcp-server/src/__tests__/recategorize.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import { applyRecategorize } from '../tools/recategorize.js';
+import type { McpServerConfig } from '../config.js';
+import { FIXED_NOW, makeMemory } from './fixtures.js';
+
+const nowFn = () => FIXED_NOW;
+
+describe('applyRecategorize() — governed in-place category correction (5bm.7)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-recat-'));
+    dbPath = join(tmpDir, 'teamkb.db');
+    config = {
+      tenantId: 'test-tenant',
+      basePath: tmpDir,
+      spoolPath: join(tmpDir, 'spool'),
+      dbPath,
+      feedbackPath: join(tmpDir, 'feedback'),
+    };
+  });
+
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  function seed(category: string) {
+    const memory = makeMemory({ category: category as never });
+    const db = createDatabase({ path: dbPath });
+    new MemoryRepository(db).insert(memory);
+    db.close();
+    return memory;
+  }
+
+  it('corrects the category and writes a recategorized audit event', () => {
+    const memory = seed('reference');
+    const result = applyRecategorize(
+      { memoryId: memory.id, category: 'decision', reason: 'is a decision', actor: 'jeremy' },
+      config,
+      nowFn,
+    );
+    expect(result.fromCategory).toBe('reference');
+    expect(result.toCategory).toBe('decision');
+
+    const db = createDatabase({ path: dbPath });
+    try {
+      expect(new MemoryRepository(db).findById(memory.id)?.category).toBe('decision');
+      const events = new AuditRepository(db).findByMemory(memory.id);
+      expect(events.some((e) => e.action === 'recategorized')).toBe(true);
+      const recat = events.find((e) => e.action === 'recategorized');
+      expect(recat?.details).toMatchObject({ fromCategory: 'reference', toCategory: 'decision' });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('rejects a same-category no-op', () => {
+    const memory = seed('pattern');
+    expect(() =>
+      applyRecategorize(
+        { memoryId: memory.id, category: 'pattern', reason: 'x', actor: 'jeremy' },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/already category/);
+  });
+
+  it('rejects an unknown category', () => {
+    const memory = seed('reference');
+    expect(() =>
+      applyRecategorize(
+        { memoryId: memory.id, category: 'made-up' as never, reason: 'x', actor: 'jeremy' },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/Invalid category/);
+  });
+
+  it('rejects an invalid UUID before opening the DB', () => {
+    expect(() =>
+      applyRecategorize(
+        { memoryId: 'not-a-uuid', category: 'decision', reason: 'x', actor: 'jeremy' },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/not a valid UUID/);
+  });
+
+  it('throws when the memory does not exist', () => {
+    expect(() =>
+      applyRecategorize(
+        {
+          memoryId: '00000000-0000-4000-8000-000000000000',
+          category: 'decision',
+          reason: 'x',
+          actor: 'jeremy',
+        },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/Memory not found/);
+  });
+});

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { searchTool } from './tools/search.js';
 import { importFiles } from './tools/import.js';
 import { getStatus } from './tools/status.js';
 import { applyTransition } from './tools/transition.js';
+import { applyRecategorize } from './tools/recategorize.js';
 import { runSync, isQmdAvailable } from './tools/sync.js';
 import { vaultPreview, vaultExecute, vaultRollback } from './tools/vault-import.js';
 import { createDatabase, MemoryLinksRepository } from '@qmd-team-intent-kb/store';
@@ -171,6 +172,35 @@ export function createServer(
           {
             memoryId: params.memoryId,
             to: params.to,
+            reason: params.reason,
+            actor: params.actor,
+          },
+          config,
+        );
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        };
+      },
+    );
+
+    // teamkb_recategorize — governed in-place category correction (5bm.7)
+    server.tool(
+      'teamkb_recategorize',
+      'Correct a curated memory’s category in place (no supersession). Re-asserts enum membership and writes a `recategorized` audit event with {fromCategory, toCategory}.',
+      {
+        memoryId: z.string().uuid().describe('UUID of the curated memory to recategorize'),
+        category: MemoryCategory.describe('The corrected category'),
+        reason: z.string().min(1).describe('Human-readable reason for the correction'),
+        actor: z
+          .string()
+          .min(1)
+          .describe('Identifier of the person or system initiating the recategorization'),
+      },
+      async (params) => {
+        const result = applyRecategorize(
+          {
+            memoryId: params.memoryId,
+            category: params.category,
             reason: params.reason,
             actor: params.actor,
           },

--- a/apps/mcp-server/src/tools/recategorize.ts
+++ b/apps/mcp-server/src/tools/recategorize.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from 'node:crypto';
+import type { MemoryCategory as MemoryCategoryType } from '@qmd-team-intent-kb/schema';
+import { MemoryCategory } from '@qmd-team-intent-kb/schema';
+import { createDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { McpServerConfig } from '../config.js';
+
+/** Input for teamkb_recategorize (5bm.7) */
+interface RecategorizeInput {
+  memoryId: string;
+  category: MemoryCategoryType;
+  reason: string;
+  actor: string;
+}
+
+/** Result returned after a successful recategorization */
+interface RecategorizeResult {
+  memoryId: string;
+  fromCategory: string;
+  toCategory: string;
+  auditEventId: string;
+  message: string;
+}
+
+/**
+ * Governed in-place recategorization of a curated memory (5bm.7).
+ *
+ * Category is assigned probabilistically at compile time; a miscategorization
+ * permanently distorts ranking and export-collection placement, and the only
+ * prior correction path was supersede-and-recreate (which inflated the
+ * superseded-churn the ontology audit found). This corrects the category in
+ * place and writes a `recategorized` audit event ({fromCategory, toCategory}) —
+ * the memory row's `update()` re-asserts enum membership, and both writes commit
+ * in one SQLite transaction. Low-frequency user action, so a per-call connection
+ * is acceptable (mirrors applyTransition).
+ */
+export function applyRecategorize(
+  input: RecategorizeInput,
+  config: McpServerConfig,
+  nowFn: () => string = () => new Date().toISOString(),
+): RecategorizeResult {
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!uuidPattern.test(input.memoryId)) {
+    throw new Error(`Invalid memoryId: "${input.memoryId}" is not a valid UUID`);
+  }
+  if (!MemoryCategory.safeParse(input.category).success) {
+    throw new Error(`Invalid category: "${input.category}"`);
+  }
+
+  const db = createDatabase({ path: config.dbPath });
+  try {
+    const memoryRepo = new MemoryRepository(db);
+    const auditRepo = new AuditRepository(db);
+
+    const memory = memoryRepo.findById(input.memoryId);
+    if (memory === null) {
+      throw new Error(`Memory not found: ${input.memoryId}`);
+    }
+    if (memory.category === input.category) {
+      throw new Error(`Memory is already category "${memory.category}"`);
+    }
+
+    const now = nowFn();
+    const auditEventId = randomUUID();
+    const fromCategory = memory.category;
+
+    const applyFn = db.transaction(() => {
+      // The row update re-asserts enum membership (5bm.1); a bad category never lands.
+      memoryRepo.update({ ...memory, category: input.category, updatedAt: now });
+      auditRepo.insert({
+        id: auditEventId,
+        action: 'recategorized',
+        memoryId: input.memoryId,
+        tenantId: memory.tenantId,
+        actor: { type: 'human', id: input.actor },
+        reason: input.reason,
+        details: { fromCategory, toCategory: input.category },
+        timestamp: now,
+      });
+    });
+
+    applyFn();
+
+    return {
+      memoryId: input.memoryId,
+      fromCategory,
+      toCategory: input.category,
+      auditEventId,
+      message: `Memory recategorized from "${fromCategory}" to "${input.category}"`,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -86,6 +86,11 @@ export const AuditAction = z.enum([
   'deleted',
   'searched',
   'exported',
+  // Governed in-place category correction (5bm.7). A miscategorized memory —
+  // category is assigned probabilistically at compile time — is corrected with a
+  // receipted audit event carrying {fromCategory, toCategory}, instead of the
+  // supersede-and-recreate path that inflated the superseded-churn the audit found.
+  'recategorized',
   // Evidence Bundle emission on a curation/promotion cycle (IEP unification
   // thesis, DR-010 Q3). Added for the eval-surface emit path (bead tr08.15/.17/.19).
   'eval-result',

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -42,6 +42,7 @@ export { AuditEvent } from './audit-event.js';
 
 export {
   TransitionRequest,
+  RecategorizeRequest,
   ALLOWED_TRANSITIONS,
   isTransitionAllowed,
   validateTransition,

--- a/packages/schema/src/lifecycle.ts
+++ b/packages/schema/src/lifecycle.ts
@@ -1,4 +1,5 @@
 import type { MemoryLifecycleState } from './enums.js';
+import { MemoryCategory } from './enums.js';
 import { Author, NonEmptyString, Uuid } from './common.js';
 import { z } from 'zod';
 
@@ -9,6 +10,18 @@ export const TransitionRequest = z.object({
   supersededBy: Uuid.optional(),
 });
 export type TransitionRequest = z.infer<typeof TransitionRequest>;
+
+/**
+ * Metadata required for a governed recategorization (5bm.7) — an in-place
+ * category correction with a receipted audit event, so a miscategorized memory
+ * is fixed without the supersede-and-recreate churn.
+ */
+export const RecategorizeRequest = z.object({
+  category: MemoryCategory,
+  reason: NonEmptyString,
+  actor: Author,
+});
+export type RecategorizeRequest = z.infer<typeof RecategorizeRequest>;
 
 /** All allowed transitions from each state */
 export const ALLOWED_TRANSITIONS: Record<MemoryLifecycleState, MemoryLifecycleState[]> = {


### PR DESCRIPTION
## What
A full governed recategorization surface — correct a memory's category **in place** with a receipted audit event, instead of supersede-and-recreate.

## Why + decision rationale
Category is assigned probabilistically at compile time; the audit found a miscategorization permanently distorts ranking + export-collection placement, and the only correction path was supersede-and-recreate — which inflated the 38%-superseded churn the audit measured. Bead `qmd-team-intent-kb-5bm.7`. **Chose in-place update + receipted audit over supersede-and-recreate** because a correction is not a new fact; recreating fabricates lineage and churns lifecycle state — the exact anti-pattern this closes.

## Layer touched
`schema` (new `recategorized` AuditAction + `RecategorizeRequest`) · `apps/api` (service + route) · `apps/mcp-server` (admin tool). No cross-layer invariant change; the memory `update()` still re-asserts enum membership (5bm.1).

## How it works
- `MemoryService.recategorize`: validate → reject same-category no-op (400) / missing (404) → write corrected row → append `recategorized` audit event `{fromCategory, toCategory}`.
- `POST /api/memories/:id/recategorize`.
- MCP admin tool `teamkb_recategorize` (both writes in one SQLite transaction, mirroring `teamkb_transition`, write-gated to admin).
- Category change moves the export collection on the next exporter run (`getDirectory` keys on category) — no separate move step.

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2092/2092 tests** green — new service tests (in-place update, receipted `{from,to}` audit, same-category 400, 404, bad body) + MCP tool tests (correction+audit, same-category, unknown category, bad UUID, not-found). OpenAPI contract snapshot updated for the new endpoint (intentional surface addition).

## Risk assessment
Low. New, additive, admin-gated surface; no existing path changes. The audit event is a new enum value (append-only chain unaffected). Rollback = revert.

## Operational impact
New admin MCP tool + API route. No migration/data change.

## Follow-up & deferred
Expose recategorization in the plugin's **team mode** (a `bobs-big-brain-plugin` change, coordinated like `brain_transition` shipped).

## Governance links
Bead `qmd-team-intent-kb-5bm.7` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io