### PR TITLE
feat(exporter): per-memory quarantine instead of whole-run abort (5bm.12)

### DIFF
--- a/apps/git-exporter/src/__tests__/change-detector.test.ts
+++ b/apps/git-exporter/src/__tests__/change-detector.test.ts
@@ -147,4 +147,19 @@ describe('detectChanges', () => {
     expect(changeset.toWrite).toHaveLength(2); // active + deprecated
     expect(changeset.toArchive).toHaveLength(2); // archived + superseded
   });
+
+  it('quarantines an unreadable row (5bm.12) without dropping the healthy ones', () => {
+    const good = makeCuratedMemory({ category: 'pattern', lifecycle: 'active' });
+    const bad = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    memoryRepo.insert(good);
+    memoryRepo.insert(bad);
+    db.pragma('ignore_check_constraints = ON');
+    db.prepare('UPDATE curated_memories SET category = ? WHERE id = ?').run('vanished', bad.id);
+    db.pragma('ignore_check_constraints = OFF');
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite.map((w) => w.memory.id)).toEqual([good.id]);
+    expect(changeset.quarantined).toHaveLength(1);
+    expect(changeset.quarantined[0]!.id).toBe(bad.id);
+  });
 });

--- a/apps/git-exporter/src/__tests__/exporter.test.ts
+++ b/apps/git-exporter/src/__tests__/exporter.test.ts
@@ -282,4 +282,41 @@ describe('runExport', () => {
     expect(result.unchanged).toBe(1);
     expect(result.written).toHaveLength(0);
   });
+
+  // ─── Per-memory quarantine (5bm.12) ────────────────────────────────────────
+
+  it('quarantines a corrupt-category row and still exports the healthy ones', () => {
+    const good1 = makeCuratedMemory({ category: 'pattern', lifecycle: 'active' });
+    const good2 = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    const bad = makeCuratedMemory({ category: 'convention', lifecycle: 'active' });
+    memoryRepo.insert(good1);
+    memoryRepo.insert(good2);
+    memoryRepo.insert(bad);
+    // Plant a pre-CHECK-style corrupt category the mapper/schema will reject.
+    db.pragma('ignore_check_constraints = ON');
+    db.prepare('UPDATE curated_memories SET category = ? WHERE id = ?').run(
+      'gone-category',
+      bad.id,
+    );
+    db.pragma('ignore_check_constraints = OFF');
+
+    // The run does NOT throw even though one row is unreadable.
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    // Both healthy memories exported; the corrupt one set aside + named.
+    expect(result.written).toHaveLength(2);
+    expect(result.quarantined).toHaveLength(1);
+    expect(result.quarantined[0]!.id).toBe(bad.id);
+    expect(result.quarantined[0]!.reason).toMatch(/category/i);
+    // No file was written for the quarantined memory.
+    for (const path of result.written) {
+      expect(path).not.toContain(bad.id);
+    }
+  });
+
+  it('reports an empty quarantine list when every memory is healthy', () => {
+    memoryRepo.insert(makeCuratedMemory({ category: 'pattern', lifecycle: 'active' }));
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+    expect(result.quarantined).toEqual([]);
+  });
 });

--- a/apps/git-exporter/src/cli.ts
+++ b/apps/git-exporter/src/cli.ts
@@ -150,6 +150,9 @@ async function cmdExport(args: string[], deps: ExporterCliDeps): Promise<number>
           archived: result.archived.length,
           removed: result.removed.length,
           skipped: result.skipped.length,
+          quarantined: result.quarantined.length,
+          // Full quarantine detail so a cron wrapper can alert + name the rows.
+          quarantined_memories: result.quarantined,
           unchanged: result.unchanged,
         }) + '\n',
       );
@@ -160,7 +163,20 @@ async function cmdExport(args: string[], deps: ExporterCliDeps): Promise<number>
           `Archived:   ${result.archived.length}\n` +
           `Removed:    ${result.removed.length}\n` +
           `Skipped:    ${result.skipped.length}\n` +
+          `Quarantined:${result.quarantined.length}\n` +
           `Unchanged:  ${result.unchanged}\n`,
+      );
+    }
+    // Quarantine is a partial-success signal, not a failure (the run still
+    // exported every healthy memory) — but make it LOUD on stderr so a cron
+    // wrapper or operator notices the set-aside rows and can fix them at source.
+    if (result.quarantined.length > 0) {
+      process.stderr.write(
+        `⚠ ${result.quarantined.length} memory(ies) quarantined (not exported):\n` +
+          result.quarantined
+            .map((q) => `  - ${q.id} [category=${q.category || '<none>'}]: ${q.reason}`)
+            .join('\n') +
+          '\n',
       );
     }
     return 0;

