### PR TITLE
feat(store): backfill enum CHECK constraints onto the live curated_memories table (5bm.9)

### DIFF
--- a/packages/store/src/__tests__/migration-v9-check-backfill.test.ts
+++ b/packages/store/src/__tests__/migration-v9-check-backfill.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Migration v9 — enum CHECK-constraint backfill (bead qmd-team-intent-kb-5bm.9).
+ *
+ * New DBs get the CHECK constraints from CURATED_MEMORIES_DDL, so v9 is a no-op
+ * for them (covered implicitly by the whole suite still passing). These tests
+ * exercise the REAL path: a LEGACY `curated_memories` table with NO CHECK
+ * constraints (the shape of a pre-5bm.1 live DB), rebuilt in place on the next
+ * `createDatabase`. We assert the constraints land, every row + rowid survives,
+ * the external-content FTS index still resolves, the memory_links foreign key
+ * stays intact, and a row that violates the new constraints aborts the whole
+ * migration (fail-closed) rather than silently dropping data.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createDatabase } from '../database.js';
+
+/** The pre-5bm.1 `curated_memories` DDL: identical columns, NO CHECK clauses. */
+const LEGACY_CURATED_MEMORIES = `
+CREATE TABLE curated_memories (
+  id TEXT PRIMARY KEY,
+  candidate_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  content TEXT NOT NULL,
+  title TEXT NOT NULL,
+  category TEXT NOT NULL,
+  trust_level TEXT NOT NULL,
+  sensitivity TEXT NOT NULL DEFAULT 'internal',
+  author_json TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  lifecycle TEXT NOT NULL DEFAULT 'active',
+  content_hash TEXT NOT NULL,
+  policy_evaluations_json TEXT NOT NULL DEFAULT '[]',
+  supersession_json TEXT,
+  promoted_at TEXT NOT NULL,
+  promoted_by_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1
+);
+CREATE VIRTUAL TABLE curated_memories_fts USING fts5(
+  title, content, content='curated_memories', content_rowid='rowid'
+);
+CREATE TRIGGER curated_memories_fts_insert AFTER INSERT ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(rowid, title, content) VALUES (new.rowid, new.title, new.content);
+END;
+CREATE TRIGGER curated_memories_fts_delete AFTER DELETE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+END;
+CREATE TRIGGER curated_memories_fts_update AFTER UPDATE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+  INSERT INTO curated_memories_fts(rowid, title, content) VALUES (new.rowid, new.title, new.content);
+END;
+CREATE TABLE memory_links (
+  id TEXT PRIMARY KEY,
+  source_memory_id TEXT NOT NULL REFERENCES curated_memories(id),
+  target_memory_id TEXT NOT NULL REFERENCES curated_memories(id),
+  link_type TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  created_by TEXT NOT NULL,
+  source TEXT NOT NULL,
+  import_batch_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(source_memory_id, target_memory_id, link_type)
+);
+CREATE TABLE schema_migrations (
+  version INTEGER PRIMARY KEY, name TEXT NOT NULL,
+  applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;
+
+function insertLegacyMemory(
+  db: Database.Database,
+  id: string,
+  overrides: Record<string, string> = {},
+): void {
+  const row = {
+    id,
+    candidate_id: `cand-${id}`,
+    source: 'import',
+    content: `content for ${id}`,
+    title: `title ${id}`,
+    category: 'reference',
+    trust_level: 'medium',
+    sensitivity: 'internal',
+    author_json: '{"type":"system","id":"legacy"}',
+    tenant_id: 'default',
+    lifecycle: 'active',
+    content_hash: id.repeat(4).slice(0, 64).padEnd(64, '0'),
+    promoted_at: '2026-01-01T00:00:00.000Z',
+    promoted_by_json: '{"type":"system","id":"curator"}',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+  db.prepare(
+    `INSERT INTO curated_memories
+       (id, candidate_id, source, content, title, category, trust_level, sensitivity,
+        author_json, tenant_id, lifecycle, content_hash, promoted_at, promoted_by_json, updated_at)
+     VALUES
+       (@id, @candidate_id, @source, @content, @title, @category, @trust_level, @sensitivity,
+        @author_json, @tenant_id, @lifecycle, @content_hash, @promoted_at, @promoted_by_json, @updated_at)`,
+  ).run(row);
+}
+
+/** Build a legacy (pre-CHECK, migrations@8) DB file and return its path. */
+function buildLegacyDb(dir: string, seed: (db: Database.Database) => void): string {
+  const dbPath = join(dir, 'legacy.db');
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(LEGACY_CURATED_MEMORIES);
+  for (let v = 1; v <= 8; v++) {
+    db.prepare('INSERT INTO schema_migrations (version, name) VALUES (?, ?)').run(v, `legacy-${v}`);
+  }
+  seed(db);
+  db.close();
+  return dbPath;
+}
+
+describe('migration v9 — CHECK backfill on a legacy table (5bm.9)', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('adds CHECK constraints, preserves every row + rowid, keeps FTS and FKs intact', () => {
+    dir = mkdtempSync(join(tmpdir(), 'v9-legacy-'));
+    const dbPath = buildLegacyDb(dir, (db) => {
+      insertLegacyMemory(db, 'aaaaaaaa', { category: 'decision', title: 'alpha widget' });
+      insertLegacyMemory(db, 'bbbbbbbb', { category: 'pattern', title: 'beta gadget' });
+      db.prepare(
+        `INSERT INTO memory_links (id, source_memory_id, target_memory_id, link_type, created_by, source)
+         VALUES ('lnk1', 'aaaaaaaa', 'bbbbbbbb', 'related', 'system', 'import')`,
+      ).run();
+    });
+
+    // Sanity: the legacy table has NO check and is at version 8.
+    const pre = new Database(dbPath, { readonly: true });
+    expect(
+      (
+        pre.prepare("SELECT sql FROM sqlite_schema WHERE name='curated_memories'").get() as {
+          sql: string;
+        }
+      ).sql,
+    ).not.toMatch(/CHECK/i);
+    pre.close();
+
+    // Reopening through createDatabase runs migrations → v9 rebuild.
+    const db = createDatabase({ path: dbPath });
+    try {
+      // 1. CHECK constraints now present.
+      const ddl = (
+        db.prepare("SELECT sql FROM sqlite_schema WHERE name='curated_memories'").get() as {
+          sql: string;
+        }
+      ).sql;
+      expect(ddl).toMatch(/CHECK\s*\(\s*category\s+IN/i);
+      expect(ddl).toMatch(/CHECK\s*\(\s*sensitivity\s+IN/i);
+
+      // 2. Every row + its rowid preserved.
+      const rows = db
+        .prepare('SELECT rowid, id, category FROM curated_memories ORDER BY rowid')
+        .all() as Array<{ rowid: number; id: string; category: string }>;
+      expect(rows.map((r) => r.id)).toEqual(['aaaaaaaa', 'bbbbbbbb']);
+      expect(rows[0]!.rowid).toBe(1);
+      expect(rows[1]!.rowid).toBe(2);
+
+      // 3. External-content FTS still resolves by the preserved rowids.
+      const fts = db
+        .prepare(
+          "SELECT c.id FROM curated_memories_fts f JOIN curated_memories c ON c.rowid = f.rowid WHERE curated_memories_fts MATCH 'gadget'",
+        )
+        .all() as Array<{ id: string }>;
+      expect(fts.map((r) => r.id)).toEqual(['bbbbbbbb']);
+
+      // 4. memory_links FK row survives and referential integrity is clean.
+      expect((db.prepare('SELECT COUNT(*) AS n FROM memory_links').get() as { n: number }).n).toBe(
+        1,
+      );
+      expect((db.pragma('foreign_key_check') as unknown[]).length).toBe(0);
+
+      // 5. The new constraint actually rejects a bad write now.
+      expect(() =>
+        db
+          .prepare(
+            "INSERT INTO curated_memories (id, candidate_id, source, content, title, category, trust_level, sensitivity, author_json, tenant_id, content_hash, promoted_at, promoted_by_json, updated_at) VALUES ('x','c','import','y','z','not-a-category','medium','internal','{}','t','h','p','{}','u')",
+          )
+          .run(),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('fails closed (rolls back, keeps CHECK off) if a legacy row violates the new constraints', () => {
+    dir = mkdtempSync(join(tmpdir(), 'v9-bad-'));
+    const dbPath = buildLegacyDb(dir, (db) => {
+      insertLegacyMemory(db, 'good1111', { category: 'reference' });
+      insertLegacyMemory(db, 'bad22222', { category: 'totally-invalid-category' });
+    });
+
+    // The INSERT..SELECT into the CHECK'd table hits the bad row → migration throws.
+    expect(() => createDatabase({ path: dbPath })).toThrow();
+
+    // Transaction rolled back: the table is still the un-constrained legacy one,
+    // and no data was lost.
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const ddl = (
+        db.prepare("SELECT sql FROM sqlite_schema WHERE name='curated_memories'").get() as {
+          sql: string;
+        }
+      ).sql;
+      expect(ddl).not.toMatch(/CHECK/i);
+      expect(
+        (db.prepare('SELECT COUNT(*) AS n FROM curated_memories').get() as { n: number }).n,
+      ).toBe(2);
+      expect(
+        (
+          db.prepare('SELECT COALESCE(MAX(version),0) AS v FROM schema_migrations').get() as {
+            v: number;
+          }
+        ).v,
+      ).toBe(8);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/store/src/database.ts
+++ b/packages/store/src/database.ts
@@ -91,17 +91,52 @@ function runMigrations(db: Database.Database): void {
 
   if (pending.length === 0) return;
 
+  // A table-rebuild migration (5bm.9) does DROP + RENAME on a table referenced
+  // by a foreign key. `PRAGMA foreign_keys` is a no-op inside a transaction, so
+  // it must be toggled here, around the batch. We disable enforcement for the
+  // rebuild and re-verify integrity with `foreign_key_check` before commit.
+  const needsForeignKeysOff = pending.some((m) => m.rebuildsTable === true);
+  if (needsForeignKeysOff) {
+    db.pragma('foreign_keys = OFF');
+  }
+
   const applyAll = db.transaction(() => {
     for (const migration of pending) {
-      db.exec(migration.sql);
+      if (migration.apply !== undefined) {
+        migration.apply(db);
+      } else if (migration.sql !== undefined) {
+        db.exec(migration.sql);
+      } else {
+        throw new Error(
+          `Migration ${migration.version} (${migration.name}) has neither sql nor apply`,
+        );
+      }
       db.prepare('INSERT INTO schema_migrations (version, name) VALUES (?, ?)').run(
         migration.version,
         migration.name,
       );
     }
+    // Verify referential integrity inside the transaction so a violation rolls
+    // the whole rebuild back rather than committing a corrupt graph.
+    if (needsForeignKeysOff) {
+      const violations = db.pragma('foreign_key_check') as unknown[];
+      if (Array.isArray(violations) && violations.length > 0) {
+        throw new Error(
+          `Migration foreign_key_check found ${violations.length} violation(s): ${JSON.stringify(
+            violations,
+          )}`,
+        );
+      }
+    }
   });
 
-  applyAll();
+  try {
+    applyAll();
+  } finally {
+    if (needsForeignKeysOff) {
+      db.pragma('foreign_keys = ON');
+    }
+  }
 }
 
 /**

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -3,6 +3,8 @@
  * Each entry creates one table and its associated indexes idempotently.
  */
 
+import type Database from 'better-sqlite3';
+
 const CANDIDATES_DDL = `
 CREATE TABLE IF NOT EXISTS candidates (
   id TEXT PRIMARY KEY,
@@ -121,7 +123,112 @@ export const TABLE_DDL: string[] = [
 interface Migration {
   version: number;
   name: string;
-  sql: string;
+  /** Static DDL migration. Exactly one of `sql` / `apply` must be set. */
+  sql?: string;
+  /**
+   * Procedural migration (5bm.9) for changes SQL-only migrations can't express
+   * — e.g. a conditional table rebuild that must inspect the live schema first.
+   * Runs inside the same migration transaction as `sql` migrations.
+   */
+  apply?: (db: Database.Database) => void;
+  /**
+   * Set when this migration rebuilds a table referenced by a foreign key
+   * (DROP + RENAME). The runner disables `foreign_keys` for the batch and runs
+   * `foreign_key_check` before commit, since the pragma is a no-op inside a
+   * transaction and DROP of an FK-referenced table would otherwise fail.
+   */
+  rebuildsTable?: boolean;
+}
+
+/**
+ * The exact `curated_memories` schema as of migration v9 — a frozen snapshot,
+ * intentionally NOT a reference to CURATED_MEMORIES_DDL (migrations must not
+ * drift with the live DDL). Used only by the v9 rebuild below.
+ */
+const CURATED_MEMORIES_V9_REBUILD = `
+CREATE TABLE curated_memories_v9_new (
+  id TEXT PRIMARY KEY,
+  candidate_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('claude_session', 'manual', 'import', 'mcp', 'bulk_import')),
+  content TEXT NOT NULL,
+  title TEXT NOT NULL,
+  category TEXT NOT NULL CHECK (category IN ('decision', 'pattern', 'convention', 'architecture', 'troubleshooting', 'reference', 'onboarding')),
+  trust_level TEXT NOT NULL CHECK (trust_level IN ('high', 'medium', 'low', 'untrusted')),
+  sensitivity TEXT NOT NULL DEFAULT 'internal' CHECK (sensitivity IN ('public', 'internal', 'confidential', 'restricted')),
+  author_json TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  lifecycle TEXT NOT NULL DEFAULT 'active' CHECK (lifecycle IN ('active', 'deprecated', 'superseded', 'archived')),
+  content_hash TEXT NOT NULL,
+  policy_evaluations_json TEXT NOT NULL DEFAULT '[]',
+  supersession_json TEXT,
+  promoted_at TEXT NOT NULL,
+  promoted_by_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO curated_memories_v9_new (
+  rowid, id, candidate_id, source, content, title, category, trust_level, sensitivity,
+  author_json, tenant_id, metadata_json, lifecycle, content_hash, policy_evaluations_json,
+  supersession_json, promoted_at, promoted_by_json, updated_at, version
+)
+SELECT
+  rowid, id, candidate_id, source, content, title, category, trust_level, sensitivity,
+  author_json, tenant_id, metadata_json, lifecycle, content_hash, policy_evaluations_json,
+  supersession_json, promoted_at, promoted_by_json, updated_at, version
+FROM curated_memories;
+DROP TABLE curated_memories;
+ALTER TABLE curated_memories_v9_new RENAME TO curated_memories;
+CREATE INDEX idx_memories_tenant ON curated_memories(tenant_id);
+CREATE INDEX idx_memories_hash ON curated_memories(content_hash);
+CREATE INDEX idx_memories_lifecycle ON curated_memories(lifecycle);
+CREATE INDEX idx_memories_updated ON curated_memories(updated_at);
+CREATE INDEX idx_memories_tenant_lifecycle ON curated_memories(tenant_id, lifecycle);
+CREATE INDEX idx_memories_lifecycle_updated ON curated_memories(lifecycle, updated_at);
+CREATE INDEX idx_memories_tenant_category ON curated_memories(tenant_id, category);
+CREATE TRIGGER curated_memories_fts_insert
+AFTER INSERT ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(rowid, title, content)
+  VALUES (new.rowid, new.title, new.content);
+END;
+CREATE TRIGGER curated_memories_fts_delete
+AFTER DELETE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+END;
+CREATE TRIGGER curated_memories_fts_update
+AFTER UPDATE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+  INSERT INTO curated_memories_fts(rowid, title, content)
+  VALUES (new.rowid, new.title, new.content);
+END;
+`.trim();
+
+/**
+ * Migration v9 (bead 5bm.9): backfill the enum CHECK constraints onto a legacy
+ * `curated_memories` table. New DBs already get the constraints from
+ * CURATED_MEMORIES_DDL, so this is a NO-OP unless the live table predates 5bm.1
+ * (detected by the absence of a category CHECK) — giving it zero blast radius on
+ * fresh DBs and tests. When a legacy table IS found it is rebuilt in place
+ * (rowid preserved so the external-content FTS index stays valid), then the FTS
+ * index is rebuilt as belt-and-suspenders. `rebuildsTable` tells the runner to
+ * disable foreign_keys for the DROP + run foreign_key_check before commit.
+ */
+function applyCheckConstraintBackfill(db: Database.Database): void {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'curated_memories'")
+    .get() as { sql: string } | undefined;
+
+  // Already constrained (fresh DB from CURATED_MEMORIES_DDL) → nothing to do.
+  if (row !== undefined && /CHECK\s*\(\s*category\s+IN/i.test(row.sql)) {
+    return;
+  }
+
+  db.exec(CURATED_MEMORIES_V9_REBUILD);
+  // Rebuild the external-content FTS index from the (rowid-preserved) content so
+  // it is provably consistent regardless of any rowid edge case.
+  db.exec("INSERT INTO curated_memories_fts(curated_memories_fts) VALUES ('rebuild');");
 }
 
 export const MIGRATIONS: Migration[] = [
@@ -314,5 +421,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_seq ON audit_events(seq);
     sql: `
 CREATE INDEX IF NOT EXISTS idx_candidates_status_tenant ON candidates(status, tenant_id);
     `.trim(),
+  },
+  {
+    version: 9,
+    name: 'backfill_curated_memories_enum_check_constraints',
+    apply: applyCheckConstraintBackfill,
+    rebuildsTable: true,
   },
 ];


### PR DESCRIPTION
## What
5bm.1 added SQLite CHECK constraints (source/category/trust/sensitivity/lifecycle) to the `curated_memories` DDL — but **only new databases** get them; a brain created before 5bm.1 has an unconstrained table, so the DB layer isn't actually a backstop below the app-layer enum guard on the live data. Migration **v9** backfills the constraints onto a legacy table via a fail-closed, in-place rebuild, with **zero blast radius on fresh DBs**.

## Why (decision rationale)
**Chose a conditional procedural rebuild over an unconditional SQL migration** because an unconditional DROP+RENAME would fire on every fresh DB and every test run — huge blast radius for a constraint those DBs already have. The migration NO-OPs when a category CHECK is already present and only rebuilds a genuinely legacy table. rowid is **preserved** (not regenerated) because the FTS5 index is external-content (`content_rowid='rowid'`); regenerating would desync it.

## Layers touched
- **store/schema.ts** — `Migration` gains optional `apply(db)` (procedural — SQL can't inspect the live schema) + `rebuildsTable`. v9's `apply`: detect existing CHECK → no-op; else create `*_new` WITH CHECKs, `INSERT..SELECT` preserving rowid, DROP, RENAME, recreate 7 indexes + 3 FTS triggers, FTS `'rebuild'`. Rebuild DDL is a **frozen v9 snapshot**, not a reference to live DDL.
- **store/database.ts** — `runMigrations` supports `apply` migrations and, when any pending migration sets `rebuildsTable`, disables `foreign_keys` for the batch (the pragma is a no-op inside a transaction; DROP of the FK-referenced table would else fail) and runs `foreign_key_check` **before commit** so a broken graph rolls back.

No govern/API invariant change — this is a DB-layer backstop.

## How it works
On next DB open, migrations run; v9 rebuilds only if unconstrained. All FK enforcement is off during the DROP but re-verified via `foreign_key_check` inside the transaction, so any violation aborts + rolls back.

## Verification & evidence
- **store: 260 pass** (+2): a hand-built LEGACY table (no CHECK, migrations@8, real FTS + triggers + `memory_links` FK) is rebuilt on open — CHECKs land, rows + rowids preserved, FTS resolves, FK intact, `foreign_key_check` clean, bad write now rejected; and a legacy row that **violates** the new constraint aborts the whole migration (rolls back, table stays legacy, version stays 8, no data loss).
- **REAL-DATA test on a copy of the live brain (17,273 rows / 185 MB)**: migrated in ~2.5s → version 9, rows preserved (17273), all 3 CHECKs present, `integrity_check` + `quick_check` = **ok**, **0** `foreign_key_check` violations, FTS still resolves (17,213 hits for "the"), rowid contiguous 1..17273, 302 `memory_links` intact, bad-category insert rejected.
- `tsc -b` clean · `eslint` clean · `prettier` formatted.

## Risk assessment
Medium (table-rebuild path). Mitigated: no-op on already-constrained DBs; fail-closed + full rollback on any violation or FK break; **proven on a real copy of production data**. Backward-compatible — old API code writes conforming data, so the new CHECK never rejects legitimate writes.

## Operational impact
The live brain gets v9 the next time the API/tooling opens `~/.teamkb/teamkb.db`. All 17,273 live rows already conform (audited: every source/category/trust/sensitivity/lifecycle value in-vocabulary), so it applies cleanly. **Live apply is a separate backup-gated step**: quiesce API → back up → open once to migrate → verify → restart.

## Follow-up
- Live apply performed under `5bm.9` after merge (backup + restore-verified).

Refs jeremylongshore/qmd-team-intent-kb#170

- Jeremy Longshore
intentsolutions.io