### PR TITLE
feat(policy-engine): add the contradiction_check rule with a pre-phase that no reject can skip

### DIFF
--- a/.policy-hash
+++ b/.policy-hash
@@ -6,4 +6,5 @@ e3d0746d3ae94d87ca6cfb8787ffa86901262e8334f6e0b9134b08f34e8563fc   packages/poli
 c7d87405ca41bc1848bc31a9177d7b53e9e7c082567d28d700dc4268072eeeb7   packages/policy-engine/src/rules/tenant-match-rule.ts
 b28f01e57900b09e33eafad6ac3bfe9e360b81216efafc63e70cbb7625876eea   packages/policy-engine/src/rules/sensitivity-gate-rule.ts
 b596ca83e40ebefd2dcbf8df62987b5d14039643ff1ff4e4f1c96ea370200a46   packages/policy-engine/src/rules/content-sanitization-rule.ts
+70e03af9c372e54f29a8d5e422b02101b4e61f7e08924c1b85bc1e26b31b4a12   packages/policy-engine/src/rules/contradiction-check-rule.ts
 9dcaced9c7eb0d61d1bd4c258796861f420fc50ac5b519e53e237cb7090a1359   packages/policy-engine/src/rules/index.ts

--- a/.policy-hash
+++ b/.policy-hash
@@ -6,4 +6,4 @@ e3d0746d3ae94d87ca6cfb8787ffa86901262e8334f6e0b9134b08f34e8563fc   packages/poli
 c7d87405ca41bc1848bc31a9177d7b53e9e7c082567d28d700dc4268072eeeb7   packages/policy-engine/src/rules/tenant-match-rule.ts
 b28f01e57900b09e33eafad6ac3bfe9e360b81216efafc63e70cbb7625876eea   packages/policy-engine/src/rules/sensitivity-gate-rule.ts
 b596ca83e40ebefd2dcbf8df62987b5d14039643ff1ff4e4f1c96ea370200a46   packages/policy-engine/src/rules/content-sanitization-rule.ts
