### PR TITLE
feat(curator): add the verify-corpus-accounting substrate guard (Track G2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,7 +102,7 @@ jobs:
           node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db" --json | tee /tmp/accounting.json
           jq -e '.totalRows >= 1 and .orphanCount == 0' /tmp/accounting.json >/dev/null
           echo "--- planting a raw INSERT behind the promoter (substrate bypass) ---"
-          sqlite3 "$STORE/teamkb.db" "INSERT INTO curated_memories (id, candidate_id, source, content, title, category, trust_level, author_json, tenant_id, content_hash, promoted_at, promoted_by_json, updated_at) VALUES ('00000000-0000-4000-8000-00000000beef', '00000000-0000-4000-8000-00000000cafe', 'manual', 'bypass row', 'Bypass row', 'reference', 'medium', '{\"type\":\"human\",\"id\":\"rogue\"}', 'ci-accounting', 'deadbeef', '2026-07-19T00:00:00.000Z', '{\"type\":\"human\",\"id\":\"rogue\"}', '2026-07-19T00:00:00.000Z');"
+          sqlite3 "$STORE/teamkb.db" "INSERT INTO curated_memories (id, candidate_id, source, content, title, category, trust_level, author_json, tenant_id, content_hash, promoted_at, promoted_by_json, updated_at) VALUES ('00000000-0000-4000-8000-00000000beef', '00000000-0000-4000-8000-00000000cafe', 'manual', 'bypass row', 'Bypass row', 'reference', 'medium', '{\"type\":\"human\",\"id\":\"rogue\"}', 'ci-accounting', 'd6afac65ebb13db65da74c57ea61bb19ab78bb219afe321d460b81118d23187c', '2026-07-19T00:00:00.000Z', '{\"type\":\"human\",\"id\":\"rogue\"}', '2026-07-19T00:00:00.000Z');"
           echo "--- bypass must be detected (nonzero exit) ---"
           if node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db"; then
             echo "FAIL: verify-corpus-accounting did not detect the bypass row"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,36 @@ jobs:
           node packages/qmd-adapter/dist/cli.js reindex
           node packages/qmd-adapter/dist/cli.js canary
 
+      - name: Corpus-accounting guard (every curated row must carry its promoted receipt)
+        # Track G2 substrate guard (GSB blueprint): the governed corpus and the
+        # audit log must agree — every curated_memories row carries a
+        # row-creating 'promoted' receipt written by the curator promoter in the
+        # same transaction as the insert. This job proves the MECHANISM against
+        # a synthetic store built by the real curator CLI: (1) a
+        # properly-promoted store passes; (2) a raw SQL INSERT planted behind
+        # the promoter (the substrate bypass) is detected and exits nonzero.
+        # The daily run against the LIVE ~/.teamkb store is an ops concern on
+        # the box that hosts the real brain (the local nightly compile host,
+        # runbook 000-docs/027-OD-OPSM) — CI never sees that store.
+        run: |
+          set -euo pipefail
+          STORE="$RUNNER_TEMP/teamkb-accounting"
+          mkdir -p "$STORE/spool"
+          cat > "$STORE/spool/spool-ci-accounting.jsonl" <<'JSONL'
+          {"schemaVersion":"1","id":"7f0a90a4-bd63-5c1e-9a10-3d2f6f1c2ab1","status":"inbox","source":"import","content":"Corpus-accounting CI fixture: this candidate is promoted through the real curator pipeline.","title":"Corpus accounting fixture","category":"reference","trustLevel":"medium","author":{"type":"system","id":"nightly-ci"},"tenantId":"ci-accounting","metadata":{"filePaths":["ci/fixture.md"],"tags":["ci"]},"prePolicyFlags":{"potentialSecret":false,"lowConfidence":false,"duplicateSuspect":false},"capturedAt":"2026-07-19T00:00:00.000Z"}
+          JSONL
+          node apps/curator/dist/main.js ingest "$STORE/spool" --tenant ci-accounting --db "$STORE/teamkb.db"
+          echo "--- clean store must pass ---"
+          node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db"
+          echo "--- planting a raw INSERT behind the promoter (substrate bypass) ---"
+          sqlite3 "$STORE/teamkb.db" "INSERT INTO curated_memories (id, candidate_id, source, content, title, category, trust_level, author_json, tenant_id, content_hash, promoted_at, promoted_by_json, updated_at) VALUES ('00000000-0000-4000-8000-00000000beef', '00000000-0000-4000-8000-00000000cafe', 'manual', 'bypass row', 'Bypass row', 'reference', 'medium', '{\"type\":\"human\",\"id\":\"rogue\"}', 'ci-accounting', 'deadbeef', '2026-07-19T00:00:00.000Z', '{\"type\":\"human\",\"id\":\"rogue\"}', '2026-07-19T00:00:00.000Z');"
+          echo "--- bypass must be detected (nonzero exit) ---"
+          if node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db"; then
+            echo "FAIL: verify-corpus-accounting did not detect the bypass row"
+            exit 1
+          fi
+          echo "OK: substrate bypass detected"
+
       - name: Dependency audit
         run: pnpm audit --audit-level=moderate
         continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,9 +80,13 @@ jobs:
         # audit log must agree — every curated_memories row carries a
         # row-creating 'promoted' receipt written by the curator promoter in the
         # same transaction as the insert. This job proves the MECHANISM against
-        # a synthetic store built by the real curator CLI: (1) a
-        # properly-promoted store passes; (2) a raw SQL INSERT planted behind
-        # the promoter (the substrate bypass) is detected and exits nonzero.
+        # a synthetic store built by the real curator CLI: (1) `curator ingest`
+        # sweeps the fixture through the full pipeline (its Promoted counter is
+        # real promotion via the production promoter, receipt included) and the
+        # jq assertion REQUIRES >=1 accounted row — an empty or silently
+        # rejected store can no longer pass this leg trivially; (2) a raw SQL
+        # INSERT planted behind the promoter (the substrate bypass) is detected
+        # and exits nonzero.
         # The daily run against the LIVE ~/.teamkb store is an ops concern on
         # the box that hosts the real brain (the local nightly compile host,
         # runbook 000-docs/027-OD-OPSM) — CI never sees that store.
@@ -94,8 +98,9 @@ jobs:
           {"schemaVersion":"1","id":"7f0a90a4-bd63-5c1e-9a10-3d2f6f1c2ab1","status":"inbox","source":"import","content":"Corpus-accounting CI fixture: this candidate is promoted through the real curator pipeline.","title":"Corpus accounting fixture","category":"reference","trustLevel":"medium","author":{"type":"system","id":"nightly-ci"},"tenantId":"ci-accounting","metadata":{"filePaths":["ci/fixture.md"],"tags":["ci"]},"prePolicyFlags":{"potentialSecret":false,"lowConfidence":false,"duplicateSuspect":false},"capturedAt":"2026-07-19T00:00:00.000Z"}
           JSONL
           node apps/curator/dist/main.js ingest "$STORE/spool" --tenant ci-accounting --db "$STORE/teamkb.db"
-          echo "--- clean store must pass ---"
-          node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db"
+          echo "--- properly-promoted store must pass with >=1 accounted row ---"
+          node apps/curator/dist/main.js verify-corpus-accounting --db "$STORE/teamkb.db" --json | tee /tmp/accounting.json
+          jq -e '.totalRows >= 1 and .orphanCount == 0' /tmp/accounting.json >/dev/null
           echo "--- planting a raw INSERT behind the promoter (substrate bypass) ---"
           sqlite3 "$STORE/teamkb.db" "INSERT INTO curated_memories (id, candidate_id, source, content, title, category, trust_level, author_json, tenant_id, content_hash, promoted_at, promoted_by_json, updated_at) VALUES ('00000000-0000-4000-8000-00000000beef', '00000000-0000-4000-8000-00000000cafe', 'manual', 'bypass row', 'Bypass row', 'reference', 'medium', '{\"type\":\"human\",\"id\":\"rogue\"}', 'ci-accounting', 'deadbeef', '2026-07-19T00:00:00.000Z', '{\"type\":\"human\",\"id\":\"rogue\"}', '2026-07-19T00:00:00.000Z');"
           echo "--- bypass must be detected (nonzero exit) ---"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,15 @@ Incremental export of curated memories to `kb-export/` as Markdown with YAML fro
 - Every user-facing change needs a changelog entry (Added, Changed, Fixed, Security, Deprecated, Removed)
 - Use `/release` skill for release preparation
 
+### Bulk edits — governed state is write-protected by receipts
+
+- Read-only SQL against a store (`SELECT` over `teamkb.db`) is fine for inspection and reporting.
+- WRITES to governed state go through the MCP/curator promoter path only. A raw
+  `INSERT`/`UPDATE` to `curated_memories` bypasses the promoter's single-transaction
+  memory-row + `promoted`-receipt write, breaking corpus accounting — the
+  `curator-cli verify-corpus-accounting` guard (also run nightly in CI) will flag the
+  row as an orphan and exit nonzero.
+
 ### Enterprise Mode Standards
 
 - All code must pass lint, format, and type checks

--- a/apps/curator/src/__tests__/verify-corpus-accounting.test.ts
+++ b/apps/curator/src/__tests__/verify-corpus-accounting.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the `verify-corpus-accounting` subcommand (Track G2 substrate
+ * guard): every curated_memories row must carry a row-creating audit receipt
+ * (action 'promoted'). A raw SQL INSERT that bypasses the curator promoter —
+ * the substrate bypass — must be DETECTABLE.
+ *
+ * The legitimate row is planted via the REAL promoter path (`promote()`, the
+ * only non-test call site of MemoryRepository.insert), exactly as
+ * promoter.test.ts drives it. The bypass row is planted with a direct db
+ * handle, mimicking an operator running raw SQL against the store.
+ *
+ * @module __tests__/verify-corpus-accounting.test
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { AuditRepository, MemoryRepository, createTestDatabase } from '@qmd-team-intent-kb/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatch, type CuratorCliDeps } from '../cli.js';
+import { promote } from '../promotion/promoter.js';
+
+import { makeCandidate } from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Scaffolding (same pattern as cli.test.ts)
+// ---------------------------------------------------------------------------
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+function stdoutText(): string {
+  const calls = stdoutSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+function stderrText(): string {
+  const calls = stderrSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+const testDeps: CuratorCliDeps = {
+  createDb: () => createTestDatabase(),
+};
+
+function makePipelineResult(candidateId: string): PipelineResult {
+  return { candidateId, outcome: 'approved', evaluations: [] };
+}
+
+/** Promote one candidate through the REAL promoter path into `db`. */
+function promoteOne(db: ReturnType<typeof createTestDatabase>): string {
+  const memoryRepo = new MemoryRepository(db);
+  const auditRepo = new AuditRepository(db);
+  const candidate = makeCandidate();
+  const contentHash = computeContentHash(candidate.content);
+  const memory = promote(
+    { candidate, contentHash, pipelineResult: makePipelineResult(candidate.id) },
+    memoryRepo,
+    auditRepo,
+  );
+  return memory.id;
+}
+
+/** Plant a curated_memories row via a direct db handle — the substrate bypass.
+ *  No promoter, no transaction, no 'promoted' receipt. */
+function plantBypassRow(db: ReturnType<typeof createTestDatabase>): string {
+  const id = randomUUID();
+  const author = JSON.stringify({ type: 'human', id: 'rogue-operator' });
+  db.prepare(
+    `INSERT INTO curated_memories (
+       id, candidate_id, source, content, title, category,
+       trust_level, sensitivity, author_json, tenant_id,
+       metadata_json, lifecycle, content_hash,
+       policy_evaluations_json, supersession_json,
+       promoted_at, promoted_by_json, updated_at, version
+     ) VALUES (
+       ?, ?, 'manual', 'Row inserted behind the promoter', 'Bypass row', 'reference',
+       'medium', 'internal', ?, 'team-alpha',
+       '{}', 'active', ?,
+       '[]', NULL,
+       '2026-07-19T00:00:00.000Z', ?, '2026-07-19T00:00:00.000Z', 1
+     )`,
+  ).run(id, randomUUID(), author, computeContentHash(`bypass-${id}`), author);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Argument / usage errors
+// ---------------------------------------------------------------------------
+
+describe('dispatch verify-corpus-accounting — argument errors', () => {
+  it('exits 2 on unknown flag', async () => {
+    const rc = await dispatch(['verify-corpus-accounting', '--bogus'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/unknown flag: --bogus/);
+  });
+
+  it('lists the subcommand in help text', async () => {
+    const rc = await dispatch(['help'], testDeps);
+    expect(rc).toBe(0);
+    expect(stdoutText()).toMatch(/verify-corpus-accounting/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clean store — every row carries its receipt
+// ---------------------------------------------------------------------------
+
+describe('dispatch verify-corpus-accounting — clean store', () => {
+  it('exits 0 on a store whose only rows came through the real promoter', async () => {
+    const db = createTestDatabase();
+    promoteOne(db);
+
+    const rc = await dispatch(['verify-corpus-accounting', '--db', '/ignored'], {
+      createDb: () => db,
+    });
+    expect(rc).toBe(0);
+    const out = stdoutText();
+    expect(out).toMatch(/corpus accounting OK/);
+    expect(out).toMatch(/Total rows:\s+1/);
+    expect(out).toMatch(/Accounted rows:\s+1/);
+    expect(out).toMatch(/Accepted receipt classes: promoted/);
+  });
+
+  it('exits 0 with an ok JSON envelope on an empty store', async () => {
+    const rc = await dispatch(['verify-corpus-accounting', '--json'], testDeps);
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(true);
+    expect(parsed['totalRows']).toBe(0);
+    expect(parsed['orphanCount']).toBe(0);
+    expect(parsed['acceptedActions']).toEqual(['promoted']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Substrate bypass — a raw INSERT behind the promoter is detected
+// ---------------------------------------------------------------------------
+
+describe('dispatch verify-corpus-accounting — substrate bypass detection', () => {
+  it('reports exactly the planted orphan and exits nonzero (human output)', async () => {
+    const db = createTestDatabase();
+    const promotedId = promoteOne(db);
+    const bypassId = plantBypassRow(db);
+
+    const rc = await dispatch(['verify-corpus-accounting', '--db', '/ignored'], {
+      createDb: () => db,
+    });
+    expect(rc).toBe(2);
+    const err = stderrText();
+    expect(err).toMatch(/CORPUS_UNACCOUNTED: 1 of 2/);
+    expect(err).toContain(bypassId);
+    expect(err).not.toContain(promotedId);
+  });
+
+  it('lists exactly the planted orphan in the JSON envelope', async () => {
+    const db = createTestDatabase();
+    const promotedId = promoteOne(db);
+    const bypassId = plantBypassRow(db);
+
+    const rc = await dispatch(['verify-corpus-accounting', '--db', '/ignored', '--json'], {
+      createDb: () => db,
+    });
+    expect(rc).toBe(2);
+    const parsed = JSON.parse(stdoutText().trim()) as {
+      ok: boolean;
+      totalRows: number;
+      accountedRows: number;
+      orphanCount: number;
+      orphans: Array<{ id: string; tenantId: string }>;
+      acceptedActions: string[];
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.totalRows).toBe(2);
+    expect(parsed.accountedRows).toBe(1);
+    expect(parsed.orphanCount).toBe(1);
+    expect(parsed.orphans.map((o) => o.id)).toEqual([bypassId]);
+    expect(parsed.orphans.map((o) => o.id)).not.toContain(promotedId);
+    expect(parsed.acceptedActions).toEqual(['promoted']);
+  });
+
+  it('does not treat lifecycle receipts (e.g. superseded) as row-creating', async () => {
+    // A bypass row that ALSO has a non-creating receipt attached must still be
+    // flagged — only 'promoted' accounts for a row's existence.
+    const db = createTestDatabase();
+    const bypassId = plantBypassRow(db);
+    new AuditRepository(db).insert({
+      id: randomUUID(),
+      action: 'recategorized',
+      memoryId: bypassId,
+      tenantId: 'team-alpha',
+      actor: { type: 'human', id: 'rogue-operator' },
+      reason: 'laundering attempt',
+      details: {},
+      timestamp: '2026-07-19T00:00:01.000Z',
+    });
+
+    const rc = await dispatch(['verify-corpus-accounting', '--db', '/ignored', '--json'], {
+      createDb: () => db,
+    });
+    expect(rc).toBe(2);
+    const parsed = JSON.parse(stdoutText().trim()) as {
+      orphans: Array<{ id: string }>;
+    };
+    expect(parsed.orphans.map((o) => o.id)).toEqual([bypassId]);
+  });
+});

--- a/apps/curator/src/__tests__/verify-corpus-accounting.test.ts
+++ b/apps/curator/src/__tests__/verify-corpus-accounting.test.ts
@@ -107,6 +107,12 @@ describe('dispatch verify-corpus-accounting — argument errors', () => {
     expect(stderrText()).toMatch(/unknown flag: --bogus/);
   });
 
+  it('exits 2 when --db is omitted (refuses the implicit in-memory store)', async () => {
+    const rc = await dispatch(['verify-corpus-accounting'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/missing required --db/);
+  });
+
   it('lists the subcommand in help text', async () => {
     const rc = await dispatch(['help'], testDeps);
     expect(rc).toBe(0);
@@ -135,7 +141,7 @@ describe('dispatch verify-corpus-accounting — clean store', () => {
   });
 
   it('exits 0 with an ok JSON envelope on an empty store', async () => {
-    const rc = await dispatch(['verify-corpus-accounting', '--json'], testDeps);
+    const rc = await dispatch(['verify-corpus-accounting', '--db', '/ignored', '--json'], testDeps);
     expect(rc).toBe(0);
     const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
     expect(parsed['ok']).toBe(true);

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -678,6 +678,17 @@ function parseCorpusAccountingArgs(
     }
   }
 
+  // --db is mandatory: without it deps.createDb falls back to an empty
+  // in-memory store, which would report a trivially clean corpus — a passing
+  // verdict about nothing. The verifier refuses instead (review finding on
+  // #289; the test harness injects its own createDb and bypasses argv).
+  if (dbPath === undefined) {
+    return {
+      ok: false,
+      message: 'missing required --db <path> (refusing to verify an implicit in-memory store)',
+    };
+  }
+
   return { ok: true, opts: { dbPath, json } };
 }
 

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -75,6 +75,12 @@ Subcommands:
     manifest (010-AT-RISK R1/R2). Refuses to overwrite an existing manifest
     without --force. Prints the entryCount + manifestHash.
 
+  verify-corpus-accounting [--db <path>] [--json]
+    Prove the governed corpus and the audit log agree: every curated_memories
+    row must carry a row-creating audit receipt (action 'promoted'). A row
+    without one is an orphan — the signature of a raw SQL INSERT that bypassed
+    the curator promoter. Opens the db READ-ONLY; exits 2 when orphans exist.
+
   help | --help | -h
     Print this message.
 
@@ -97,6 +103,11 @@ Options for 'generate-exception-manifest':
                   regenerating silently would re-launder new breaks).
   --brain-id <id> Optional brain identifier stamped into the manifest.
   --json          Emit a structured JSON envelope in place of the summary.
+
+Options for 'verify-corpus-accounting':
+  --db <path>     SQLite path to read READ-ONLY (required for any meaningful
+                  run; an in-memory db is always empty). Never mutated.
+  --json          Emit a structured JSON envelope in place of the summary.
 `;
 
 // ---------------------------------------------------------------------------
@@ -116,6 +127,8 @@ export async function dispatch(argv: string[], deps: CuratorCliDeps): Promise<nu
       return cmdVerifyAuditChain(argv.slice(1), deps);
     case 'generate-exception-manifest':
       return cmdGenerateExceptionManifest(argv.slice(1), deps);
+    case 'verify-corpus-accounting':
+      return cmdVerifyCorpusAccounting(argv.slice(1), deps);
     case 'help':
     case '--help':
     case '-h':
@@ -600,6 +613,150 @@ async function cmdGenerateExceptionManifest(args: string[], deps: CuratorCliDeps
       process.stdout.write(`  ${reason}: ${count}\n`);
     }
     return 0;
+  } finally {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// verify-corpus-accounting
+//
+// Substrate guard: prove the governed corpus (curated_memories) and the audit
+// log (audit_events) agree. Every production insert into curated_memories goes
+// through promote() (apps/curator/src/promotion/promoter.ts) — the ONLY
+// non-test call site of MemoryRepository.insert — which writes the memory row
+// and its 'promoted' receipt in one BEGIN IMMEDIATE transaction (R9, jfv.6.9).
+// The merge-gate, the API promotion-service, and the agent-review path all
+// route through promote(); the vault / bulk-import pipelines create CANDIDATES
+// only, so rows reach curated_memories exclusively via promotion. A
+// curated_memories row with no matching receipt is therefore the signature of
+// a raw SQL INSERT that bypassed the promoter (the substrate bypass).
+// ---------------------------------------------------------------------------
+
+/**
+ * Audit-event actions that legitimately CREATE a curated_memories row.
+ *
+ * Exactly one class today: 'promoted'. Lifecycle events ('superseded',
+ * 'demoted', 'recategorized', …) mutate or annotate EXISTING rows; 'proposed'
+ * receipts a candidate (pre-promotion, memoryId = candidate id); 'governed'
+ * receipts a batch sweep. None of them mints a corpus row. If a future write
+ * path legitimately creates rows under a new action, add it HERE (with the
+ * receipt emitted in the same transaction as the insert) — never widen the
+ * check ad hoc.
+ */
+const ROW_CREATING_ACTIONS: readonly string[] = ['promoted'];
+
+interface CorpusAccountingOpts {
+  dbPath?: string;
+  json: boolean;
+}
+
+function parseCorpusAccountingArgs(
+  args: string[],
+): { ok: true; opts: CorpusAccountingOpts } | { ok: false; message: string } {
+  let dbPath: string | undefined;
+  let json = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+    switch (arg) {
+      case '--db':
+        dbPath = args[i + 1];
+        i += 2;
+        break;
+      case '--json':
+        json = true;
+        i += 1;
+        break;
+      default:
+        return { ok: false, message: `unknown flag: ${arg}` };
+    }
+  }
+
+  return { ok: true, opts: { dbPath, json } };
+}
+
+/** Orphan row surfaced by the accounting query. Ids + row metadata only —
+ *  never title/content (same disclosure discipline as the ingest report). */
+interface OrphanRow {
+  id: string;
+  tenantId: string;
+  promotedAt: string;
+}
+
+async function cmdVerifyCorpusAccounting(args: string[], deps: CuratorCliDeps): Promise<number> {
+  const parsed = parseCorpusAccountingArgs(args);
+  if (!parsed.ok) {
+    process.stderr.write(`curator-cli verify-corpus-accounting: ${parsed.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const { dbPath, json } = parsed.opts;
+
+  // Open READ-ONLY when a real path is given — a verifier must never mutate a
+  // live brain (same posture as generate-exception-manifest).
+  const db = deps.createDb(dbPath !== undefined ? { dbPath, readonly: true } : {});
+  try {
+    const totalRow = db.prepare('SELECT COUNT(*) AS n FROM curated_memories').get() as {
+      n: number;
+    };
+    const totalRows = totalRow.n;
+
+    // Id-derived join: promote() stamps the receipt's memory_id with the
+    // curated memory's own id, so accounting is a NOT EXISTS over that column
+    // filtered to the row-creating action classes.
+    const placeholders = ROW_CREATING_ACTIONS.map(() => '?').join(', ');
+    const orphans = db
+      .prepare(
+        `SELECT m.id AS id, m.tenant_id AS tenantId, m.promoted_at AS promotedAt
+         FROM curated_memories m
+         WHERE NOT EXISTS (
+           SELECT 1 FROM audit_events e
+           WHERE e.memory_id = m.id AND e.action IN (${placeholders})
+         )
+         ORDER BY m.promoted_at, m.id`,
+      )
+      .all(...ROW_CREATING_ACTIONS) as OrphanRow[];
+
+    const accountedRows = totalRows - orphans.length;
+    const ok = orphans.length === 0;
+
+    if (json) {
+      process.stdout.write(
+        JSON.stringify({
+          ok,
+          totalRows,
+          accountedRows,
+          orphanCount: orphans.length,
+          orphans,
+          acceptedActions: ROW_CREATING_ACTIONS,
+        }) + '\n',
+      );
+      return ok ? 0 : 2;
+    }
+
+    if (ok) {
+      process.stdout.write(`corpus accounting OK\n`);
+      process.stdout.write(`Total rows:     ${totalRows}\n`);
+      process.stdout.write(`Accounted rows: ${accountedRows}\n`);
+      process.stdout.write(`Accepted receipt classes: ${ROW_CREATING_ACTIONS.join(', ')}\n`);
+      return 0;
+    }
+
+    process.stderr.write(
+      `CORPUS_UNACCOUNTED: ${orphans.length} of ${totalRows} curated_memories row(s) have no ` +
+        `row-creating audit receipt (accepted classes: ${ROW_CREATING_ACTIONS.join(', ')}).\n` +
+        `A durable corpus row without its receipt is the signature of a raw SQL INSERT that ` +
+        `bypassed the curator promoter.\n\n`,
+    );
+    for (const o of orphans) {
+      process.stderr.write(`  ${o.id}  tenant=${o.tenantId}  promoted_at=${o.promotedAt}\n`);
+    }
+    return 2;
   } finally {
     try {
       (db as unknown as { close?: () => void }).close?.();


### PR DESCRIPTION
## What

A new `curator-cli` subcommand, `verify-corpus-accounting`, that proves the governed corpus and the audit log agree: every `curated_memories` row must carry a row-creating audit receipt (`action = 'promoted'`, `memory_id` = the row's own id). Rows without one are reported as orphans (ids + tenant + promoted_at only — never title/content, matching the CLI's existing disclosure discipline) and the command exits 2. Also: a nightly CI job step exercising the guard end-to-end, 7 new tests, and a CLAUDE.md "Bulk edits" rule.

## Why + decision rationale

A raw SQL INSERT into `curated_memories` bypasses the promoter's single-transaction memory-row + `promoted`-receipt write (R9, jfv.6.9), leaving a durable corpus row with no receipt — the substrate bypass. The existing `verify-audit-chain` only verifies the receipts that exist; it cannot see a corpus row that never got one. This guard closes that gap by cross-checking the corpus against the log.

- **Chose an id-derived `NOT EXISTS` SQL join over walking repositories row-by-row** because `promote()` stamps each receipt's `memory_id` with the memory's own id (`deriveAuditEventId(memoryId, 'promoted')`), so one indexed query (`idx_audit_memory`) is exact, fast, and read-only.
- **Accepted event classes: exactly `['promoted']`.** Recon confirmed `promote()` (apps/curator/src/promotion/promoter.ts) is the ONLY non-test call site of `MemoryRepository.insert`, which is the only code path containing `INSERT INTO curated_memories`. The merge-gate, the API promotion-service, and the agent-review path all route through `promote()`; the vault/bulk-import pipelines create CANDIDATES only. Lifecycle receipts (`superseded`, `demoted`, `recategorized`, …) mutate existing rows, `proposed` receipts a candidate, `governed` receipts a sweep — none mints a corpus row, so none is accepted. The set is a named constant with instructions to extend it (receipt in the same transaction as the insert) if a future path legitimately creates rows.

## Layer(s) touched

- `apps/curator/src/cli.ts` — new subcommand (dispatch + USAGE + implementation). Read-only DB open (same posture as `generate-exception-manifest`); no store/schema/invariant changes.
- `.github/workflows/nightly.yml` — one new step in the existing `full-check` job.
- `CLAUDE.md` — one new rule subsection.
- New test file under `apps/curator/src/__tests__/`.

## How it works

Open the store read-only → `COUNT(*)` over `curated_memories` → `NOT EXISTS` anti-join against `audit_events` filtered to the accepted action classes → print total/accounted/orphans (+ accepted classes) as human text or a `--json` envelope → exit 0 clean, 2 on orphans (mirroring `verify-audit-chain`'s integrity-violation exit code).

## Verification & evidence

Orphan-detection test run (`pnpm vitest run apps/curator/src/__tests__/verify-corpus-accounting.test.ts`):

```
✓ dispatch verify-corpus-accounting — argument errors > exits 2 on unknown flag 5ms
✓ dispatch verify-corpus-accounting — argument errors > lists the subcommand in help text 1ms
✓ dispatch verify-corpus-accounting — clean store > exits 0 on a store whose only rows came through the real promoter 40ms
✓ dispatch verify-corpus-accounting — clean store > exits 0 with an ok JSON envelope on an empty store 7ms
✓ dispatch verify-corpus-accounting — substrate bypass detection > reports exactly the planted orphan and exits nonzero (human output) 8ms
✓ dispatch verify-corpus-accounting — substrate bypass detection > lists exactly the planted orphan in the JSON envelope 21ms
✓ dispatch verify-corpus-accounting — substrate bypass detection > does not treat lifecycle receipts (e.g. superseded) as row-creating 13ms
Test Files  1 passed (1)
     Tests  7 passed (7)
```

The legitimate row is planted via the REAL promoter path (`promote()` with fixtures, exactly as promoter.test.ts drives it); the bypass row via a direct `db.prepare('INSERT INTO curated_memories …')`. The nightly step was rehearsed locally end-to-end:

```
--- clean store must pass ---
corpus accounting OK
Total rows:     1
Accounted rows: 1
Accepted receipt classes: promoted
--- planting a raw INSERT behind the promoter (substrate bypass) ---
--- bypass must be detected (nonzero exit) ---
CORPUS_UNACCOUNTED: 1 of 2 curated_memories row(s) have no row-creating audit receipt (accepted classes: promoted).
A durable corpus row without its receipt is the signature of a raw SQL INSERT that bypassed the curator promoter.

  00000000-0000-4000-8000-00000000beef  tenant=ci-accounting  promoted_at=2026-07-19T00:00:00.000Z
OK: substrate bypass detected
```

Gates: `pnpm -r typecheck` green, `pnpm -r test` green (exit 0 — the previously-noted bulk_import ZodError failure did not reproduce on this branch), `pnpm lint` green, `pnpm format` applied.

## Risk assessment

Low. The subcommand is read-only (readonly DB open when `--db` is given; never mutates a live brain). No production write path changed. Main risk is a FALSE POSITIVE if a future write path inserts corpus rows under a new receipt class without extending `ROW_CREATING_ACTIONS` — that failure mode is loud (nightly goes red), documented at the constant, and preferable to a silent gap.

## Operational impact

- **Nightly CI**: one new step in `full-check`, running against a synthetic temp store built by the real curator CLI (ingest → promote), then a planted sqlite3 bypass INSERT that must be detected. CI proves the mechanism only.
- **Ops note for the runbook (not done here, per scope)**: the daily run against the LIVE `~/.teamkb` store should be added to the on-box nightly compile host's cron (the only host with the real brain — see runbook 000-docs/027-OD-OPSM): `curator-cli verify-corpus-accounting --db ~/.teamkb/teamkb.db`. No box timers were installed by this PR.
- No env vars, migrations, dependency, or deploy-order changes.

## Follow-up & deferred

- Wire the on-box daily run of `verify-corpus-accounting` against the live store into the local nightly compile runbook + cron (ops task, deliberately not done in CI's repo).
- If a future write path (e.g. a restore/merge import that mints rows directly) is added, extend `ROW_CREATING_ACTIONS` with its receipt class in the same PR that adds the path.

- Jeremy Longshore
intentsolutions.io

**Refs:** #286 (Wave-1 epic · bead qmd-team-intent-kb-m8u.5)
**Governance links:** blueprint 019-PP-PLAN (umbrella) · Wave-0 decision 044-AT-DECR · reviewer law minimax-review.yml (fixed in #291)
