### PR TITLE
feat(search): read-time sensitivity enforcement — never return confidential/restricted (5bm.11)

### DIFF
--- a/apps/api/src/__tests__/search.test.ts
+++ b/apps/api/src/__tests__/search.test.ts
@@ -173,4 +173,38 @@ describe('POST /api/search', () => {
     expect(hit.score).toBeGreaterThan(0);
     expect(hit.score).toBeLessThanOrEqual(1);
   });
+
+  it('excludes confidential and restricted memories from search results (5bm.11)', () => {
+    const visible = makeMemory({ title: 'Indexing strategy public', sensitivity: 'internal' });
+    const confidential = makeMemory({
+      title: 'Indexing strategy secret',
+      sensitivity: 'confidential',
+      contentHash: 'c'.repeat(64),
+    });
+    const restricted = makeMemory({
+      title: 'Indexing strategy locked',
+      sensitivity: 'restricted',
+      contentHash: 'd'.repeat(64),
+    });
+    memoryRepo.insert(visible);
+    memoryRepo.insert(confidential);
+    memoryRepo.insert(restricted);
+
+    return app
+      .inject({
+        method: 'POST',
+        url: '/api/search',
+        payload: { query: 'indexing', scope: 'curated' },
+      })
+      .then((res) => {
+        expect(res.statusCode).toBe(200);
+        const body = res.json();
+        // Only the internal-sensitivity memory is search-visible.
+        expect(body.totalCount).toBe(1);
+        const ids = body.hits.map((h: { memoryId: string }) => h.memoryId);
+        expect(ids).toContain(visible.id);
+        expect(ids).not.toContain(confidential.id);
+        expect(ids).not.toContain(restricted.id);
+      });
+  });
 });

--- a/apps/api/src/services/search-service.ts
+++ b/apps/api/src/services/search-service.ts
@@ -1,6 +1,10 @@
 import type { MemoryRepository } from '@qmd-team-intent-kb/store';
 import type { SearchQuery, SearchResult, SearchHit, SearchScope } from '@qmd-team-intent-kb/schema';
-import { rerankSearchHits, rerankCitedHits } from '@qmd-team-intent-kb/common';
+import {
+  rerankSearchHits,
+  rerankCitedHits,
+  isSearchVisibleSensitivity,
+} from '@qmd-team-intent-kb/common';
 import { badRequest } from '../errors.js';
 
 /**
@@ -116,12 +120,24 @@ export class SearchService {
       normalised,
       (memoryId) => {
         const memory = this.memoryRepo.findById(memoryId);
-        return memory === null ? null : { category: memory.category, updatedAt: memory.updatedAt };
+        return memory === null
+          ? null
+          : {
+              category: memory.category,
+              updatedAt: memory.updatedAt,
+              sensitivity: memory.sensitivity,
+            };
       },
       nowIso,
     );
 
-    const allHits: SearchHit[] = reranked.map((hit) => ({
+    // Read-time sensitivity enforcement (5bm.11): drop confidential/restricted
+    // hits so a sensitive memory is never returned to a search caller — the same
+    // levels the exporter skips (5bm.3). The qmd index should already exclude
+    // them; this is the defense-in-depth for a pre-skip index or a resolved row.
+    const visible = reranked.filter((hit) => isSearchVisibleSensitivity(hit.sensitivity));
+
+    const allHits: SearchHit[] = visible.map((hit) => ({
       memoryId: hit.memoryId ?? undefined,
       title: titleFromCitation(hit.file),
       snippet: hit.snippet,
@@ -138,7 +154,10 @@ export class SearchService {
 
   /** SQLite text-match fallback with freshness reranking. */
   private searchViaSqlite(query: SearchQuery): SearchResult {
-    const memories = this.memoryRepo.searchByText(query.query, query.tenantId, query.categories);
+    const allMemories = this.memoryRepo.searchByText(query.query, query.tenantId, query.categories);
+    // Read-time sensitivity enforcement (5bm.11): the SQLite path returns rows
+    // directly, so drop confidential/restricted here — the leak the audit found.
+    const memories = allMemories.filter((m) => isSearchVisibleSensitivity(m.sensitivity));
 
     const nowIso = new Date().toISOString();
     const queryLower = query.query.toLowerCase();

--- a/apps/mcp-server/src/__tests__/search.test.ts
+++ b/apps/mcp-server/src/__tests__/search.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import { makeMemory } from '@qmd-team-intent-kb/test-fixtures';
 import { searchTool } from '../tools/search.js';
 import type { QmdQueryPort } from '../tools/search.js';
 import type { McpServerConfig } from '../config.js';
@@ -140,5 +144,60 @@ describe('searchTool — remote brain mode (TEAMKB_API_URL set)', () => {
 
     await searchTool({ query: 'x' }, makeConfig({ apiUrl: 'http://dev:3847' }), { fetchFn });
     expect(auth).toBeUndefined();
+  });
+});
+
+describe('searchTool — local read-time sensitivity filter (5bm.11)', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('drops a confidential hit whose citation resolves to a sensitive stored row', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'teamkb-sens-'));
+    const dbPath = join(dir, 'teamkb.db');
+    const db = createDatabase({ path: dbPath });
+    const repo = new MemoryRepository(db);
+    const visible = makeMemory({ title: 'Public map', sensitivity: 'internal' });
+    const secret = makeMemory({
+      title: 'Secret map',
+      sensitivity: 'confidential',
+      contentHash: 'c'.repeat(64),
+    });
+    repo.insert(visible);
+    repo.insert(secret);
+    db.close();
+
+    // A stale/pre-skip index could surface BOTH citations; the read-time filter
+    // must still drop the confidential one.
+    const adapter: QmdQueryPort = {
+      query: () =>
+        Promise.resolve({
+          ok: true as const,
+          value: [
+            {
+              file: `qmd://kb-curated/${visible.id}.md`,
+              score: 0.9,
+              snippet: '',
+              collection: 'kb-curated',
+            },
+            {
+              file: `qmd://kb-curated/${secret.id}.md`,
+              score: 0.8,
+              snippet: '',
+              collection: 'kb-curated',
+            },
+          ],
+        }),
+    };
+
+    const result = await searchTool({ query: 'map' }, makeConfig({ dbPath }), {
+      makeAdapter: () => adapter,
+    });
+
+    const citations = result.results.map((r) => r.citation);
+    expect(citations).toContain(`qmd://kb-curated/${visible.id}.md`);
+    expect(citations).not.toContain(`qmd://kb-curated/${secret.id}.md`);
+    expect(result.count).toBe(1);
   });
 });