--- a/apps/git-exporter/src/diff/change-detector.ts
+++ b/apps/git-exporter/src/diff/change-detector.ts
@@ -21,15 +21,21 @@ export function detectChanges(
   const exportState = exportStateRepo.get(config.targetId);
 
   let memories: CuratedMemory[];
+  // Read failures (5bm.12): a row that fails domain validation on read — e.g. a
+  // legacy category later removed from the enum — is isolated per-row rather than
+  // aborting the batch, then quarantined below alongside mapping failures.
+  const readFailures: Array<{ id: string; reason: string }> = [];
 
   if (config.tenantId !== undefined) {
-    memories = memoryRepo.findByTenant(config.tenantId);
+    const res = memoryRepo.findByTenantResilient(config.tenantId);
+    memories = res.memories;
+    readFailures.push(...res.failures);
   } else {
-    const active = memoryRepo.findByLifecycle('active');
-    const deprecated = memoryRepo.findByLifecycle('deprecated');
-    const superseded = memoryRepo.findByLifecycle('superseded');
-    const archived = memoryRepo.findByLifecycle('archived');
-    memories = [...active, ...deprecated, ...superseded, ...archived];
+    const parts = (['active', 'deprecated', 'superseded', 'archived'] as const).map((lc) =>
+      memoryRepo.findByLifecycleResilient(lc),
+    );
+    memories = parts.flatMap((p) => p.memories);
+    readFailures.push(...parts.flatMap((p) => p.failures));
   }
 
   if (exportState !== null) {
@@ -38,19 +44,39 @@ export function detectChanges(
 
   const toWrite: ExportChangeset['toWrite'] = [];
   const toArchive: ExportChangeset['toArchive'] = [];
+  // A row we could not even deserialize is quarantined with an empty category —
+  // we never got a valid domain object to read one from.
+  const quarantined: ExportChangeset['quarantined'] = readFailures.map((f) => ({
+    id: f.id,
+    category: '',
+    reason: f.reason,
+  }));
 
   for (const memory of memories) {
-    if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
-      // File may currently live in its category directory (from when it was active).
-      const categoryDir = getCategoryDirectory(memory.category);
-      const fromPath = join(config.outputDir, categoryDir, `${memory.id}.md`);
-      const toPath = join(config.outputDir, getRelativePath(memory));
-      toArchive.push({ memory, fromPath, toPath });
-    } else {
-      const filePath = join(config.outputDir, getRelativePath(memory));
-      toWrite.push({ memory, filePath });
+    // Per-memory quarantine (5bm.12): the directory-mapper is fail-closed (5bm.5)
+    // and throws on an unknown category. Catch it here so ONE malformed memory
+    // is set aside and reported — not allowed to abort the export of every other
+    // memory. A quarantined memory is neither written nor silently dropped into
+    // curated/; the operator fixes it at source (recategorize, 5bm.7).
+    try {
+      if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
+        // File may currently live in its category directory (from when it was active).
+        const categoryDir = getCategoryDirectory(memory.category);
+        const fromPath = join(config.outputDir, categoryDir, `${memory.id}.md`);
+        const toPath = join(config.outputDir, getRelativePath(memory));
+        toArchive.push({ memory, fromPath, toPath });
+      } else {
+        const filePath = join(config.outputDir, getRelativePath(memory));
+        toWrite.push({ memory, filePath });
+      }
+    } catch (err) {
+      quarantined.push({
+        id: memory.id,
+        category: memory.category ?? '',
+        reason: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
-  return { toWrite, toArchive, toRemove: [] };
+  return { toWrite, toArchive, toRemove: [], quarantined };
 }

--- a/apps/git-exporter/src/exporter.ts
+++ b/apps/git-exporter/src/exporter.ts
@@ -42,6 +42,9 @@ export function runExport(
   const archived: string[] = [];
   const removed: string[] = [];
   const skipped: string[] = [];
+  // Carry forward the memories the change-detector could not map (5bm.12) and
+  // append any that fail during formatting/writing below.
+  const quarantined = [...changeset.quarantined];
   let unchanged = 0;
 
   for (const item of changeset.toWrite) {
@@ -49,19 +52,29 @@ export function runExport(
       skipped.push(item.memory.id);
       continue;
     }
-    const content = formatMemoryAsMarkdown(item.memory);
+    // Per-memory quarantine (5bm.12): a formatter/write failure on one memory
+    // must not abort the whole run — set it aside and keep exporting the rest.
+    try {
+      const content = formatMemoryAsMarkdown(item.memory);
 
-    // Skip if file content is already identical (idempotency guard)
-    if (existsSync(item.filePath)) {
-      const existing = readFileSync(item.filePath, 'utf8');
-      if (existing === content) {
-        unchanged++;
-        continue;
+      // Skip if file content is already identical (idempotency guard)
+      if (existsSync(item.filePath)) {
+        const existing = readFileSync(item.filePath, 'utf8');
+        if (existing === content) {
+          unchanged++;
+          continue;
+        }
       }
-    }
 
-    writeFile(item.filePath, content);
-    written.push(item.filePath);
+      writeFile(item.filePath, content);
+      written.push(item.filePath);
+    } catch (err) {
+      quarantined.push({
+        id: item.memory.id,
+        category: item.memory.category ?? '',
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   for (const item of changeset.toArchive) {
@@ -69,9 +82,17 @@ export function runExport(
       skipped.push(item.memory.id);
       continue;
     }
-    const content = formatMemoryAsMarkdown(item.memory);
-    archiveFile(item.fromPath, item.toPath, content);
-    archived.push(item.toPath);
+    try {
+      const content = formatMemoryAsMarkdown(item.memory);
+      archiveFile(item.fromPath, item.toPath, content);
+      archived.push(item.toPath);
+    } catch (err) {
+      quarantined.push({
+        id: item.memory.id,
+        category: item.memory.category ?? '',
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   for (const filePath of changeset.toRemove) {
@@ -87,6 +108,7 @@ export function runExport(
     archived,
     removed,
     skipped,
+    quarantined,
     unchanged,
     totalProcessed:
       changeset.toWrite.length + changeset.toArchive.length + changeset.toRemove.length,

--- a/apps/git-exporter/src/types.ts
+++ b/apps/git-exporter/src/types.ts
@@ -9,6 +9,22 @@ export interface ExportConfig {
   tenantId?: string;
 }
 
+/**
+ * A memory that could not be exported and was set aside (5bm.12) instead of
+ * aborting the whole run — e.g. an unknown category the fail-closed
+ * directory-mapper (5bm.5) refuses to place. Reported so the operator can fix
+ * it at source (recategorize, 5bm.7); recategorizing bumps `updatedAt`, which
+ * naturally re-enters the memory into the next export once it maps cleanly.
+ */
+export interface QuarantinedMemory {
+  /** Memory id set aside. */
+  id: string;
+  /** The category that could not be mapped (empty string if unavailable). */
+  category: string;
+  /** Human-readable reason the memory was quarantined. */
+  reason: string;
+}
+
 export interface ExportResult {
   /** File paths written */
   written: string[];
@@ -18,6 +34,8 @@ export interface ExportResult {
   removed: string[];
   /** Memory IDs skipped due to sensitivity restrictions */
   skipped: string[];
+  /** Memories set aside due to an unmappable/unformattable state (5bm.12) */
+  quarantined: QuarantinedMemory[];
   /** Count of files that didn't need updating */
   unchanged: number;
   totalProcessed: number;
@@ -45,4 +63,6 @@ export interface ExportChangeset {
   toWrite: Array<{ memory: CuratedMemory; filePath: string }>;
   toArchive: Array<{ memory: CuratedMemory; fromPath: string; toPath: string }>;
   toRemove: string[];
+  /** Memories that could not be mapped to a path and were set aside (5bm.12). */
+  quarantined: QuarantinedMemory[];
 }

--- a/packages/store/src/__tests__/memory-repository-resilient-read.test.ts
+++ b/packages/store/src/__tests__/memory-repository-resilient-read.test.ts
@@ -1,0 +1,90 @@
+/**
+ * MemoryRepository resilient batch-read tests (bead qmd-team-intent-kb-5bm.12).
+ *
+ * `findByLifecycle` / `findByTenant` map every row through `rowToMemory`, which
+ * THROWS on a row that fails domain validation (e.g. a legacy category later
+ * removed from the enum). One such row therefore aborts the whole batch — and,
+ * downstream, the whole git-export run. `findByLifecycleResilient` /
+ * `findByTenantResilient` isolate the failure per-row so healthy memories still
+ * come back and the bad row is reported for quarantine.
+ *
+ * A genuinely-corrupt row is planted by inserting a valid memory then raw-
+ * UPDATE-ing its category under `ignore_check_constraints` — exactly the shape
+ * of a pre-CHECK legacy row (SQLite CHECK guards writes, not existing data).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { MemoryRepository } from '../repositories/memory-repository.js';
+import { makeMemory } from './fixtures.js';
+
+/** Plant an off-vocabulary category on an existing row, bypassing the CHECK. */
+function corruptCategory(db: Database.Database, id: string, badCategory: string): void {
+  db.pragma('ignore_check_constraints = ON');
+  try {
+    db.prepare('UPDATE curated_memories SET category = ? WHERE id = ?').run(badCategory, id);
+  } finally {
+    db.pragma('ignore_check_constraints = OFF');
+  }
+}
+
+describe('MemoryRepository.findByLifecycleResilient (5bm.12)', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  it('returns healthy memories and isolates a corrupt row instead of throwing', () => {
+    const good = makeMemory({ title: 'Healthy', lifecycle: 'active' });
+    const bad = makeMemory({ title: 'Corrupt', lifecycle: 'active', contentHash: 'c'.repeat(64) });
+    repo.insert(good);
+    repo.insert(bad);
+    corruptCategory(db, bad.id, 'not-a-real-category');
+
+    // The strict read blows up the whole batch on the corrupt row...
+    expect(() => repo.findByLifecycle('active')).toThrow();
+
+    // ...the resilient read returns the healthy one and names the bad one.
+    const { memories, failures } = repo.findByLifecycleResilient('active');
+    expect(memories.map((m) => m.id)).toEqual([good.id]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]!.id).toBe(bad.id);
+    expect(failures[0]!.reason).toMatch(/category/i);
+  });
+
+  it('reports no failures when every row is valid', () => {
+    repo.insert(makeMemory({ lifecycle: 'active' }));
+    const { memories, failures } = repo.findByLifecycleResilient('active');
+    expect(memories).toHaveLength(1);
+    expect(failures).toHaveLength(0);
+  });
+});
+
+describe('MemoryRepository.findByTenantResilient (5bm.12)', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  it('isolates a corrupt tenant row', () => {
+    const good = makeMemory({ tenantId: 'team-alpha', title: 'Good' });
+    const bad = makeMemory({
+      tenantId: 'team-alpha',
+      title: 'Bad',
+      contentHash: 'd'.repeat(64),
+    });
+    repo.insert(good);
+    repo.insert(bad);
+    corruptCategory(db, bad.id, 'nope');
+
+    const { memories, failures } = repo.findByTenantResilient('team-alpha');
+    expect(memories.map((m) => m.id)).toEqual([good.id]);
+    expect(failures.map((f) => f.id)).toEqual([bad.id]);
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -10,6 +10,10 @@ export {
   MemoryRepository,
   InvalidLifecycleTransitionError,
 } from './repositories/memory-repository.js';
+export type {
+  RowDeserializationFailure,
+  ResilientReadResult,
+} from './repositories/memory-repository.js';
 export { PolicyRepository } from './repositories/policy-repository.js';
 export { AuditRepository } from './repositories/audit-repository.js';
 export type { AuditChainRow } from './repositories/audit-repository.js';

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -53,6 +53,43 @@ const MemoryRowSchema = z.object({
  * @returns validated CuratedMemory
  * @throws Error with row id and Zod issue details if parsing fails
  */
+/** One row that could not be deserialized into a CuratedMemory (5bm.12). */
+export interface RowDeserializationFailure {
+  /** The row's primary key, or '<unknown>' if even that could not be read. */
+  id: string;
+  /** Why deserialization failed. */
+  reason: string;
+}
+
+/** Result of a resilient (per-row error-isolated) batch read (5bm.12). */
+export interface ResilientReadResult {
+  memories: CuratedMemory[];
+  failures: RowDeserializationFailure[];
+}
+
+/**
+ * Deserialize rows one-by-one, collecting per-row failures instead of letting
+ * one bad row abort the whole batch (5bm.12). The DB always stores the primary
+ * key in the `id` column, so a failure can still name the offending row even
+ * when its domain validation fails.
+ */
+function deserializeRowsResilient(rows: unknown[]): ResilientReadResult {
+  const memories: CuratedMemory[] = [];
+  const failures: RowDeserializationFailure[] = [];
+  for (const row of rows) {
+    try {
+      memories.push(rowToMemory(row));
+    } catch (err) {
+      const rawId = (row as { id?: unknown } | null)?.id;
+      failures.push({
+        id: typeof rawId === 'string' ? rawId : '<unknown>',
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return { memories, failures };
+}
+
 function rowToMemory(row: unknown): CuratedMemory {
   const flatResult = MemoryRowSchema.safeParse(row);
   if (!flatResult.success) {
@@ -383,6 +420,23 @@ export class MemoryRepository {
   findByLifecycle(lifecycle: MemoryLifecycleState): CuratedMemory[] {
     const rows = this.stmtFindByLifecycle.all(lifecycle);
     return rows.map(rowToMemory);
+  }
+
+  /**
+   * Like {@link findByLifecycle} but isolates per-row deserialization failures
+   * (5bm.12) instead of throwing the whole batch when one row fails domain
+   * validation (e.g. a legacy category later removed from the enum). Used by the
+   * git-exporter so a single corrupt row is quarantined + reported, not allowed
+   * to abort the export of every healthy memory. Strict callers keep using
+   * {@link findByLifecycle}.
+   */
+  findByLifecycleResilient(lifecycle: MemoryLifecycleState): ResilientReadResult {
+    return deserializeRowsResilient(this.stmtFindByLifecycle.all(lifecycle));
+  }
+
+  /** Tenant-scoped counterpart of {@link findByLifecycleResilient} (5bm.12). */
+  findByTenantResilient(tenantId: string): ResilientReadResult {
+    return deserializeRowsResilient(this.stmtFindByTenant.all(tenantId));
   }
 
   /**


### PR DESCRIPTION
## What
Completes the deferred hardening of `5bm.5`. The fail-closed directory-mapper (5bm.5) correctly throws on an unknown category — but that turned **one** malformed memory into a **whole-run abort**: no files written, export state untouched, the entire governed corpus stops publishing. Worse, the *realistic* corrupt-row case (a legacy category later removed from the enum) throws even earlier — at `rowToMemory` **read** time, before the mapper is reached. This makes the export resilient at **both** boundaries: a single bad memory is set aside ("quarantined") and reported; every healthy memory still exports.

## Why (decision rationale)
**Chose resilient-read methods on the store over making `findByLifecycle` itself skip-and-collect**, because the strict throw-the-batch contract is correct for every *other* caller (govern, API) — only the exporter wants best-effort. A quarantined memory is neither written nor silently laundered into `curated/`; the fix is at source via recategorize (`5bm.7`), which bumps `updatedAt` and naturally re-enters the memory into the next export once it maps cleanly.

## Layers touched
- **store** — `findByLifecycleResilient` / `findByTenantResilient` + `deserializeRowsResilient` (per-row error isolation). Strict readers unchanged. New exported types `RowDeserializationFailure`, `ResilientReadResult`.
- **compile→export boundary** — `change-detector` reads resiliently and seeds a new `ExportChangeset.quarantined[]`; per-memory mapping wrapped so a mapper throw also quarantines. `exporter` wraps format+write per memory; `ExportResult` gains `quarantined: QuarantinedMemory[]`.
- **cli** — `Quarantined: N` line, full list in JSON (`quarantined_memories`), LOUD ⚠ stderr block naming each row. **Exit stays 0** — a partial export that published every healthy memory is a success.

No invariant change to govern; this is export-path availability.

## How it works
Rows are deserialized one-by-one; a domain-validation failure becomes `{id, reason}` instead of throwing the batch. Read-failure rows can't be `updatedAt`-filtered (we can't read them), so they **re-report every run until fixed** — deliberate: a corrupt row should keep nagging, not vanish. Mapping/format failures self-heal on recategorize.

## Verification & evidence
- **store: 258 pass** (+3 — resilient read isolates a corrupt row the *strict* read throws on; clean batch reports zero failures; tenant variant).
- **git-exporter: 115 pass** (+3 — `runExport` quarantines a corrupt-category row and still writes both healthy ones with no file for the bad one; empty-quarantine happy path; `change-detector` isolates an unreadable row).
- Corrupt rows planted realistically via `ignore_check_constraints` + raw `UPDATE` — the exact shape of a pre-CHECK legacy row (SQLite CHECK guards writes, not existing data).
- `tsc -b` clean · `eslint` clean · `prettier` formatted.

## Risk assessment
Low. `ExportResult` / `ExportChangeset` gain a field (additive; no caller reads a fixed shape). Behavior change is **strictly more available** — the exporter now completes where it previously threw. No schema/migration. Store's strict readers are untouched, so govern/API behavior is unchanged.

## Operational impact
None at deploy — no migration, no new env. Takes effect on the next exporter release.

## Follow-up
- The whole-machine/compile cron should alert on `quarantined > 0` (JSON `.quarantined`) — ops wiring, not code; to be noted in the backup/ops runbook.

Refs jeremylongshore/qmd-team-intent-kb#170

- Jeremy Longshore
intentsolutions.io