### PR TITLE
docs(readme): reflect read-time sensitivity enforcement in govern hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Highlights:
 - **Supply-Chain Security** — Cosign keyless signing + SLSA Level 3 provenance for container images (Phase 10)
 - **Hybrid Retrieval** — qmd binary fused with a native FTS5 (BM25) backend via reciprocal-rank fusion (RRF, k=60), freshness + category rerank, and a stratified Recall@10/nDCG@10 eval ratchet gating ranking changes in CI (semantic sqlite-vec path deferred behind the eval gate)
 - **MCP Server** — local + team-brain tool surface for Claude Code; read tools always register, write tools are admin-gated, team mode proxies the remote brain over the tailnet
-- **Govern Hardening** — write-time enum-membership backstop + CHECK constraints on curated memories, lifecycle state-graph enforcement, sensitivity classified at promotion, fail-closed export category mapping, spool `schemaVersion` validation, and an anti-dormancy policy-coverage gate
+- **Govern Hardening** — write-time enum-membership backstop + CHECK constraints on curated memories, lifecycle state-graph enforcement, sensitivity persisted at promotion and enforced at read time (curated search never returns confidential/restricted memories), fail-closed export category mapping, spool `schemaVersion` validation, and an anti-dormancy policy-coverage gate
 
 ## Getting Started
 


### PR DESCRIPTION
## What
One-line addition to the README **Govern Hardening** highlight: sensitivity is now described as *persisted at promotion **and** enforced at read time (curated search never returns confidential/restricted memories)*, replacing the write-time-only phrasing "sensitivity classified at promotion".

## Why
Read-time sensitivity enforcement (epic 5bm, `5bm.11`) is merged and live on the brain — implemented at `apps/api/src/services/search-service.ts:134` and covered by `apps/api/src/__tests__/search.test.ts` ("excludes confidential and restricted memories from search results"). The README understated it as a write-time classification only, missing the deterministic govern guarantee that search never returns confidential/restricted content. The fused BM25/FTS5 RRF (k=60) model-free retrieval lines were already accurate and left untouched. No forbidden honesty words present (verified by grep). No version bump (stays v0.7.0 / Unreleased).

## Refs
Epic 5bm (ontology govern hardening); `5bm.11` read-time sensitivity enforcement.

- Jeremy Longshore
intentsolutions.io