--- a/apps/mcp-server/src/tools/search.ts
+++ b/apps/mcp-server/src/tools/search.ts
@@ -1,7 +1,50 @@
 import { join } from 'node:path';
 import type { SearchScope } from '@qmd-team-intent-kb/schema';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import {
+  extractMemoryIdFromCitation,
+  isSearchVisibleSensitivity,
+} from '@qmd-team-intent-kb/common';
+import { createDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
 import type { McpServerConfig } from '../config.js';
+
+/** One raw qmd hit before it is mapped to the caller-facing shape. */
+interface RawQmdHit {
+  file: string;
+  score: number;
+  snippet: string;
+  collection: string;
+}
+
+/**
+ * Read-time sensitivity filter (5bm.11) for the local qmd path. Resolves each
+ * hit's citation back to its stored row and drops confidential/restricted
+ * memories, mirroring the exporter's skip (5bm.3) and the API search-service.
+ * A hit whose citation does not resolve to a stored row is NOT an identifiable
+ * sensitive memory, so it is kept. Opens the store read-only; on any store error
+ * it fails OPEN to the raw hits — the qmd index itself already excludes sensitive
+ * rows for a post-5bm.3 export, so this is defense-in-depth, not the only gate.
+ */
+function filterSensitiveHits(hits: RawQmdHit[], dbPath: string): RawQmdHit[] {
+  if (hits.length === 0) return hits;
+  try {
+    const db = createDatabase({ path: dbPath, readonly: true });
+    try {
+      const repo = new MemoryRepository(db);
+      return hits.filter((h) => {
+        const id = extractMemoryIdFromCitation(h.file);
+        if (id === null) return true;
+        const memory = repo.findById(id);
+        if (memory === null) return true;
+        return isSearchVisibleSensitivity(memory.sensitivity);
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    return hits;
+  }
+}
 
 /** One cited hit returned to the MCP caller. */
 export interface SearchHitOut {
@@ -95,14 +138,20 @@ async function searchLocal(
   const adapter = makeAdapter(config.tenantId, exportDir);
   const result = await adapter.query(query, scope);
 
-  const results: SearchHitOut[] = result.ok
-    ? result.value.slice(0, limit).map((r) => ({
-        citation: r.file,
-        snippet: r.snippet,
-        score: r.score,
-        collection: r.collection,
-      }))
-    : [];
+  const hits = result.ok ? result.value : [];
+  // Read-time sensitivity enforcement (5bm.11): drop confidential/restricted
+  // hits so a sensitive memory is never returned. The qmd index should already
+  // exclude them (exporter skip, 5bm.3); this resolves each hit's stored row as
+  // defense-in-depth for a pre-skip index. A hit that doesn't resolve is not an
+  // identifiable sensitive memory — kept.
+  const visible = filterSensitiveHits(hits, config.dbPath);
+
+  const results: SearchHitOut[] = visible.slice(0, limit).map((r) => ({
+    citation: r.file,
+    snippet: r.snippet,
+    score: r.score,
+    collection: r.collection,
+  }));
 
   return { source: 'qmd-local', query, scope, count: results.length, results };
 }

--- a/packages/common/src/__tests__/freshness.test.ts
+++ b/packages/common/src/__tests__/freshness.test.ts
@@ -5,6 +5,7 @@ import {
   rerankSearchHits,
   extractMemoryIdFromCitation,
   rerankCitedHits,
+  isSearchVisibleSensitivity,
 } from '../freshness.js';
 
 const NOW = '2026-03-19T00:00:00.000Z';
@@ -177,5 +178,33 @@ describe('rerankCitedHits', () => {
     ];
     const reranked = rerankCitedHits(hits, () => null, NOW);
     expect(reranked.map((h) => h.file)).toEqual(hits.map((h) => h.file));
+  });
+
+  it('threads a resolved memory sensitivity onto the cited hit (5bm.11)', () => {
+    const hits = [{ file: 'qmd://kb-curated/secret.md', score: 0.9 }];
+    const reranked = rerankCitedHits(
+      hits,
+      () => ({ category: 'reference', updatedAt: NOW, sensitivity: 'confidential' }),
+      NOW,
+    );
+    expect(reranked[0]!.sensitivity).toBe('confidential');
+  });
+
+  it('defaults an unresolved cited hit to public sensitivity (5bm.11)', () => {
+    const hits = [{ file: 'qmd://kb-curated/gone.md', score: 0.5 }];
+    const reranked = rerankCitedHits(hits, () => null, NOW);
+    expect(reranked[0]!.sensitivity).toBe('public');
+  });
+});
+
+describe('isSearchVisibleSensitivity (5bm.11)', () => {
+  it('keeps public and internal search-visible', () => {
+    expect(isSearchVisibleSensitivity('public')).toBe(true);
+    expect(isSearchVisibleSensitivity('internal')).toBe(true);
+  });
+
+  it('hides confidential and restricted from search', () => {
+    expect(isSearchVisibleSensitivity('confidential')).toBe(false);
+    expect(isSearchVisibleSensitivity('restricted')).toBe(false);
   });
 });

--- a/packages/common/src/freshness.ts
+++ b/packages/common/src/freshness.ts
@@ -62,6 +62,26 @@ export function extractMemoryIdFromCitation(citation: string): string | null {
 export interface CitedHitMetadata {
   category: string;
   updatedAt: string;
+  /** Sensitivity of the resolved memory (5bm.11), so a cited hit can be
+   * sensitivity-filtered at read time. Optional: a resolver that doesn't supply
+   * it (e.g. a rank-only caller) leaves the hit search-visible ('public'). */
+  sensitivity?: string;
+}
+
+/**
+ * Sensitivity levels kept OUT of general search results (5bm.11) — the same
+ * levels the git-exporter skips (5bm.3), so a confidential/restricted memory is
+ * never returned to a search caller. A memory whose sensitivity is not one of
+ * these is search-visible.
+ */
+export const SEARCH_HIDDEN_SENSITIVITY: ReadonlySet<string> = new Set([
+  'confidential',
+  'restricted',
+]);
+
+/** True if a memory of this sensitivity may appear in general search results. */
+export function isSearchVisibleSensitivity(sensitivity: string): boolean {
+  return !SEARCH_HIDDEN_SENSITIVITY.has(sensitivity);
 }
 
 /**
@@ -79,7 +99,15 @@ export function rerankCitedHits<T extends { file: string; score: number }>(
   resolveMetadata: (memoryId: string) => CitedHitMetadata | null,
   nowIso: string,
   halfLifeDays: number = 90,
-): Array<T & { finalScore: number; category: string; updatedAt: string; memoryId: string | null }> {
+): Array<
+  T & {
+    finalScore: number;
+    category: string;
+    updatedAt: string;
+    sensitivity: string;
+    memoryId: string | null;
+  }
+> {
   const enriched = hits.map((h) => {
     const id = extractMemoryIdFromCitation(h.file);
     const meta = id === null ? null : resolveMetadata(id);
@@ -88,6 +116,9 @@ export function rerankCitedHits<T extends { file: string; score: number }>(
       memoryId: meta === null ? null : id,
       category: meta?.category ?? '',
       updatedAt: meta?.updatedAt ?? nowIso,
+      // Unresolvable hit (orphaned citation) is not an identifiable sensitive
+      // memory — treat as public/searchable; a resolved hit carries its real level.
+      sensitivity: meta?.sensitivity ?? 'public',
     };
   });
   return rerankSearchHits(enriched, nowIso, halfLifeDays);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,6 +19,8 @@ export {
   rerankSearchHits,
   extractMemoryIdFromCitation,
   rerankCitedHits,
+  isSearchVisibleSensitivity,
+  SEARCH_HIDDEN_SENSITIVITY,
 } from './freshness.js';
 export type { CitedHitMetadata } from './freshness.js';
 export {


### PR DESCRIPTION
## What
Completes the deferred half of `5bm.3`. The git-exporter already **skips** confidential/restricted memories from the qmd index at **write time** (5bm.3), but the ontology audit found the **read paths still returned them**:
- the API search-service **SQLite fallback** returns `curated_memories` rows directly — the direct leak;
- the MCP **local-mode** search maps raw qmd hits with no sensitivity gate.

This adds a read-time filter so a confidential/restricted memory is **never returned to a search caller on any path**.

## Why (decision rationale)
**Default-exclude, chosen over role-gated inclusion**, because the audit finding is literally "a confidential memory is returned to *any* caller" — the complete fix is to not return it, not to add a privileged include-path (search is the wrong surface for sensitive rows; get-by-known-id is the authorized path and is out of scope here). The excluded set is exactly the two levels the exporter skips, so write-time and read-time agree.

## Layers touched
- `packages/common` — `SEARCH_HIDDEN_SENSITIVITY` + `isSearchVisibleSensitivity()`; `CitedHitMetadata.sensitivity?` threaded through `rerankCitedHits` (unresolved citation → `public` → kept, since it's not an identifiable sensitive row).
- `apps/api` search-service — **both** paths filter (SQLite drops rows pre-rank; qmd resolver returns sensitivity and reranked hits are filtered as defense-in-depth for a pre-skip index).
- `apps/mcp-server` — `searchLocal` resolves each hit's stored row read-only and drops sensitive ones; **fails open** to raw hits on any store error (the index already excludes them post-5bm.3, so this is a second gate). `searchRemote` proxies to the now-filtered API.

No invariant change to write-time governance; this is a read-surface tightening.

## How it works
Every search result set is filtered against the same predicate the exporter uses. The qmd index *should* already lack sensitive rows post-5bm.3; the resolver-based filters are the belt-and-suspenders for an index built before the skip landed.

## Verification & evidence
- `common`: **138 pass** (+4 — sensitivity threading, unresolved→public default, `isSearchVisibleSensitivity` truth table).
- `api`: **18 pass** (+1 integration — insert confidential + restricted + internal, assert only the internal row returns).
- `mcp-server`: **8 pass** (+1 real temp-file DB — a stale index surfacing BOTH citations still drops the confidential one).
- `tsc -b` clean · `eslint` clean · `prettier` formatted.

## Risk assessment
Low. Behavior change is strictly **subtractive** (sensitive rows removed from results). No schema/migration. MCP filter fails open, so a missing/locked DB degrades to prior behavior rather than erroring.

## Operational impact
None at deploy time — no migration, no new env. Takes effect for the live brain on the next API/MCP release.

## Follow-up
- The plugin (`bobs-big-brain-plugin`) local-server mirrors this MCP path and will get the same filter in a coordinated follow-on.

Refs jeremylongshore/qmd-team-intent-kb#170

- Jeremy Longshore
intentsolutions.io