-5087c3d7b23ecfadbac68e8d2f6f9d5dcffd94c738b05993f402a456b0f312a3   packages/policy-engine/src/rules/index.ts
+9dcaced9c7eb0d61d1bd4c258796861f420fc50ac5b519e53e237cb7090a1359   packages/policy-engine/src/rules/index.ts

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -111,6 +111,12 @@ export class PromotionService {
       pipelineResult = pipeline.evaluate(candidate, {
         existingHashes: new Set(tenantMemories.map((m) => m.contentHash)),
         tenantId,
+        // contradiction_check lookup (E1): reuse the tenant-scoped memory load
+        // above — ACTIVE lifecycle only, filtered to the requested category.
+        getActiveMemoriesInCategory: (category) =>
+          tenantMemories
+            .filter((m) => m.lifecycle === 'active' && m.category === category)
+            .map((m) => ({ id: m.id, content: m.content })),
       });
     }
 

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -111,6 +111,14 @@ export class Curator {
     const pipelineResult = pipeline.evaluate(candidate, {
       existingHashes: hashSet,
       tenantId: this.config.tenantId,
+      // contradiction_check lookup (E1): tenant-scoped ACTIVE memories filtered
+      // to the requested category. Queried lazily — the store is only hit when
+      // a contradiction rule actually runs.
+      getActiveMemoriesInCategory: (category) =>
+        this.deps.memoryRepo
+          .findByTenantAndLifecycle(this.config.tenantId, 'active')
+          .filter((m) => m.category === category)
+          .map((m) => ({ id: m.id, content: m.content })),
     });
 
     // Suppress the per-candidate reject receipt when configured (B1 sweep) — the

--- a/apps/curator/src/merge/merge-gate.ts
+++ b/apps/curator/src/merge/merge-gate.ts
@@ -344,6 +344,14 @@ export function mergeGovern(
     //     rule. Either way: quarantine, never write.
     let pipelineResult: PipelineResult | undefined;
     if (pipeline !== undefined) {
+      // NOTE (E1): `getActiveMemoriesInCategory` is deliberately NOT injected
+      // here, so `contradiction_check` passes vacuously in the merge path. The
+      // merge re-governs rows a clone ALREADY promoted; any non-approved outcome
+      // quarantines, so a contradiction flag here would silently drop
+      // near-similar-but-distinct rows at merge time — a semantic change to the
+      // fold, and a determinism hazard (the lookup would observe rows written
+      // earlier in this same pass). Contradiction review belongs to first
+      // promotion (curator / promotion service), not the re-govern fold.
       pipelineResult = pipeline.evaluate(candidate, {
         existingHashes,
         tenantId: options.tenantId,

--- a/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import type { PolicyRule, MemoryCategory } from '@qmd-team-intent-kb/schema';
+import { evaluateContradictionCheck } from '../rules/contradiction-check-rule.js';
+import type { ActiveMemorySnapshot, EvaluationContext } from '../types.js';
+import { makeCandidate, makeContext } from './fixtures.js';
+
+function makeRule(overrides?: Partial<PolicyRule>): PolicyRule {
+  return {
+    id: 'rule-contradiction_check',
+    type: 'contradiction_check',
+    action: 'flag',
+    enabled: true,
+    priority: 0,
+    parameters: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Wrap makeContext with a category-scoped active-memory map so tests can
+ * observe both the lookup wiring and the category scoping.
+ */
+function withActiveMemories(
+  context: EvaluationContext,
+  byCategory: Partial<Record<MemoryCategory, ActiveMemorySnapshot[]>>,
+): EvaluationContext {
+  return {
+    ...context,
+    getActiveMemoriesInCategory: (category) => byCategory[category] ?? [],
+  };
+}
+
+const CONVENTION_TEXT =
+  'Always wrap async boundaries in try/catch and convert failures to Result types for the caller.';
+// Same topic, heavily overlapping vocabulary, different text — the v1 target shape.
+const CONTRADICTING_TEXT =
+  'Never wrap async boundaries in try/catch and convert failures to Result types for the caller.';
+const DISJOINT_TEXT =
+  'Deploy the ingest daemon with systemd timers; blue-green swaps happen at the Caddy layer.';
+
+describe('evaluateContradictionCheck', () => {
+  it('passes vacuously when no active-memory lookup is injected', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT });
+    const result = evaluateContradictionCheck(candidate, makeRule(), makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    expect(result.reason).toMatch(/skipped/i);
+  });
+
+  it('flags a candidate with high token overlap against an active same-category memory', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-1', content: CONTRADICTING_TEXT }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('flag');
+    expect(result.reason).toContain('mem-1');
+    expect(result.reason).toMatch(/human review/i);
+    expect(result.score).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('stays silent on disjoint content in the same category', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-2', content: DISJOINT_TEXT }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('is category-scoped: an overlapping memory in ANOTHER category does not flag', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      // The near-identical text lives under 'decision', not the candidate's category.
+      decision: [{ id: 'mem-3', content: CONTRADICTING_TEXT }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('skips byte-identical content — exact duplication is dedup_check territory', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-4', content: CONVENTION_TEXT }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('never returns fail — the v1 contract is pass or flag only', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-5', content: CONTRADICTING_TEXT }],
+    });
+    // Even configured with action=reject, the evaluator's own outcome is 'flag'.
+    const result = evaluateContradictionCheck(candidate, makeRule({ action: 'reject' }), context);
+    expect(['pass', 'flag']).toContain(result.outcome);
+    expect(result.outcome).not.toBe('fail');
+  });
+
+  it('respects a custom threshold parameter', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-6', content: CONTRADICTING_TEXT }],
+    });
+    // Threshold 1.0: nothing short of full token-set overlap flags.
+    const strict = evaluateContradictionCheck(
+      candidate,
+      makeRule({ parameters: { threshold: 1.0 } }),
+      context,
+    );
+    expect(strict.outcome).toBe('pass');
+    // Threshold ~0: any overlap flags.
+    const loose = evaluateContradictionCheck(
+      candidate,
+      makeRule({ parameters: { threshold: 0.01 } }),
+      context,
+    );
+    expect(loose.outcome).toBe('flag');
+  });
+
+  it('names every suspect (capped) and reports the top similarity as score', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [
+        { id: 'mem-a', content: CONTRADICTING_TEXT },
+        { id: 'mem-b', content: `${CONVENTION_TEXT} Additionally prefer neverthrow.` },
+        { id: 'mem-c', content: DISJOINT_TEXT },
+      ],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('flag');
+    expect(result.reason).toContain('mem-a');
+    expect(result.reason).toContain('mem-b');
+    expect(result.reason).not.toContain('mem-c');
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('passes when the category has no active memories at all', () => {
+    const candidate = makeCandidate({ content: CONVENTION_TEXT, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {});
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
+});

--- a/packages/policy-engine/src/__tests__/pipeline.test.ts
+++ b/packages/policy-engine/src/__tests__/pipeline.test.ts
@@ -260,3 +260,95 @@ describe('PolicyPipeline', () => {
     expect(result.rejectedBy).toBe('rule-dedup_check');
   });
 });
+
+// ---------------------------------------------------------------------------
+// E1 ordering invariant: contradiction_check evaluates BEFORE any reject
+// short-circuit — structurally, not by priority convention.
+// ---------------------------------------------------------------------------
+
+describe('PolicyPipeline contradiction_check pre-phase (E1)', () => {
+  const CONVENTION_TEXT =
+    'Always wrap async boundaries in try/catch and convert failures to Result types for the caller.';
+  const CONTRADICTING_TEXT =
+    'Never wrap async boundaries in try/catch and convert failures to Result types for the caller.';
+
+  /** Lookup returning one active same-category memory that heavily overlaps. */
+  const contradictingLookup = (category: string) =>
+    category === 'convention' ? [{ id: 'mem-existing', content: CONTRADICTING_TEXT }] : [];
+
+  it('records the contradiction flag even when a reject rule also trips (reject cannot skip it)', () => {
+    // tenant_match rejects (context tenant mismatch) AND the candidate
+    // contradicts an existing memory. The reject rule carries priority 0 — the
+    // most favourable priority a reject rule can have — while contradiction_check
+    // carries the WORST priority, so only the structural pre-phase (not priority
+    // luck) can explain it running.
+    const policy = makePolicy([
+      makeRule('tenant_match', { action: 'reject', priority: 0 }),
+      makeRule('contradiction_check', { action: 'flag', priority: 99 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({
+      tenantId: 'team-alpha',
+      category: 'convention',
+      content: CONVENTION_TEXT,
+    });
+    const result = pipeline.evaluate(candidate, {
+      tenantId: 'team-beta',
+      getActiveMemoriesInCategory: contradictingLookup,
+    });
+
+    // The reject still wins the OUTCOME…
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('rule-tenant_match');
+    // …but the contradiction evaluation ran first and its flag is in the
+    // decision output.
+    expect(result.flaggedBy).toContain('rule-contradiction_check');
+    const contradictionEval = result.evaluations.find((e) => e.ruleType === 'contradiction_check');
+    expect(contradictionEval?.outcome).toBe('flag');
+    // Structural ordering: the contradiction evaluation precedes the rejecting one.
+    expect(result.evaluations[0]?.ruleType).toBe('contradiction_check');
+  });
+
+  it('evaluates contradiction rules first even when every priority favours the reject rule', () => {
+    const policy = makePolicy([
+      makeRule('content_length', {
+        action: 'reject',
+        priority: 0,
+        parameters: { min: 999999 }, // always fails → rejects
+      }),
+      makeRule('contradiction_check', { action: 'flag', priority: 100 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ category: 'convention', content: CONVENTION_TEXT });
+    const result = pipeline.evaluate(candidate, {
+      getActiveMemoriesInCategory: contradictingLookup,
+    });
+    expect(result.outcome).toBe('rejected');
+    expect(result.flaggedBy).toContain('rule-contradiction_check');
+    // Both evaluations are present: contradiction (pre-phase) + the rejecting rule.
+    expect(result.evaluations.map((e) => e.ruleType)).toEqual([
+      'contradiction_check',
+      'content_length',
+    ]);
+  });
+
+  it('flags (never rejects) on contradiction even when configured with action=reject', () => {
+    const policy = makePolicy([makeRule('contradiction_check', { action: 'reject' })]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ category: 'convention', content: CONVENTION_TEXT });
+    const result = pipeline.evaluate(candidate, {
+      getActiveMemoriesInCategory: contradictingLookup,
+    });
+    expect(result.outcome).toBe('flagged');
+    expect(result.rejectedBy).toBeUndefined();
+    expect(result.flaggedBy).toContain('rule-contradiction_check');
+  });
+
+  it('approves cleanly when the lookup is not injected (vacuous pass, like dedup)', () => {
+    const policy = makePolicy([makeRule('contradiction_check', { action: 'flag' })]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ category: 'convention', content: CONVENTION_TEXT });
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('approved');
+  });
+});

--- a/packages/policy-engine/src/__tests__/recommended-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/recommended-policy.test.ts
@@ -44,6 +44,7 @@ describe('RECOMMENDED_POLICY_RULES', () => {
       'sensitivity_gate',
       'dedup_check',
       'content_sanitization',
+      'contradiction_check',
     ] as const) {
       expect(byType.get(t)).toBe('flag');
     }
@@ -97,6 +98,7 @@ describe('findUncoveredRuleTypes + assertPolicyCompleteness', () => {
     expect(findUncoveredRuleTypes(twoRule)).toEqual(
       [
         'content_sanitization',
+        'contradiction_check',
         'dedup_check',
         'relevance_score',
         'sensitivity_gate',
@@ -130,6 +132,7 @@ describe('findUncoveredRuleTypes + assertPolicyCompleteness', () => {
         'dedup_check',
         'tenant_match',
         'content_sanitization',
+        'contradiction_check',
       ]),
     ).not.toThrow();
   });
@@ -142,7 +145,7 @@ describe('PolicyPipeline.dormantRuleTypes (runtime completeness gate, 5bm.2)', (
     expect(new PolicyPipeline(policy).dormantRuleTypes).toEqual([]);
   });
 
-  it('lists the 6 dormant rules of the audited 2-rule live shape', async () => {
+  it('lists the 7 dormant rules of the audited 2-rule live shape', async () => {
     const { PolicyPipeline } = await import('../pipeline.js');
     const twoRule = GovernancePolicy.parse({
       id: '22222222-2222-4222-8222-222222222222',
@@ -174,6 +177,7 @@ describe('PolicyPipeline.dormantRuleTypes (runtime completeness gate, 5bm.2)', (
     expect(new PolicyPipeline(twoRule).dormantRuleTypes).toEqual(
       [
         'content_sanitization',
+        'contradiction_check',
         'dedup_check',
         'relevance_score',
         'sensitivity_gate',

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,4 +1,10 @@
-export type { RuleResult, EvaluationContext, RuleEvaluator, PipelineResult } from './types.js';
+export type {
+  RuleResult,
+  EvaluationContext,
+  RuleEvaluator,
+  PipelineResult,
+  ActiveMemorySnapshot,
+} from './types.js';
 export { createRule, RULE_REGISTRY } from './rules/index.js';
 export { evaluateSecretDetection } from './rules/secret-detection-rule.js';
 export { evaluateContentLength } from './rules/content-length-rule.js';
@@ -8,6 +14,7 @@ export { evaluateDedupCheck } from './rules/dedup-check-rule.js';
 export { evaluateTenantMatch } from './rules/tenant-match-rule.js';
 export { evaluateSensitivityGate } from './rules/sensitivity-gate-rule.js';
 export { evaluateContentSanitization } from './rules/content-sanitization-rule.js';
+export { evaluateContradictionCheck } from './rules/contradiction-check-rule.js';
 export { PolicyPipeline } from './pipeline.js';
 export {
   RECOMMENDED_POLICY_RULES,

--- a/packages/policy-engine/src/pipeline.ts
+++ b/packages/policy-engine/src/pipeline.ts
@@ -6,13 +6,27 @@ import { findUncoveredRuleTypes } from './recommended-policy.js';
 /**
  * Executes the full governance policy pipeline against a memory candidate.
  *
- * Rule execution order:
- *   1. Sort by priority ascending (0 = highest priority, runs first)
- *   2. Skip disabled rules
- *   3. Execute each rule's evaluator
- *   4. On 'fail' + action='reject' → short-circuit and return 'rejected'
- *   5. On 'fail' + action='flag' OR outcome='flag' → record and continue
- *   6. After all rules → 'flagged' if any flags, otherwise 'approved'
+ * Rule execution is TWO-PHASE (E1 ordering invariant):
+ *
+ *   Phase 1 — contradiction rules (`contradiction_check`), ALWAYS evaluated
+ *   first, structurally outside the reject short-circuit. A candidate that
+ *   contradicts an existing active memory must carry that flag in the decision
+ *   output even when another rule rejects it — a reject must never mask a
+ *   contradiction signal. This phase is enforced by construction (a separate
+ *   loop that runs to completion before any short-circuit exists), not by
+ *   priority convention: no priority value can move a reject rule ahead of it.
+ *   Phase 1 can only flag, never reject — any non-pass outcome is recorded as
+ *   a flag regardless of the rule's configured action.
+ *
+ *   Phase 2 — every other rule:
+ *     1. Sort by priority ascending (0 = highest priority, runs first)
+ *     2. Skip disabled rules
+ *     3. Execute each rule's evaluator
+ *     4. On 'fail' + action='reject' → short-circuit and return 'rejected'
+ *        (phase-1 flags are preserved on the rejected result's `flaggedBy`)
+ *     5. On 'fail' + action='flag' OR outcome='flag' → record and continue
+ *
+ * After both phases → 'flagged' if any flags, otherwise 'approved'.
  */
 export class PolicyPipeline {
   private readonly policy: GovernancePolicy;
@@ -40,29 +54,54 @@ export class PolicyPipeline {
       policy: this.policy,
       existingHashes: partialContext.existingHashes,
       tenantId: partialContext.tenantId,
+      getActiveMemoriesInCategory: partialContext.getActiveMemoriesInCategory,
     };
 
-    // Sort enabled rules by priority ascending (lower number = higher priority)
-    const orderedRules = this.policy.rules
-      .filter((r) => r.enabled)
-      .sort((a, b) => a.priority - b.priority);
+    const enabledRules = this.policy.rules.filter((r) => r.enabled);
+    const byPriority = (a: (typeof enabledRules)[number], b: (typeof enabledRules)[number]) =>
+      a.priority - b.priority;
+
+    // Phase-1 / phase-2 partition — the ordering invariant lives in this split,
+    // not in priority numbers.
+    const contradictionRules = enabledRules
+      .filter((r) => r.type === 'contradiction_check')
+      .sort(byPriority);
+    const standardRules = enabledRules
+      .filter((r) => r.type !== 'contradiction_check')
+      .sort(byPriority);
 
     const evaluations: RuleResult[] = [];
     const flaggedBy: string[] = [];
 
-    for (const rule of orderedRules) {
+    // Phase 1: contradiction rules run to completion before any rule can
+    // short-circuit. Flag-only by construction: even a (future) evaluator
+    // returning 'fail' records a flag here, never a rejection.
+    for (const rule of contradictionRules) {
+      const evaluator = createRule(rule.type);
+      const result = evaluator(candidate, rule, context);
+      evaluations.push(result);
+      if (result.outcome !== 'pass') {
+        flaggedBy.push(rule.id);
+      }
+    }
+
+    // Phase 2: standard priority-ordered evaluation with reject short-circuit.
+    for (const rule of standardRules) {
       const evaluator = createRule(rule.type);
       const result = evaluator(candidate, rule, context);
       evaluations.push(result);
 
       if (result.outcome === 'fail') {
         if (rule.action === 'reject') {
-          // Hard stop — candidate is rejected
+          // Hard stop — candidate is rejected. Phase-1 contradiction flags (and
+          // any flags recorded earlier in this phase) survive on the result so
+          // the decision output still carries the contradiction signal.
           return {
             candidateId: candidate.id,
             outcome: 'rejected',
             evaluations,
             rejectedBy: rule.id,
+            ...(flaggedBy.length > 0 ? { flaggedBy } : {}),
           };
         }
         // action is 'flag' (or 'approve'/'require_review') — record as flagged and continue

--- a/packages/policy-engine/src/recommended-policy.ts
+++ b/packages/policy-engine/src/recommended-policy.ts
@@ -115,6 +115,19 @@ export const RECOMMENDED_POLICY_RULES: readonly PolicyRule[] = [
     parameters: {},
     description: 'Flag content that required sanitization.',
   },
+  {
+    // E1: flag-only in v1, and the pipeline evaluates contradiction rules in a
+    // dedicated pre-phase regardless of this priority number — the priority
+    // only orders it among other contradiction rules.
+    id: 'rec-contradiction-check',
+    type: 'contradiction_check',
+    action: 'flag',
+    enabled: true,
+    priority: 8,
+    parameters: {},
+    description:
+      'Flag candidates that heavily overlap an existing active same-category memory (potential contradiction, v1 token-overlap heuristic).',
+  },
 ];
 
 /**

--- a/packages/policy-engine/src/rules/contradiction-check-rule.ts
+++ b/packages/policy-engine/src/rules/contradiction-check-rule.ts
@@ -1,0 +1,125 @@
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+/**
+ * Default Jaccard token-overlap similarity at or above which a candidate is
+ * flagged as a potential contradiction of an existing active memory.
+ * Conservative on purpose: 0.6 means the two texts share well over half their
+ * combined vocabulary — same-topic territory — while ordinary same-category
+ * memories about different things sit far below it.
+ */
+const DEFAULT_THRESHOLD = 0.6;
+
+/** Cap on how many suspect memory ids are named in the flag reason. */
+const MAX_REPORTED = 5;
+
+/** Parse and clamp the similarity threshold from rule parameters. */
+function parseThreshold(params: Record<string, unknown> | undefined): number {
+  const raw = params?.['threshold'];
+  if (typeof raw !== 'number' || Number.isNaN(raw)) return DEFAULT_THRESHOLD;
+  return Math.min(1, Math.max(0, raw));
+}
+
+/** Lowercased alphanumeric token set of a text. */
+function tokenSet(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+}
+
+/** Jaccard similarity of two token sets: |A ∩ B| / |A ∪ B| (0 when both empty). */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Rule evaluator that flags a candidate whose content overlaps heavily with an
+ * existing ACTIVE memory in the SAME category without being byte-identical
+ * (GSB blueprint Track E1).
+ *
+ * ## v1 heuristic — token overlap, honestly stated
+ *
+ * Detection is Jaccard similarity over lowercased alphanumeric token sets.
+ * Token overlap is NOT semantic contradiction — "deploy on Fridays" and "never
+ * deploy on Fridays" score high, but so do two compatible restatements of the
+ * same convention. What high overlap reliably means is *same topic, different
+ * text*: exactly the shape a contradiction takes, and exactly what a human
+ * should read before the candidate is promoted. So v1 surfaces these for
+ * review; it never decides. Semantic contradiction detection is deliberately
+ * deferred (Wave-2 C3/E2 territory) and, per the core invariant, any model
+ * involvement would propose — this deterministic pipeline would still own the
+ * decision.
+ *
+ * ## Behavioural contract
+ *
+ * - Returns only `pass` or `flag`, NEVER `fail` — so no `action: 'reject'`
+ *   configuration can turn a v1 contradiction hit into a rejection.
+ * - Byte-identical content is skipped: exact duplication is `dedup_check`'s
+ *   job (which runs separately on content hashes); double-reporting it here
+ *   would be noise.
+ * - Scoped to the candidate's own category via
+ *   {@link EvaluationContext.getActiveMemoriesInCategory}; when the lookup is
+ *   not injected the rule passes vacuously (mirrors `dedup_check` without
+ *   `existingHashes`).
+ *
+ * Parameters:
+ * - threshold: number — Jaccard similarity in [0, 1] at or above which to flag
+ *   (default 0.6).
+ */
+export function evaluateContradictionCheck(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  context: EvaluationContext,
+): RuleResult {
+  if (context.getActiveMemoriesInCategory === undefined) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: 'No active-memory lookup provided — contradiction check skipped',
+    };
+  }
+
+  const threshold = parseThreshold(rule.parameters);
+  const candidateTokens = tokenSet(candidate.content);
+  const suspects: Array<{ id: string; similarity: number }> = [];
+
+  for (const memory of context.getActiveMemoriesInCategory(candidate.category)) {
+    // Byte-identical content is dedupe's job, not a contradiction.
+    if (memory.content === candidate.content) continue;
+    const similarity = jaccard(candidateTokens, tokenSet(memory.content));
+    if (similarity >= threshold) {
+      suspects.push({ id: memory.id, similarity });
+    }
+  }
+
+  if (suspects.length === 0) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: `No active '${candidate.category}' memory overlaps at or above ${threshold}`,
+    };
+  }
+
+  suspects.sort((a, b) => b.similarity - a.similarity);
+  const reported = suspects
+    .slice(0, MAX_REPORTED)
+    .map((s) => `${s.id} (${s.similarity.toFixed(2)})`)
+    .join(', ');
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'flag',
+    reason:
+      `Potential contradiction: high token overlap with ${suspects.length} active ` +
+      `'${candidate.category}' memor${suspects.length === 1 ? 'y' : 'ies'} — ${reported}. ` +
+      'v1 heuristic (token overlap, not semantic) — human review required.',
+    score: suspects[0]?.similarity,
+  };
+}

--- a/packages/policy-engine/src/rules/index.ts
+++ b/packages/policy-engine/src/rules/index.ts
@@ -8,6 +8,7 @@ import { evaluateDedupCheck } from './dedup-check-rule.js';
 import { evaluateTenantMatch } from './tenant-match-rule.js';
 import { evaluateSensitivityGate } from './sensitivity-gate-rule.js';
 import { evaluateContentSanitization } from './content-sanitization-rule.js';
+import { evaluateContradictionCheck } from './contradiction-check-rule.js';
 
 /** Registry mapping PolicyRuleType values to their evaluator functions */
 export const RULE_REGISTRY: Record<PolicyRuleType, RuleEvaluator> = {
@@ -19,6 +20,7 @@ export const RULE_REGISTRY: Record<PolicyRuleType, RuleEvaluator> = {
   tenant_match: evaluateTenantMatch,
   sensitivity_gate: evaluateSensitivityGate,
   content_sanitization: evaluateContentSanitization,
+  contradiction_check: evaluateContradictionCheck,
 };
 
 /**

--- a/packages/policy-engine/src/types.ts
+++ b/packages/policy-engine/src/types.ts
@@ -1,4 +1,9 @@
-import type { MemoryCandidate, GovernancePolicy, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type {
+  MemoryCandidate,
+  GovernancePolicy,
+  PolicyRule,
+  MemoryCategory,
+} from '@qmd-team-intent-kb/schema';
 
 /** Result of evaluating a single rule against a candidate */
 export interface RuleResult {
@@ -9,12 +14,32 @@ export interface RuleResult {
   score?: number; // for scoring rules (relevance, trust)
 }
 
+/**
+ * The minimal projection of an ACTIVE curated memory that the
+ * `contradiction_check` rule compares a candidate against (E1). Kept to
+ * id + content so callers can hand the rule a cheap snapshot — the rule itself
+ * stays pure and store-free; the caller that constructs the
+ * {@link EvaluationContext} owns the query.
+ */
+export interface ActiveMemorySnapshot {
+  id: string;
+  content: string;
+}
+
 /** Context provided to rule evaluators */
 export interface EvaluationContext {
   candidate: MemoryCandidate;
   policy: GovernancePolicy;
   existingHashes?: Set<string>; // for dedup checking
   tenantId?: string; // for tenant match validation
+  /**
+   * Injected lookup for `contradiction_check` (E1): return the ACTIVE curated
+   * memories of the caller's tenant in the given category. Injected by whoever
+   * constructs the context (curator / promotion service) so the rule stays a
+   * pure function; when absent the rule passes vacuously, exactly like
+   * `existingHashes` for dedup.
+   */
+  getActiveMemoriesInCategory?: (category: MemoryCategory) => readonly ActiveMemorySnapshot[];
 }
 
 /** Function signature for a rule evaluator */
@@ -30,5 +55,8 @@ export interface PipelineResult {
   outcome: 'approved' | 'rejected' | 'flagged';
   evaluations: RuleResult[];
   rejectedBy?: string; // ruleId that caused rejection
-  flaggedBy?: string[]; // ruleIds that flagged
+  // ruleIds that flagged. Present on 'flagged' results, and ALSO on 'rejected'
+  // results when a phase-1 contradiction rule (or an earlier flag rule) fired
+  // before the reject short-circuit (E1) — a reject never erases a flag.
+  flaggedBy?: string[];
 }

--- a/packages/schema/src/__tests__/enums.test.ts
+++ b/packages/schema/src/__tests__/enums.test.ts
@@ -93,9 +93,20 @@ describe('PolicyRuleType', () => {
     'tenant_match',
     'sensitivity_gate',
     'content_sanitization',
+    'contradiction_check',
   ];
   it.each(types)('accepts "%s"', (val) => {
     expect(PolicyRuleType.parse(val)).toBe(val);
+  });
+
+  // Membership lock-step guard: the accept-list above IS the full enum. If a
+  // member is added to the Zod enum without extending this list (or vice versa)
+  // this fails, forcing the same-PR update discipline the 5bm.1 DDL lock-step
+  // test enforces for the curated_memories column enums. (PolicyRuleType itself
+  // has NO DDL CHECK — rules live in governance_policies.rules_json — so this
+  // test is its only membership gate.)
+  it('the accept-list covers the entire enum (no untested members)', () => {
+    expect([...types].sort()).toEqual([...PolicyRuleType.options].sort());
   });
   it('rejects invalid value', () => {
     expect(() => PolicyRuleType.parse('custom')).toThrow();
@@ -107,6 +118,10 @@ describe('PolicyRuleType', () => {
 
   it('accepts content_sanitization as PolicyRuleType', () => {
     expect(PolicyRuleType.parse('content_sanitization')).toBe('content_sanitization');
+  });
+
+  it('accepts contradiction_check as PolicyRuleType (E1)', () => {
+    expect(PolicyRuleType.parse('contradiction_check')).toBe('contradiction_check');
   });
 });
 

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -67,6 +67,14 @@ export type CandidateStatus = z.infer<typeof CandidateStatus>;
 export const SearchScope = z.enum(['curated', 'all', 'inbox', 'archived']).default('curated');
 export type SearchScope = z.infer<typeof SearchScope>;
 
+// `contradiction_check` (GSB blueprint Track E1) surfaces candidates whose
+// content overlaps heavily with an existing ACTIVE memory in the same category
+// WITHOUT being byte-identical (identical content is `dedup_check`'s job) —
+// same-topic-different-content is the shape a contradiction takes before a human
+// reads it. v1 is a deterministic token-overlap heuristic, action=flag only; it
+// never rejects. Rule values live in `governance_policies.rules_json` (validated
+// by this Zod enum) — there is no per-rule-type DB column or CHECK constraint,
+// so adding a member here needs no store migration.
 export const PolicyRuleType = z.enum([
   'secret_detection',
   'dedup_check',
@@ -76,6 +84,7 @@ export const PolicyRuleType = z.enum([
   'tenant_match',
   'sensitivity_gate',
   'content_sanitization',
+  'contradiction_check',
 ]);
 export type PolicyRuleType = z.infer<typeof PolicyRuleType>;
 

--- a/scripts/verify-policy-hash.sh
+++ b/scripts/verify-policy-hash.sh
@@ -37,6 +37,7 @@ FILES=(
   "packages/policy-engine/src/rules/tenant-match-rule.ts"
   "packages/policy-engine/src/rules/sensitivity-gate-rule.ts"
   "packages/policy-engine/src/rules/content-sanitization-rule.ts"
+  "packages/policy-engine/src/rules/contradiction-check-rule.ts"
   "packages/policy-engine/src/rules/index.ts"
   "packages/policy-engine/src/policy-engine.ts"
 )


### PR DESCRIPTION
## What

Adds a `contradiction_check` policy rule type (GSB blueprint **Track E1**): a deterministic v1 evaluator that FLAGS a candidate whose content overlaps heavily (Jaccard token-set similarity, default threshold 0.6, param-overridable) with an existing **ACTIVE** curated memory in the **same category** without being byte-identical — plus a structural pipeline change so contradiction rules always evaluate **before** any reject short-circuit.

## Why + decision rationale

A candidate that contradicts durable knowledge must carry that signal into the decision output even when another rule rejects it first — otherwise the reject short-circuit silently swallows exactly the human-review signal this rule exists to produce.

- **Chose a two-phase pipeline split over forced priority ordering** because `priority` is operator-editable policy data — a convention, not an invariant. The split (phase 1: all contradiction rules run to completion; phase 2: everything else with the existing short-circuit) makes the ordering unfalsifiable by any policy configuration.
- **Chose an injected `getActiveMemoriesInCategory` lookup on `EvaluationContext` over letting the rule query the store** so the evaluator stays a pure, store-free function (mirrors `existingHashes` for `dedup_check`; absent lookup → vacuous pass).
- **Chose flag-only-by-construction for v1**: the evaluator returns only `pass`/`flag`, never `fail`, and phase 1 records any non-pass as a flag — so no `action: 'reject'` configuration can turn a v1 heuristic hit into a rejection.
- **Honest heuristic framing**: token overlap ≠ semantic contradiction. High overlap reliably means *same topic, different text* — the shape a contradiction takes — so v1 surfaces those for human review and never decides. This is stated in the evaluator doc and in every flag reason string. The pipeline stays fully deterministic — no model calls (core invariant preserved).

## Layer(s) touched + invariant changes

- `packages/schema` — **new `PolicyRuleType` enum member** `contradiction_check` (+ a new Zod↔accept-list membership lock-step test for the enum itself).
- `packages/policy-engine` — **new ordering invariant**: two-phase `PolicyPipeline.evaluate` (contradiction pre-phase runs before any reject short-circuit; a rejected result now preserves pre-phase flags on `flaggedBy`); new evaluator + registry entry; `RECOMMENDED_POLICY_RULES` gains the rule (action=flag, priority 8) to satisfy the 5bm.2 anti-dormancy gate; `EvaluationContext` gains the optional injected lookup; `ActiveMemorySnapshot` exported.
- `apps/curator` — injects the real tenant-scoped ACTIVE-lifecycle category lookup in `processSingle`; **merge-gate deliberately un-wired** (documented in-line: the fold re-governs already-promoted rows where any non-approved outcome quarantines — a contradiction flag there would silently drop near-similar rows at merge time, and the lookup would be a determinism hazard).
- `apps/api` — promotion service injects the lookup from its already-loaded tenant memory set.
- `.policy-hash` re-pinned via `scripts/verify-policy-hash.sh --init` (C10 governance-ruleset tripwire; fired as designed on the rules/ change).

## How it works

Phase 1 partitions enabled rules by `type === 'contradiction_check'` and evaluates them first (priority orders them only among themselves); any non-pass outcome is recorded as a flag. Phase 2 runs the remaining rules priority-ascending with the pre-existing reject short-circuit; a reject returns `outcome: 'rejected'` **with** the phase-1 `flaggedBy` and both phases' `evaluations` preserved. The evaluator tokenizes to lowercased alphanumeric sets, computes Jaccard `|A∩B|/|A∪B|` against each active same-category memory, skips byte-identical content (dedup_check's job, which runs separately on content hashes), and names the top suspects (capped at 5) with similarities in the flag reason.

## Verification & evidence

- `pnpm -r test` — all green: schema 250, policy-engine 95 (incl. 9 new evaluator unit tests: flags-on-overlap, silent-on-disjoint, category-scoped, identical-skip, never-fail, threshold param; and 4 new pipeline-invariant tests, incl. **the load-bearing one: a candidate tripping BOTH a priority-0 reject rule and a priority-99 contradiction rule still records the contradiction flag in the decision output**), store 261 (5bm.1 DDL lock-step suite untouched and green), curator 271, api 338, common 138, qmd-adapter 177, claude-runtime 140, edge-daemon 145, git-exporter 115, mcp-server 71, eval-surface 27, reporting 31, repo-resolver 71.
- `pnpm -r typecheck` — clean (the `Record<PolicyRuleType, RuleEvaluator>` registry and the anti-dormancy gate both force compile/CI-time coverage of the new member).
- `pnpm format` — applied; pre-commit lint-staged + policy-hash gate passed.
- One flake observed and ruled out: `apps/api` `auth-revoke.test.ts` (scrypt-timing) failed once in the first full run, passed clean on re-run (`23 files / 338 tests passed`); unrelated to this diff. The pre-existing source-trust bulk_import ZodError failure flagged as possible did **not** reproduce — the suite is fully green on this branch.

## Risk assessment

Low. The rule is flag-only (cannot reject) and passes vacuously wherever the lookup is not injected, so no existing promotion path can newly hard-fail. Behavioral deltas: (1) candidates overlapping an active same-category memory ≥ threshold now come back `flagged` (→ 422 "left in inbox" on the API promote path, `flagged` outcome in the curator) instead of promoted — the intended review gate; (2) rejected results may now carry `flaggedBy` — all existing consumers (`rejector.ts`, `merge-gate.ts`, `promotion-service.ts`) already handle the field optionally. False positives at 0.6 are possible (compatible restatements) — that is review noise, not data loss, and the threshold is per-rule tunable.

## Operational impact — schema/migration mechanics (verified against the store code)

**No store migration is needed and none is shipped; the live brain stays at schema v9.** Verified mechanics: `PolicyRuleType` is enforced **only in Zod** — policy rules persist as JSON in `governance_policies.rules_json`; there is no `rule_type` column and no DDL CHECK constraint for rule types anywhere in `packages/store/src/schema.ts` (the 5bm.1 lock-step tests cover the `curated_memories` column enums, which are untouched). For completeness: migrations run automatically inside `createDatabase()` → `runMigrations()` on every non-readonly DB open, tracked in `schema_migrations` — so **if** a future change does need DDL, it applies on next service start with no manual step. The live `~/.teamkb/teamkb.db` was not touched by this work.

**One deliberate operational follow-through:** the LIVE policy does not yet enable `contradiction_check`, so on next curator run the 5bm.2 runtime completeness check will log a one-time-per-policy dormancy warning until the live policy is updated (the recommended-policy module documents this as a separate, reversible operational step — this PR changes no live policy).

## Follow-up & deferred

- **v2 semantic contradiction detection is Wave-2 C3/E2 territory** — deliberately out of scope; and per the core invariant, any model involvement there will only propose, with this deterministic pipeline still owning the decision.
- Enable `contradiction_check` on the LIVE brain's policy (separate operational step, see above).
- Merge-gate contradiction handling, if ever wanted, needs its own design (quarantine semantics + determinism), per the in-line note.

## Rollback

Revert the single commit. No schema/data migration to unwind; the `.policy-hash` manifest reverts with it.

- Jeremy Longshore
intentsolutions.io

**Refs:** #286 (Wave-1 epic · bead qmd-team-intent-kb-m8u.6)
**Governance links:** blueprint 019-PP-PLAN (umbrella) · Wave-0 decision 044-AT-DECR · reviewer law minimax-review.yml (fixed in #291)

---
## Review response (2026-07-19)
- **Adversarial HIGH (policy-hash manifest):** real — the new rule file was absent from the engineer-curated FILES list, so the evaluator itself was unpinned. Fixed in the follow-up commit on this branch: file added to the list, `--init` re-run (10 files pinned), `--verify` OK.
- **Defect-lane observations** (curator O(active) unscoped lookup; ASCII-only tokenization for non-English content): accepted as v1 limitations; follow-up beads will be filed under the Wave-2 epic at settle.
