### PR TITLE
feat(health): surface live-policy dormancy in the health check (5bm.10)

### DIFF
--- a/apps/api/src/__tests__/health.test.ts
+++ b/apps/api/src/__tests__/health.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import type Database from 'better-sqlite3';
-import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { createTestDatabase, PolicyRepository } from '@qmd-team-intent-kb/store';
+import { buildRecommendedPolicy } from '@qmd-team-intent-kb/policy-engine';
+import type { PolicyRule } from '@qmd-team-intent-kb/schema';
 import { buildApp } from '../app.js';
+
+const NOW = '2026-07-17T00:00:00.000Z';
 
 describe('GET /api/health', () => {
   let db: Database.Database;
@@ -37,5 +41,56 @@ describe('GET /api/health', () => {
     const res = await app.inject({ method: 'GET', url: '/api/health' });
     const body = res.json<{ version: string }>();
     expect(body.version).toBe('0.4.0');
+  });
+
+  // ─── Policy dormancy surfacing (5bm.10) ────────────────────────────────────
+
+  it('reports no policy dormancy when no policy exists', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.json<{ policyDormancy: unknown[] }>().policyDormancy).toEqual([]);
+  });
+
+  it('reports zero dormancy for the complete recommended policy', async () => {
+    new PolicyRepository(db).insert(buildRecommendedPolicy('acme', NOW));
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.json<{ policyDormancy: unknown[] }>().policyDormancy).toEqual([]);
+    expect(res.statusCode).toBe(200); // dormancy never degrades liveness
+  });
+
+  it('lists the dormant rule types for an incomplete enabled policy', async () => {
+    // Only two rules enabled — the shape of the pre-5bm.2 live policy.
+    const partial = buildRecommendedPolicy('acme', NOW);
+    const twoRules = partial.rules.filter(
+      (r: PolicyRule) => r.type === 'secret_detection' || r.type === 'content_length',
+    );
+    new PolicyRepository(db).insert({ ...partial, rules: twoRules });
+
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    const body = res.json<{
+      status: string;
+      policyDormancy: Array<{ policyName: string; dormantRuleTypes: string[] }>;
+    }>();
+    expect(res.statusCode).toBe(200);
+    expect(body.status).toBe('healthy'); // still live
+    expect(body.policyDormancy).toHaveLength(1);
+    // The six uncovered registered rule types are named.
+    expect(body.policyDormancy[0]!.dormantRuleTypes).toEqual(
+      expect.arrayContaining([
+        'tenant_match',
+        'source_trust',
+        'relevance_score',
+        'sensitivity_gate',
+        'dedup_check',
+        'content_sanitization',
+      ]),
+    );
+    expect(body.policyDormancy[0]!.dormantRuleTypes).not.toContain('secret_detection');
+  });
+
+  it('ignores a disabled policy for dormancy', async () => {
+    const partial = buildRecommendedPolicy('acme', NOW);
+    new PolicyRepository(db).insert({ ...partial, rules: [], enabled: false });
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.json<{ policyDormancy: unknown[] }>().policyDormancy).toEqual([]);
   });
 });

--- a/apps/api/src/services/health-service.ts
+++ b/apps/api/src/services/health-service.ts
@@ -1,4 +1,15 @@
 import type Database from 'better-sqlite3';
+import { PolicyRepository } from '@qmd-team-intent-kb/store';
+import { findUncoveredRuleTypes } from '@qmd-team-intent-kb/policy-engine';
+
+/** One active policy that leaves registered rules unenforced (5bm.10). */
+interface PolicyDormancy {
+  policyId: string;
+  policyName: string;
+  tenantId: string;
+  /** Registered rule types the policy does not actively enforce. */
+  dormantRuleTypes: string[];
+}
 
 /** Payload returned by the health endpoint. */
 interface HealthStatus {
@@ -6,6 +17,13 @@ interface HealthStatus {
   uptime: number;
   dbConnected: boolean;
   version: string;
+  /**
+   * Per-policy dormancy (5bm.10): any ENABLED policy that leaves registered
+   * rules inert. Empty means every active policy enforces the full registry.
+   * This does NOT affect liveness (`status`) — a dormant rule is a governance
+   * config signal an operator should act on, not a process outage.
+   */
+  policyDormancy: PolicyDormancy[];
 }
 
 /**
@@ -32,6 +50,34 @@ export class HealthService {
       uptime: Math.floor((Date.now() - this.startTime) / 1000),
       dbConnected,
       version: '0.4.0',
+      policyDormancy: dbConnected ? this.checkPolicyDormancy() : [],
     };
+  }
+
+  /**
+   * Inspect every ENABLED policy for registered rules it does not enforce
+   * (5bm.10). Read-only; failure to read policies degrades to an empty result
+   * rather than failing the health probe.
+   */
+  private checkPolicyDormancy(): PolicyDormancy[] {
+    try {
+      const policies = new PolicyRepository(this.db).list();
+      const dormant: PolicyDormancy[] = [];
+      for (const policy of policies) {
+        if (!policy.enabled) continue;
+        const dormantRuleTypes = findUncoveredRuleTypes(policy);
+        if (dormantRuleTypes.length > 0) {
+          dormant.push({
+            policyId: policy.id,
+            policyName: policy.name,
+            tenantId: policy.tenantId,
+            dormantRuleTypes,
+          });
+        }
+      }
+      return dormant;
+    } catch {
+      return [];
+    }
   }
 }

