### PR TITLE
fix(edge-daemon): repair the release container build (native deps + deploy filter)

### DIFF
--- a/apps/edge-daemon/deploy/Dockerfile
+++ b/apps/edge-daemon/deploy/Dockerfile
@@ -18,6 +18,12 @@ ENV PNPM_VERSION=9.15.4
 # Install pnpm via corepack (ships with Node 20; no extra network calls).
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
+# Native build toolchain for better-sqlite3 (node-gyp): the alpine base ships
+# neither Python nor a C++ compiler, so `pnpm install` fails to compile the
+# better-sqlite3 addon ("Could not find any Python installation to use"). Only
+# needed in the builder stage; the runtime stage copies the compiled output.
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /build
 
 # Copy workspace manifests first so Docker can cache the install layer
@@ -53,7 +59,11 @@ RUN pnpm --filter @qmd-team-intent-kb/edge-daemon... build
 
 # Prune the install tree to production-only deps so we only copy what the
 # runtime image needs.
-RUN pnpm --filter @qmd-team-intent-kb/edge-daemon... --prod deploy /app/deploy
+# `deploy` bundles exactly one project plus its (workspace + external) prod
+# deps — so the filter must name the single target WITHOUT the `...`
+# dependency-expansion suffix, which selects many projects and trips
+# ERR_PNPM_CANNOT_DEPLOY_MANY on pnpm 9.x.
+RUN pnpm --filter @qmd-team-intent-kb/edge-daemon --prod deploy /app/deploy
 
 
 # ---- Stage 2: runtime -------------------------------------------------------


### PR DESCRIPTION
## What
The edge-daemon image build in the Release workflow has been failing — no recent release (incl. v0.8.0, run 29648804678) produced a signed container. Two pre-existing bugs in `apps/edge-daemon/deploy/Dockerfile`:
1. `node:20-alpine` builder has **no Python / C++ toolchain**, so `pnpm install` can't compile `better-sqlite3` (`gyp ERR! Could not find any Python installation`). Added `apk add --no-cache python3 make g++` to the **builder stage only**.
2. `pnpm --filter …edge-daemon**...** --prod deploy` uses the `...` (with-deps) suffix → multiple projects → `ERR_PNPM_CANNOT_DEPLOY_MANY` on pnpm 9.x. Dropped the `...` (deploy is single-project; it still bundles workspace + external prod deps).

## Why (decision rationale)
Build tools in the builder stage, **chosen over** switching to a non-alpine base (which would bloat the runtime image). The runtime stage is untouched (multi-stage copy).

## Layer(s) touched
Ops/packaging only — one Dockerfile. No app code.

## Verification & evidence
Built the image **locally end-to-end** (`docker build -f apps/edge-daemon/deploy/Dockerfile .`): better-sqlite3 compiles → `tsc` build completes → `--prod deploy` prune succeeds → both stages export to a runnable image (`sha256:de448943…`). Exactly the step the v0.8.0 Release run failed on, now green.

## Risk
Low — Dockerfile-only. Builder layer grows (build tools); runtime image unchanged. Unblocks the signed-container + SLSA-provenance artifact.

## Operational impact
After merge, the v0.8.0 tag is re-pointed to include this fix so its Release workflow re-runs and produces the signed image.

Refs jeremylongshore/qmd-team-intent-kb

- Jeremy Longshore
intentsolutions.io