### PR TITLE
chore(release): v0.8.0 — fused retrieval + ontology-govern epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-18
+
 ### Added
 
 - **Fused lexical retrieval on the production query path.** The dormant native FTS5 (BM25) backend

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qmd-team-intent-kb/root",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Governed team memory platform for Claude Code powered by qmd",
   "author": "Jeremy Longshore",


### PR DESCRIPTION
## What
Cuts **v0.8.0**, the first release since v0.7.0. Bumps root `package.json` 0.7.0 → 0.8.0 and finalizes the `[Unreleased]` changelog into a dated `## [0.8.0] - 2026-07-18` section.

## Why + decision rationale
Minor bump — substantial new capability, no breaking public API. Headliners: **qmd BM25 + native FTS5 reciprocal-rank fusion** on the serving path (model-free), the **`5bm` ontology-govern hardening** (enum backstop + CHECK constraints incl. the live-brain backfill migration, complete recommended policy + `/api/health` dormancy, read-time sensitivity enforcement, lifecycle state-graph guard, fail-closed export + per-memory quarantine, recategorize tool, `bulk_import` source), the **EPIC-0 team-bridge API hardening**, and a **CI-gated retrieval-eval ratchet**.

**Chose a clean v0.8.0 over skipping to v0.13.0**: the pre-existing `v0.8.0`–`v0.12.0` git tags were orphan artifacts of aborted release dispatches (no GitHub release; package.json never bumped past 0.7.0 at any of them). They were deleted and v0.8.0 re-cut for a coherent `v0.7.0 → v0.8.0` history; the tag push rebuilds + re-signs the edge-daemon container for v0.8.0 with correct content.

## Layer(s) touched
Release metadata only — `CHANGELOG.md` + root `package.json`. No code.

## Verification & evidence
- CHANGELOG conformance: dated header present + `Added`/`Changed`/`Fixed`/`Security` subsections, each with bullets.
- Root `package.json` is valid SemVer, monotonic forward from v0.7.0.
- Main CI green at the release base; this PR's CI (`pnpm validate` + `build`) gates before tagging.

## Risk
Low — version/changelog only, no code. The v0.8.0 tag (pushed after merge) triggers the existing signed-container build. Not npm-published.

## Operational impact
After merge: tag `v0.8.0` → signed edge-daemon image build; GitHub release created from this changelog section.

Refs jeremylongshore/qmd-team-intent-kb

- Jeremy Longshore
intentsolutions.io