--- a/packages/store/src/__tests__/policy-repository.test.ts
+++ b/packages/store/src/__tests__/policy-repository.test.ts
@@ -38,6 +38,15 @@ describe('PolicyRepository', () => {
     expect(alphaResults[0]?.tenantId).toBe('team-alpha');
   });
 
+  it('list returns every policy across all tenants (5bm.10)', () => {
+    expect(repo.list()).toEqual([]);
+    repo.insert(makePolicy({ tenantId: 'team-alpha' }));
+    repo.insert(makePolicy({ tenantId: 'team-beta' }));
+    const all = repo.list();
+    expect(all).toHaveLength(2);
+    expect(all.map((p) => p.tenantId).sort()).toEqual(['team-alpha', 'team-beta']);
+  });
+
   it('update modifies an existing policy and returns true', () => {
     const policy = makePolicy();
     repo.insert(policy);

--- a/packages/store/src/repositories/policy-repository.ts
+++ b/packages/store/src/repositories/policy-repository.ts
@@ -71,10 +71,12 @@ export class PolicyRepository {
   private readonly stmtInsert: Database.Statement;
   private readonly stmtFindById: Database.Statement;
   private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtList: Database.Statement;
   private readonly stmtUpdate: Database.Statement;
   private readonly stmtDelete: Database.Statement;
 
   constructor(db: Database.Database) {
+    this.stmtList = db.prepare('SELECT * FROM governance_policies');
     this.stmtInsert = db.prepare(`
       INSERT INTO governance_policies (
         id, name, tenant_id, rules_json, enabled, version, created_at, updated_at
@@ -131,6 +133,14 @@ export class PolicyRepository {
   findByTenant(tenantId: string): GovernancePolicy[] {
     const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToPolicy);
+  }
+
+  /**
+   * Return every policy across all tenants (5bm.10) — used by the health/status
+   * dormancy check to find policies that leave registered rules unenforced.
+   */
+  list(): GovernancePolicy[] {
+    return this.stmtList.all().map(rowToPolicy);
   }
 
   /**


### PR DESCRIPTION
## What
The anti-dormancy machinery from `5bm.2` (`findUncoveredRuleTypes`) existed but was never wired into any live surface — so an operator had no way to **see** that the running brain's policy leaves registered rules inert. That's the exact condition that let the junk flood through: the live `~/.teamkb` policy enforces only **2 of 8** registered rule types. This wires per-policy dormancy into `GET /api/health`.

## Why (decision rationale)
Dormancy is reported as a **separate field, deliberately NOT folded into `status: healthy|degraded`** — chose informational-signal over liveness-failure because a dormant governance rule is a config issue an operator should act on, not a process outage; flipping health to `degraded` would trip uptime monitors and LB probes for a non-outage. A monitor alerts on `policyDormancy.length > 0`.

## Layers touched
- **store** — `PolicyRepository.list()` enumerates every policy across all tenants (the health check is DB-wide; `findByTenant` needed a tenant).
- **api (govern surface)** — `HealthService.check()` reports `policyDormancy`: for each ENABLED policy, the registered rule types it does not enforce. Read-only; fails open to an empty list on a policy-read error.

No govern invariant change — this is observability over the existing policy state.

## How it works
Each enabled policy is run through `findUncoveredRuleTypes` (compares the policy's enabled rule types against the full `RULE_REGISTRY`). Any policy leaving ≥1 rule dormant is named in the response with its uncovered types.

## Verification & evidence
- **api: 342 pass** (+4) — no dormancy when no policy; **zero** dormancy for the complete recommended policy; the **6 uncovered types named** for a 2-rule policy (liveness still `healthy`/200); a disabled policy is ignored.
- **store: 256 pass** (+1) — `list()` returns every policy across tenants.
- OpenAPI contract snapshot unchanged (health declares no response schema).
- `tsc -b` clean · `eslint` clean · `prettier` formatted.

## Risk assessment
Low. Additive response field; liveness semantics + HTTP status unchanged; no schema/migration; read-only + fail-open.

## Operational impact
None at deploy. After deploy, `GET /api/health` on the live brain will report the current 6 dormant rule types until the recommended policy is applied.

## Follow-up
- **Applying the complete recommended policy to the live `~/.teamkb` brain** (the other half of `5bm.10`) is done as a backup-gated operational step after merge — closes the dormancy this check now exposes.
- The plugin's `brain_status` could mirror this; `mcp-server` would need a `policy-engine` dep — deferred, coordinated with the plugin surface.

Refs jeremylongshore/qmd-team-intent-kb#170

- Jeremy Longshore
intentsolutions.io