### PR TITLE
feat(schema): accept a distinct bulk_import MemorySource so policy can gate whole-machine digestions

### DIFF
--- a/packages/policy-engine/src/__tests__/source-trust-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/source-trust-rule.test.ts
@@ -71,3 +71,21 @@ describe('evaluateSourceTrust', () => {
     expect(result.outcome).toBe('flag');
   });
 });
+
+describe('evaluateSourceTrust — bulk_import gating (5bm.8)', () => {
+  it('fails a bulk_import candidate stamped untrusted (below the default low minimum)', () => {
+    // untrusted (1) < default minimumTrust 'low' (2) → the rule fails, so a
+    // source_trust rule with action 'flag' (the recommended policy) gates the
+    // whole-machine digestion for review instead of promoting it silently.
+    const candidate = makeCandidate({ source: 'bulk_import', trustLevel: 'untrusted' });
+    const rule = makeRule({});
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+  });
+
+  it('passes a normal import at the default medium trust', () => {
+    const candidate = makeCandidate({ source: 'import', trustLevel: 'medium' });
+    const rule = makeRule({});
+    expect(evaluateSourceTrust(candidate, rule, makeContext(candidate)).outcome).toBe('pass');
+  });
+});

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-export const MemorySource = z.enum(['claude_session', 'manual', 'import', 'mcp']);
+// `bulk_import` (5bm.8) marks a whole-machine / large digestion — ICO stamps it
+// (with low trust) so a whole-machine mount is distinguishable from a deliberate
+// `import` and the source-trust policy can gate it, instead of a 17k-candidate
+// digestion looking identical to a curated import (the 2026-07-16 flood).
+export const MemorySource = z.enum(['claude_session', 'manual', 'import', 'mcp', 'bulk_import']);
 export type MemorySource = z.infer<typeof MemorySource>;
 
 export const TrustLevel = z.enum(['high', 'medium', 'low', 'untrusted']);

--- a/packages/store/src/__tests__/database.test.ts
+++ b/packages/store/src/__tests__/database.test.ts
@@ -93,6 +93,26 @@ describe('curated_memories enum CHECK constraints (5bm.1)', () => {
     db.close();
   });
 
+  it('accepts the bulk_import source (5bm.8)', () => {
+    const db = createTestDatabase();
+    const author = JSON.stringify({ type: 'human', id: 'u', name: 'U' });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO curated_memories (
+            id, candidate_id, source, content, title, category, trust_level, sensitivity,
+            author_json, tenant_id, metadata_json, lifecycle, content_hash,
+            policy_evaluations_json, supersession_json, promoted_at, promoted_by_json, updated_at, version
+          ) VALUES (
+            'i', 'c', 'bulk_import', 'x', 'x', 'reference', 'untrusted', 'internal',
+            ?, 't', '{}', 'active', 'h', '[]', NULL, 'now', ?, 'now', 1
+          )`,
+        )
+        .run(author, author),
+    ).not.toThrow();
+    db.close();
+  });
+
   it('accepts a fully in-vocabulary row', () => {
     const db = createTestDatabase();
     const author = JSON.stringify({ type: 'human', id: 'u', name: 'U' });

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -28,7 +28,7 @@ const CURATED_MEMORIES_DDL = `
 CREATE TABLE IF NOT EXISTS curated_memories (
   id TEXT PRIMARY KEY,
   candidate_id TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('claude_session', 'manual', 'import', 'mcp')),
+  source TEXT NOT NULL CHECK (source IN ('claude_session', 'manual', 'import', 'mcp', 'bulk_import')),
   content TEXT NOT NULL,
   title TEXT NOT NULL,
   category TEXT NOT NULL CHECK (category IN ('decision', 'pattern', 'convention', 'architecture', 'troubleshooting', 'reference', 'onboarding')),


### PR DESCRIPTION
## What
Adds `bulk_import` to the `MemorySource` enum and the `curated_memories.source` CHECK constraint — the **consumer half** of a coordinated ICO+INTKB change.

## Why + decision rationale
The audit found the 2026-07-16 whole-machine digestion (17k candidates, 94% `reference`) was indistinguishable from a deliberate import — ICO stamps every candidate `source:'import'` + `trustLevel:'medium'`. Bead `qmd-team-intent-kb-5bm.8` (INTKB half). **Chose a distinct source value + low trust over a metadata flag** because `source` is a first-class, enum-enforced, CHECK-backed field the policy engine already reads; a metadata flag would be un-gated free text — the laundering this epic closes.

## Coordination / ordering (important)
This is the CONSUMER side — INTKB must **accept** `bulk_import` before ICO **emits** it. Safe order: merge + deploy this first; the ICO emitter change (stamp `source:'bulk_import'` + `trustLevel:'untrusted'` on a whole-machine/`--bulk` emit) ships as a separate, after-this ICO PR. A `bulk_import` line arriving before this lands is fail-closed-skipped by `safeParse` (5bm.6), never downgraded.

## Layer touched
`schema` (enum) + `store` (CHECK). No pipeline change. The gate is free from the existing `source_trust` rule + recommended policy (5bm.2): `untrusted`(1) < default `minimumTrust 'low'`(2) → a bulk candidate fails source_trust → flagged for review.

## Verification & evidence
`pnpm typecheck` + `lint` clean; **2095/2095 tests** green — the 5bm.1 CHECK↔Zod lock-step test auto-validated the new value in both DDL and enum; new tests: a `bulk_import` row inserts (CHECK accepts), and `source_trust` **fails** an untrusted `bulk_import` candidate while **passing** a medium normal import.

## Risk assessment
Low, additive. New enum member; no existing source/row changes. Nothing emits `bulk_import` until the ICO PR lands, so this is inert-but-ready on merge. Rollback = revert.

## Operational impact
None until ICO emits. Then a whole-machine digestion's candidates arrive low-trust and get flagged by the recommended policy (once applied live, 5bm.10).

## Follow-up & deferred
ICO emitter PR (`intentional-cognition-os`): stamp `source:'bulk_import'` + `trustLevel:'untrusted'` on a `--bulk`/whole-machine emit — the producer half, ships after this.

## Governance links
Bead `qmd-team-intent-kb-5bm.8` (epic `5bm`, GH #259). Refs jeremylongshore/qmd-team-intent-kb#259

- Jeremy Longshore
intentsolutions.io