### PR TITLE
feat(eval-surface): fork-classified anchor cross-check in provenance integrity (Track F2) + anchor divergence runbook (F1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,10 @@ jobs:
         # 010-AT-RISK R5 / bead compile-then-govern-e06.2: evaluateProvenanceIntegrity
         # against a seeded throwaway brain with a benign CHAIN_FORK — passes on a
         # forked-but-untampered chain (the live brain's shape: 155 forks, 0 tamper)
-        # while failing closed on genuine tampering.
+        # while failing closed on genuine tampering. Track F2 adds the external-
+        # anchor cross-check scenarios: bootstrap (no anchor log) passes gracefully;
+        # an anchored-then-truncated chain — invisible to intra-chain verification —
+        # fails closed with anchor_history_truncated > 0.
         run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
       - name: Govern-decision eval (per-check precision/recall, fail-closed on missed secret/PII)
         # 010-AT-RISK R5/R10 · bead compile-then-govern-e06.3: the govern decision

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -51,6 +51,7 @@
 - `042-OD-OPSM-bbb-qmd-operator-runbook.md` — Bob's Big Brain + Tobi qmd: personal vs team index, `bbb-qmd` wrapper, pin/Dependabot, canary
 - `043-OD-EVAL-onboarding-qbank-v1.md` — Outsider day-1 Q-bank + baseline scoring for retrieval productization
 - `044-AT-DECR-wave0-retrieval-reconciliation.md` — Wave-0 retrieval reconciliation: ship the reranker first (Apache/MIT), defer the dense arm to a measured P2 gate, EmbeddingGemma out. Supersedes only the retrieval-arm + embedder elements of `038-AT-DECR`; unblocks the retrieval beads in the umbrella blueprint (`019-PP-PLAN` A1/B1/B2).
+- `045-OD-RNBK-anchor-remote-divergence-recovery.md` — Anchor remote divergence recovery: the private anchor-witness remote (`bobs-big-brain-anchors`, force-push-blocked), the fetch/status divergence check, per-state recovery (ahead = plain push; behind/diverged = investigate with the HISTORY_REWRITTEN tooling before ANY reconciliation), honest trust framing (detectable, not impossible)
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
 - `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)
@@ -118,4 +119,4 @@
 | 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0   | v0.7.0 release report            |
 | 040 | OD-OPSM | brain-api-tailnet-deploy            | Brain API tailnet deploy runbook |
 
-## Next Available Sequence: 045
+## Next Available Sequence: 046

--- a/000-docs/045-OD-RNBK-anchor-remote-divergence-recovery.md
+++ b/000-docs/045-OD-RNBK-anchor-remote-divergence-recovery.md
@@ -42,7 +42,13 @@ and local mode makes no cross-actor guarantee about _who_ performed a write.
 
 Because the ruleset has **no bypass actors**, not even the repo owner can
 force-push or delete the branch through the normal push path. That is
-deliberate: the remote's value is that its history only ever moves forward.
+deliberate: the remote's value is that its history moves only forward **while
+the ruleset stands**. The ruleset itself is an admin-editable GitHub object —
+a repo admin could delete or weaken it and force-push afterwards — so treat
+any change to the `protect-anchor-history` ruleset as a governance event in
+its own right (it is visible in the repo's audit log), and re-verify the
+ruleset (`gh api repos/jeremylongshore/bobs-big-brain-anchors/rulesets`)
+whenever this runbook is exercised.
 
 ## The divergence check
 

--- a/000-docs/045-OD-RNBK-anchor-remote-divergence-recovery.md
+++ b/000-docs/045-OD-RNBK-anchor-remote-divergence-recovery.md
@@ -1,0 +1,143 @@
+# 045-OD-RNBK — Anchor remote divergence recovery
+
+**Status:** Active
+**Date:** 2026-07-19
+**Audience:** operators / agents on a box with `~/.teamkb`
+**Related:** `packages/store/src/audit-anchor.ts` (verifyAnchors),
+`packages/eval-surface/src/provenance-integrity.ts` (F2 anchor cross-check),
+`packages/store/src/exception-manifest.ts` (3-state break classifier)
+
+## What this runbook covers
+
+The audit chain's external witness is a **private git remote** holding the
+anchor log. This runbook explains what state that remote can be in relative to
+the local anchor repo, what each divergence state means, and how to recover —
+without ever destroying the evidence the witness exists to preserve.
+
+## The trust framing (read this first)
+
+The audit chain is tamper-**evident**, not tamper-proof. A writer with local
+access can edit an event AND re-hash the chain forward, and intra-chain
+verification passes again. The anchor log closes part of that gap locally, but
+the anchor log is itself a local file — the same writer can regenerate it.
+
+The **remote witness** is what makes a local rewrite **detectable** — not
+impossible. Once an anchor commit is pushed to a remote that the local writer
+cannot force-push, any later local rewrite of anchored history necessarily
+diverges from what the remote already witnessed. Detection, ordering, and
+evidence — that is the whole claim. Nothing here prevents the rewrite itself,
+and local mode makes no cross-actor guarantee about _who_ performed a write.
+
+## Estate facts (as deployed)
+
+| Fact                | Value                                                               |
+| ------------------- | ------------------------------------------------------------------- |
+| Remote              | `jeremylongshore/bobs-big-brain-anchors` (private)                  |
+| Local anchor repo   | `~/.teamkb/audit` (git repo, branch `master`)                       |
+| Verified pushed tip | `32fa7cd08dd7abacc0403d6db80097d5c8d299a1`                          |
+| Ruleset             | `protect-anchor-history` (id `19181703`)                            |
+| Ruleset rules       | `non_fast_forward` blocked + deletion blocked, **no bypass actors** |
+| Verified behavior   | force-push rejected with `GH013` (tested)                           |
+| Push path           | the plugin fire-and-forget-pushes anchor commits on every govern    |
+
+Because the ruleset has **no bypass actors**, not even the repo owner can
+force-push or delete the branch through the normal push path. That is
+deliberate: the remote's value is that its history only ever moves forward.
+
+## The divergence check
+
+```bash
+git -C ~/.teamkb/audit fetch origin
+git -C ~/.teamkb/audit status
+```
+
+Interpret `status` (local `master` vs `origin/master`):
+
+### State 1 — up to date
+
+Nothing to do. The remote has witnessed everything local has anchored.
+
+### State 2 — local AHEAD of remote
+
+**Meaning:** anchor commits exist locally that have not reached the remote —
+pushes are pending or the fire-and-forget push has been failing (network,
+auth, GitHub outage). This is the only benign divergence state.
+
+**Recovery:**
+
+```bash
+git -C ~/.teamkb/audit push origin master
+```
+
+A plain push. If it fails, fix the transport (token, network) and retry. Check
+how long pushes have been failing — every unpushed anchor is a window in which
+a local rewrite would have gone unwitnessed:
+
+```bash
+git -C ~/.teamkb/audit log --oneline origin/master..master
+```
+
+### State 3 — local BEHIND remote, or DIVERGED
+
+**Meaning:** the remote holds anchor history the local repo does not. Since
+the anchor log is append-only by protocol and only this box pushes to it, a
+behind/diverged local repo means **the LOCAL history changed after anchoring**
+— the local anchor repo was rewound, rewritten, or replaced. That is exactly
+the rewrite signal the remote witness exists to catch. Treat it as an
+integrity incident, not a sync inconvenience.
+
+**Do NOT reconcile first. Investigate first.**
+
+1. **Freeze:** stop govern runs (they would push new anchors on top of a
+   suspect local state).
+2. **Capture evidence** before touching anything:
+
+   ```bash
+   git -C ~/.teamkb/audit log --oneline --graph --all | head -50
+   git -C ~/.teamkb/audit diff origin/master -- anchors.jsonl | head -100
+   cp ~/.teamkb/audit/anchors.jsonl /tmp/anchors.local.$(date -u +%Y%m%dT%H%M%SZ).jsonl
+   ```
+
+3. **Run the store's rewrite tooling** against the live chain — the evaluator
+   (`evaluateProvenanceIntegrity`) or `verifyAnchors` directly. A
+   `HISTORY_REWRITTEN` / `HISTORY_TRUNCATED` / anchor-log-integrity finding
+   confirms the live chain no longer matches what was anchored; classify chain
+   breaks through the 3-state model (benign forks and byte-pinned documented
+   exceptions are carried; tamper signatures are not).
+4. **Explain the divergence** before any reconciliation: restored backup?
+   disk corruption? deliberate edit? The remote's copy of the anchor log is
+   the reference — it was witnessed at push time and cannot have been
+   force-pushed (ruleset, no bypass actors).
+5. **Reconcile only after the investigation concludes**, and only by moving
+   local FORWARD to match the remote (e.g. re-clone the remote into
+   `~/.teamkb/audit` and re-anchor the current chain head on top). **Never
+   force-push** — the ruleset rejects it anyway (`GH013`), and attempting it
+   is itself a signal worth alerting on.
+
+### State 4 — remote unreachable
+
+Not a divergence — a visibility gap. Fix transport. Until the remote is
+reachable, anchors accumulate locally (state 2) and the witness is blind to
+anything that happens in the interim.
+
+## What the witness does NOT do
+
+- It does not prevent local rewrites — it makes them detectable after the
+  fact.
+- It does not identify the actor — cross-actor non-repudiation needs per-actor
+  signatures, which local mode does not provide.
+- It does not witness what was never pushed — the gap between the last pushed
+  anchor and now is unwitnessed by the remote (local anchors still cover it,
+  with the weaker local trust model).
+
+## How the evaluator consumes this (F2)
+
+`evaluateProvenanceIntegrity` cross-checks the live chain against the local
+anchor log on every run (`anchorLogPath`, default
+`~/.teamkb/audit/anchors.jsonl`): `HISTORY_TRUNCATED`, `HISTORY_REWRITTEN`,
+and anchor-log integrity breaks all fail closed; a missing/empty log is the
+graceful bootstrap (`anchor_status: no_anchors_yet`). Benign chain forks and
+byte-pinned documented exceptions are disclosed, not failed. The REMOTE
+divergence check in this runbook is the manual, cross-machine complement: the
+evaluator sees the local log; the remote proves the local log itself was not
+regenerated.

--- a/packages/eval-surface/scripts/ci-provenance-integrity.ts
+++ b/packages/eval-surface/scripts/ci-provenance-integrity.ts
@@ -17,6 +17,13 @@
  * asserts { passed:true, chain_forks>0, tamper_signatures:0 }. Then it seeds a
  * genuine tamper break and asserts { passed:false, tamper_signatures>0 }.
  *
+ * Track F2 adds the external-anchor cross-check scenarios on a SECOND
+ * throwaway brain: (a) an anchored, untouched chain reads `consistent` and
+ * passes; (b) truncating the chain AFTER anchoring — which leaves the chain
+ * internally clean, so intra-chain verification alone sees NOTHING — fails
+ * closed with `anchor_history_truncated > 0`. The first brain runs with a
+ * missing anchor log, proving the graceful bootstrap (`no_anchors_yet`).
+ *
  * Exit 0 on success; non-zero (with a diagnostic) on any assertion failure.
  */
 
@@ -31,6 +38,7 @@ import {
   AuditRepository,
   CURRENT_AUDIT_HASH_VERSION,
   MemoryRepository,
+  appendAnchor,
   computeEntryHash,
   createDatabase,
 } from '@qmd-team-intent-kb/store';
@@ -89,11 +97,18 @@ const dir = mkdtempSync(join(tmpdir(), 'gsb-ci-provenance-'));
 const dbPath = join(dir, 'teamkb.db');
 // A manifest path that does NOT exist → the evaluator's "no amnesty" branch.
 const noManifest = join(dir, 'no-such-exceptions.manifest.json');
+// An anchor-log path that does NOT exist → the F2 bootstrap ('no_anchors_yet')
+// branch for the fork/tamper scenarios, and never a read of ~/.teamkb.
+const noAnchors = join(dir, 'no-such-anchors.jsonl');
+// A REAL anchor log for the F2 anchored-then-truncated scenario.
+const anchorLog = join(dir, 'anchors.jsonl');
+const dbPath2 = join(dir, 'teamkb-anchored.db');
 
-// `db` is declared OUTSIDE the try so the single top-level `finally` can safely
-// `db?.close()` it on every path (success, assertion failure, unexpected throw)
-// before the temp dir is removed.
+// `db`/`db2` are declared OUTSIDE the try so the single top-level `finally` can
+// safely close them on every path (success, assertion failure, unexpected
+// throw) before the temp dir is removed.
 let db: ReturnType<typeof createDatabase> | undefined;
+let db2: ReturnType<typeof createDatabase> | undefined;
 
 try {
   db = createDatabase({ path: dbPath });
@@ -148,6 +163,7 @@ try {
   const forked = evaluateProvenanceIntegrity(memRepo, auditRepo, {
     tenantId: TENANT,
     exceptionManifestPath: noManifest,
+    anchorLogPath: noAnchors,
   });
   process.stdout.write(`forked-brain verdict: ${JSON.stringify(forked.details)}\n`);
   if (!forked.passed) fail('forked-but-untampered brain must PASS, got passed=false');
@@ -155,20 +171,67 @@ try {
     fail(`expected chain_forks > 0, got ${forked.details.chain_forks}`);
   if (Number(forked.details.tamper_signatures) !== 0)
     fail(`expected tamper_signatures 0, got ${forked.details.tamper_signatures}`);
+  // F2 bootstrap: a missing anchor log must report itself and NOT fail.
+  if (forked.details.anchor_status !== 'no_anchors_yet')
+    fail(`expected anchor_status 'no_anchors_yet', got ${forked.details.anchor_status}`);
 
   // --- now introduce a REAL tamper break and assert the eval fails closed.
   db.prepare(`UPDATE audit_events SET reason = 'TAMPERED' WHERE id = ?`).run(ids[1]);
   const tampered = evaluateProvenanceIntegrity(memRepo, auditRepo, {
     tenantId: TENANT,
     exceptionManifestPath: noManifest,
+    anchorLogPath: noAnchors,
   });
   process.stdout.write(`tampered-brain verdict: ${JSON.stringify(tampered.details)}\n`);
   if (tampered.passed) fail('a tampered brain must FAIL, got passed=true');
   if (Number(tampered.details.tamper_signatures) <= 0)
     fail('expected tamper_signatures > 0 on a tampered brain');
 
+  // --- F2: second brain — anchored, then truncated after anchoring. ---------
+  db2 = createDatabase({ path: dbPath2 });
+  const memRepo2 = new MemoryRepository(db2);
+  const auditRepo2 = new AuditRepository(db2);
+  memRepo2.insert(makeMemory('ci anchored brain seed memory'));
+  const ids2: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    const e = makeEvent(i);
+    ids2.push(e.id);
+    auditRepo2.insert(e);
+  }
+  appendAnchor(auditRepo2, anchorLog, { tenantId: TENANT });
+
+  const anchored = evaluateProvenanceIntegrity(memRepo2, auditRepo2, {
+    tenantId: TENANT,
+    exceptionManifestPath: noManifest,
+    anchorLogPath: anchorLog,
+  });
+  process.stdout.write(`anchored-brain verdict: ${JSON.stringify(anchored.details)}\n`);
+  if (!anchored.passed) fail('an anchored, untouched brain must PASS, got passed=false');
+  if (anchored.details.anchor_status !== 'consistent')
+    fail(`expected anchor_status 'consistent', got ${anchored.details.anchor_status}`);
+
+  // Truncate AFTER anchoring: drop the newest row. The remaining chain is
+  // internally clean — intra-chain verification alone sees NOTHING — so only
+  // the anchor cross-check can (and must) fail this closed.
+  db2.prepare('DELETE FROM audit_events WHERE id = ?').run(ids2[2]);
+  const truncated = evaluateProvenanceIntegrity(memRepo2, auditRepo2, {
+    tenantId: TENANT,
+    exceptionManifestPath: noManifest,
+    anchorLogPath: anchorLog,
+  });
+  process.stdout.write(`truncated-brain verdict: ${JSON.stringify(truncated.details)}\n`);
+  if (truncated.passed) fail('an anchored-then-truncated brain must FAIL, got passed=true');
+  if (Number(truncated.details.tamper_signatures) !== 0)
+    fail(
+      `truncation must be invisible to intra-chain verification (tamper_signatures 0), got ${truncated.details.tamper_signatures}`,
+    );
+  if (Number(truncated.details.anchor_history_truncated) <= 0)
+    fail(
+      `expected anchor_history_truncated > 0, got ${truncated.details.anchor_history_truncated}`,
+    );
+
   process.stdout.write(
-    'ci-provenance-integrity OK — forks pass (disclosed), tamper fails closed\n',
+    'ci-provenance-integrity OK — forks pass (disclosed), tamper fails closed, anchor truncation fails closed\n',
   );
   // Success falls through: no `process.exit(0)` here (it would bypass the
   // finally and leak the temp dir). The process exits 0 naturally once the
@@ -181,8 +244,9 @@ try {
   process.exitCode = 1;
 } finally {
   // Runs on every path (success, assertion failure, unexpected throw): close the
-  // DB handle if it was opened, then remove the temp dir. `db?.close()` is safe
-  // even if createDatabase threw before assignment.
+  // DB handles if opened, then remove the temp dir. `db?.close()` is safe even
+  // if createDatabase threw before assignment.
   db?.close();
+  db2?.close();
   rmSync(dir, { recursive: true, force: true });
 }

--- a/packages/eval-surface/src/__tests__/eval-surface.test.ts
+++ b/packages/eval-surface/src/__tests__/eval-surface.test.ts
@@ -447,19 +447,63 @@ describe('evaluateProvenanceIntegrity', () => {
       expect(r.score).toBeLessThan(1);
     });
 
-    it('FAILS CLOSED when the head at an anchored position was rewritten', () => {
+    it('FAILS CLOSED on a full re-hash-forward rewrite that intra-chain verification cannot see', () => {
       memRepo.insert(makeMemory({ content: 'soon-to-be-rewritten brain' }));
       const ids = seedChain(3);
       appendAnchor(auditRepo, anchorPath, { tenantId: DEFAULT_TENANT });
 
-      // Rewrite the anchored head row's stored hash after anchoring.
-      db.prepare(`UPDATE audit_events SET entry_hash = ? WHERE id = ?`).run('f'.repeat(64), ids[2]);
+      // TRUE re-hash-forward (the attack the anchor witness exists for): edit
+      // the MIDDLE row's payload, recompute its entry_hash under its stored
+      // hash version, then recompute every downstream row's prev_entry_hash +
+      // entry_hash — the chain now verifies CLEAN internally, and only the
+      // anchored snapshot betrays the rewrite.
+      interface RawRow {
+        id: string;
+        action: string;
+        memory_id: string;
+        tenant_id: string;
+        actor_json: string;
+        reason: string | null;
+        details_json: string;
+        timestamp: string;
+        prev_entry_hash: string | null;
+        hash_version: 1 | 2;
+      }
+      const rowOf = (id: string): RawRow =>
+        db
+          .prepare(
+            `SELECT id, action, memory_id, tenant_id, actor_json, reason, details_json,
+                    timestamp, prev_entry_hash, hash_version
+             FROM audit_events WHERE id = ?`,
+          )
+          .get(id) as RawRow;
+
+      const mid = rowOf(ids[1]!);
+      mid.reason = 'laundered by a local writer';
+      const midHash = computeEntryHash(mid, mid.hash_version);
+      db.prepare(`UPDATE audit_events SET reason = ?, entry_hash = ? WHERE id = ?`).run(
+        mid.reason,
+        midHash,
+        mid.id,
+      );
+      const head = rowOf(ids[2]!);
+      head.prev_entry_hash = midHash;
+      const headHash = computeEntryHash(head, head.hash_version);
+      db.prepare(`UPDATE audit_events SET prev_entry_hash = ?, entry_hash = ? WHERE id = ?`).run(
+        midHash,
+        headHash,
+        head.id,
+      );
 
       const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
         tenantId: DEFAULT_TENANT,
         exceptionManifestPath: NO_MANIFEST,
         anchorLogPath: anchorPath,
       });
+      // The headline claim, both halves: intra-chain verification sees NOTHING
+      // (the rewrite re-hashed forward cleanly) …
+      expect(r.details.tamper_signatures).toBe(0);
+      // … and the anchor cross-check still fails it closed.
       expect(Number(r.details.anchor_history_rewritten)).toBeGreaterThan(0);
       expect(r.details.anchor_status).toBe('divergent');
       expect(r.passed).toBe(false);

--- a/packages/eval-surface/src/__tests__/eval-surface.test.ts
+++ b/packages/eval-surface/src/__tests__/eval-surface.test.ts
@@ -7,6 +7,7 @@ import {
   AuditRepository,
   CURRENT_AUDIT_HASH_VERSION,
   MemoryRepository,
+  appendAnchor,
   computeEntryHash,
   computeManifestHash,
   createTestDatabase,
@@ -136,6 +137,10 @@ describe('evaluateProvenanceIntegrity', () => {
   // "no amnesty" branch deterministically, regardless of the host filesystem
   // (never reads a real ~/.teamkb manifest during unit tests).
   const NO_MANIFEST = join(tmpdir(), 'gsb-eval-no-such-manifest-should-not-exist.json');
+  // Same discipline for the anchor log: a never-existing path forces the F2
+  // cross-check down its graceful bootstrap branch ('no_anchors_yet') so tests
+  // not ABOUT anchoring never read a real ~/.teamkb/audit/anchors.jsonl.
+  const NO_ANCHORS = join(tmpdir(), 'gsb-eval-no-such-anchors-should-not-exist.jsonl');
 
   // ---- audit-row helpers (real repo, real chain) ------------------------
   // Mirrors packages/store/src/__tests__/audit-verify.test.ts idioms: insert
@@ -219,6 +224,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
     expect(r.name).toBe('provenance-integrity');
     expect(r.details.content_hash_mismatches).toBe(0);
@@ -237,6 +243,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
     expect(r.details.content_hash_mismatches).toBe(1);
     expect(r.passed).toBe(false);
@@ -246,6 +253,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
     expect(r.passed).toBe(true);
     expect(r.score).toBe(1);
@@ -260,6 +268,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
 
     // A benign fork is NOT tampering → the eval must pass (the whole R5 fix).
@@ -283,6 +292,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
 
     expect(Number(r.details.tamper_signatures)).toBeGreaterThan(0);
@@ -302,6 +312,7 @@ describe('evaluateProvenanceIntegrity', () => {
     const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
       tenantId: DEFAULT_TENANT,
       exceptionManifestPath: NO_MANIFEST,
+      anchorLogPath: NO_ANCHORS,
     });
     expect(r.details.content_hash_mismatches).toBe(1);
     expect(r.details.tamper_signatures).toBe(0);
@@ -353,6 +364,7 @@ describe('evaluateProvenanceIntegrity', () => {
       const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
         tenantId: DEFAULT_TENANT,
         exceptionManifestPath: manifestPath,
+        anchorLogPath: NO_ANCHORS,
       });
       // The break is DOCUMENTED (byte-pinned) → not a tamper signature → passes,
       // but is disclosed as a documented exception.
@@ -363,5 +375,114 @@ describe('evaluateProvenanceIntegrity', () => {
     } finally {
       if (existsSync(manifestPath)) rmSync(manifestPath);
     }
+  });
+
+  // -----------------------------------------------------------------------
+  // External-anchor cross-check (Track F2). The anchor log is the witness
+  // that makes a post-anchor rewrite/truncation DETECTABLE (not impossible);
+  // these tests pin the composed verdict: bootstrap is graceful, benign forks
+  // still pass with anchors present, truncation/rewrite fail closed.
+  // -----------------------------------------------------------------------
+  describe('anchor cross-check (F2)', () => {
+    let anchorPath: string;
+    beforeEach(() => {
+      anchorPath = join(
+        tmpdir(),
+        `gsb-eval-anchors-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+      );
+    });
+    afterEach(() => {
+      if (existsSync(anchorPath)) rmSync(anchorPath);
+    });
+
+    it('bootstrap: a missing anchor log reports no_anchors_yet and does NOT fail', () => {
+      memRepo.insert(makeMemory({ content: 'unanchored brain memory' }));
+      seedChain(3);
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: NO_MANIFEST,
+        anchorLogPath: anchorPath, // never written → absent
+      });
+      expect(r.details.anchor_status).toBe('no_anchors_yet');
+      expect(r.details.anchor_count).toBe(0);
+      expect(r.passed).toBe(true);
+      expect(r.score).toBe(1);
+    });
+
+    it('an anchored, untouched chain reads consistent and passes', () => {
+      memRepo.insert(makeMemory({ content: 'anchored brain memory' }));
+      seedChain(3);
+      appendAnchor(auditRepo, anchorPath, { tenantId: DEFAULT_TENANT });
+
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: NO_MANIFEST,
+        anchorLogPath: anchorPath,
+      });
+      expect(r.details.anchor_count).toBe(1);
+      expect(r.details.anchor_status).toBe('consistent');
+      expect(r.passed).toBe(true);
+      expect(r.score).toBe(1);
+    });
+
+    it('FAILS CLOSED on an anchored-then-truncated chain even though the chain verifies internally clean', () => {
+      memRepo.insert(makeMemory({ content: 'soon-to-be-truncated brain' }));
+      const ids = seedChain(3);
+      appendAnchor(auditRepo, anchorPath, { tenantId: DEFAULT_TENANT });
+
+      // Truncate AFTER anchoring: drop the newest row out-of-band. The
+      // remaining 2-row chain still verifies internally clean (no tamper
+      // signatures) — ONLY the anchor cross-check can catch this.
+      db.prepare('DELETE FROM audit_events WHERE id = ?').run(ids[2]);
+
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: NO_MANIFEST,
+        anchorLogPath: anchorPath,
+      });
+      expect(r.details.tamper_signatures).toBe(0); // intra-chain sees nothing
+      expect(Number(r.details.anchor_history_truncated)).toBeGreaterThan(0);
+      expect(r.details.anchor_status).toBe('divergent');
+      expect(r.passed).toBe(false);
+      expect(r.score).toBeLessThan(1);
+    });
+
+    it('FAILS CLOSED when the head at an anchored position was rewritten', () => {
+      memRepo.insert(makeMemory({ content: 'soon-to-be-rewritten brain' }));
+      const ids = seedChain(3);
+      appendAnchor(auditRepo, anchorPath, { tenantId: DEFAULT_TENANT });
+
+      // Rewrite the anchored head row's stored hash after anchoring.
+      db.prepare(`UPDATE audit_events SET entry_hash = ? WHERE id = ?`).run('f'.repeat(64), ids[2]);
+
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: NO_MANIFEST,
+        anchorLogPath: anchorPath,
+      });
+      expect(Number(r.details.anchor_history_rewritten)).toBeGreaterThan(0);
+      expect(r.details.anchor_status).toBe('divergent');
+      expect(r.passed).toBe(false);
+    });
+
+    it('a benign CHAIN_FORK anchored as-is still PASSES with anchors present (the live-brain shape)', () => {
+      memRepo.insert(makeMemory({ content: 'forked-then-anchored brain' }));
+      const ids = seedChain(3);
+      // The fork exists at anchor time (write-time ordering artifact) — the
+      // anchor witnesses the forked chain as-is, so nothing diverges.
+      forkLastRowBackToFirst(ids);
+      appendAnchor(auditRepo, anchorPath, { tenantId: DEFAULT_TENANT });
+
+      const r = evaluateProvenanceIntegrity(memRepo, auditRepo, {
+        tenantId: DEFAULT_TENANT,
+        exceptionManifestPath: NO_MANIFEST,
+        anchorLogPath: anchorPath,
+      });
+      expect(Number(r.details.chain_forks)).toBeGreaterThan(0); // disclosed
+      expect(r.details.tamper_signatures).toBe(0);
+      expect(r.details.anchor_status).toBe('consistent');
+      expect(r.passed).toBe(true);
+      expect(r.score).toBe(1);
+    });
   });
 });

--- a/packages/eval-surface/src/provenance-integrity.ts
+++ b/packages/eval-surface/src/provenance-integrity.ts
@@ -64,7 +64,19 @@
  * anchor divergence is treated as evidence of a post-anchor rewrite. Bootstrap
  * is graceful: a missing or empty anchor log reports
  * `anchor_status: 'no_anchors_yet'` and does NOT fail — a brain that has never
- * anchored has nothing to diverge from. The anchor-log path is configurable
+ * anchored has nothing to diverge from.
+ *
+ * ## What this evaluator does NOT do (runbook 045 carries the same bullets)
+ *
+ *   - It cannot tell a bootstrap brain from one whose LOCAL anchor log was
+ *     deleted: both collapse to `no_anchors_yet` and pass vacuously. The gap
+ *     is closed OUTSIDE this evaluator by the off-box witness — the runbook's
+ *     `git -C ~/.teamkb/audit fetch origin && git status` divergence check
+ *     against the force-push-protected remote — not by this code.
+ *   - It does not identify WHO rewrote history (no actor attribution; local
+ *     mode has no cross-actor non-repudiation).
+ *   - It does not make rewrites impossible — only detectable once anchored,
+ *     within one govern-cycle's anchoring window. The anchor-log path is configurable
  * (`options.anchorLogPath` or `$TEAMKB_ANCHOR_LOG`, default
  * `~/.teamkb/audit/anchors.jsonl`).
  *
@@ -174,9 +186,25 @@ interface AnchorBreakCounts {
 function countAnchorBreaks(breaks: readonly AnchorBreak[]): AnchorBreakCounts {
   const counts: AnchorBreakCounts = { historyTruncated: 0, historyRewritten: 0, logIntegrity: 0 };
   for (const b of breaks) {
-    if (b.reason === 'HISTORY_TRUNCATED') counts.historyTruncated += 1;
-    else if (b.reason === 'HISTORY_REWRITTEN') counts.historyRewritten += 1;
-    else counts.logIntegrity += 1;
+    // Exhaustive over the AnchorBreak reason union: a future variant fails
+    // compilation here instead of being silently laundered into one of the
+    // existing buckets. Every branch still counts toward a fail-closed verdict.
+    switch (b.reason) {
+      case 'HISTORY_TRUNCATED':
+        counts.historyTruncated += 1;
+        break;
+      case 'HISTORY_REWRITTEN':
+        counts.historyRewritten += 1;
+        break;
+      case 'ANCHOR_HASH_MISMATCH':
+      case 'ANCHOR_LINK_MISMATCH':
+        counts.logIntegrity += 1;
+        break;
+      default: {
+        const unhandled: never = b.reason;
+        throw new Error(`unhandled anchor break reason: ${String(unhandled)}`);
+      }
+    }
   }
   return counts;
 }

--- a/packages/eval-surface/src/provenance-integrity.ts
+++ b/packages/eval-surface/src/provenance-integrity.ts
@@ -36,6 +36,38 @@
  * (integrity + ordering intact) with N disclosed forks", never as a silent
  * green nor a false red.
  *
+ * ## The external-anchor cross-check (Track F2)
+ *
+ * `verifyAuditChain` re-anchors on each row's STORED `entry_hash`, so a local
+ * writer who edits history AND re-hashes every later row forward still verifies
+ * clean — and a wholesale truncation of the newest rows leaves a shorter but
+ * internally-consistent chain. The anchor log (`audit-anchor.ts`, committed to
+ * a force-push-protected git remote by the govern path) is the witness that
+ * makes those rewrites DETECTABLE — not impossible. This evaluator therefore
+ * ALSO cross-checks the chain against the anchor log via `verifyAnchors`, but
+ * it does NOT use `verifyAnchors(...).ok`: that raw boolean is
+ * `chain.breaks.length === 0 && …`, which is red-by-construction on the live
+ * brain (the ~155 carried forks above). Instead the verdict is composed:
+ *
+ *   - chain breaks    → the 3-state classifier (forks + byte-pinned documented
+ *                       exceptions disclosed-not-failed; tamper signatures fail)
+ *   - anchor breaks   → ALWAYS fail closed, partitioned for the report into
+ *                       `HISTORY_TRUNCATED` (chain now shorter than an anchored
+ *                       snapshot), `HISTORY_REWRITTEN` (the head at an anchored
+ *                       position changed — the rewrite `verifyAuditChain` alone
+ *                       cannot see), and anchor-LOG integrity breaks
+ *                       (`ANCHOR_HASH_MISMATCH` / `ANCHOR_LINK_MISMATCH`: the
+ *                       witness log itself was edited or spliced).
+ *
+ * There is no benign anchor break: benign forks live on the CHAIN side (they
+ * are write-time ordering artifacts, anchored as-is), so any live-chain vs
+ * anchor divergence is treated as evidence of a post-anchor rewrite. Bootstrap
+ * is graceful: a missing or empty anchor log reports
+ * `anchor_status: 'no_anchors_yet'` and does NOT fail — a brain that has never
+ * anchored has nothing to diverge from. The anchor-log path is configurable
+ * (`options.anchorLogPath` or `$TEAMKB_ANCHOR_LOG`, default
+ * `~/.teamkb/audit/anchors.jsonl`).
+ *
  * ## The manifest (optional)
  *
  * If an exception manifest exists, documented (byte-pinned known-migration)
@@ -60,13 +92,14 @@ import { join } from 'node:path';
 
 import { computeContentHash } from '@qmd-team-intent-kb/common';
 import type {
+  AnchorBreak,
   AuditChainRow,
   AuditRepository,
   ExceptionManifest,
   MemoryRepository,
   StoredRowTuple,
 } from '@qmd-team-intent-kb/store';
-import { classifyChainBreaks, readManifest, verifyAuditChain } from '@qmd-team-intent-kb/store';
+import { classifyChainBreaks, readManifest, verifyAnchors } from '@qmd-team-intent-kb/store';
 
 import type { EvaluatorResult } from './types.js';
 
@@ -80,6 +113,9 @@ const DEFAULT_EXCEPTION_MANIFEST_PATH = join(
   'exceptions.manifest.json',
 );
 
+/** Default on-disk location of a brain's external anchor log. */
+const DEFAULT_ANCHOR_LOG_PATH = join(homedir(), '.teamkb', 'audit', 'anchors.jsonl');
+
 export interface ProvenanceIntegrityOptions {
   /** Tenant to scope the per-memory content-integrity walk. Omit = all tenants. */
   readonly tenantId?: string;
@@ -90,6 +126,14 @@ export interface ProvenanceIntegrityOptions {
    * (no amnesty → every tamper-reason break is a tamper signature).
    */
   readonly exceptionManifestPath?: string;
+  /**
+   * Path to the external anchor log (JSONL of `AnchorRecord`s appended by the
+   * govern path). When omitted, falls back to `$TEAMKB_ANCHOR_LOG` then to
+   * `~/.teamkb/audit/anchors.jsonl`. A missing or empty log is the graceful
+   * bootstrap case (`anchor_status: 'no_anchors_yet'`), NOT a failure; any
+   * live-chain vs anchor divergence fails closed.
+   */
+  readonly anchorLogPath?: string;
 }
 
 /**
@@ -112,6 +156,29 @@ function loadManifest(explicitPath: string | undefined): ExceptionManifest | nul
   // readManifest throws on a corrupt/edited manifest — let it propagate: a
   // present manifest that fails its own integrity gates must not be ignored.
   return readManifest(path);
+}
+
+/**
+ * The fail-closed partition of anchor breaks for the report. Every anchor
+ * break gates the verdict (there is no benign anchor divergence — see the
+ * module doc); the partition exists so the report says WHICH rewrite class
+ * was detected, matching the 3-state discipline used for chain breaks.
+ */
+interface AnchorBreakCounts {
+  historyTruncated: number;
+  historyRewritten: number;
+  /** ANCHOR_HASH_MISMATCH + ANCHOR_LINK_MISMATCH — the witness log itself edited/spliced. */
+  logIntegrity: number;
+}
+
+function countAnchorBreaks(breaks: readonly AnchorBreak[]): AnchorBreakCounts {
+  const counts: AnchorBreakCounts = { historyTruncated: 0, historyRewritten: 0, logIntegrity: 0 };
+  for (const b of breaks) {
+    if (b.reason === 'HISTORY_TRUNCATED') counts.historyTruncated += 1;
+    else if (b.reason === 'HISTORY_REWRITTEN') counts.historyRewritten += 1;
+    else counts.logIntegrity += 1;
+  }
+  return counts;
 }
 
 /** Build the classifier's id → current-stored-tuple map from the live audit rows. */
@@ -145,7 +212,20 @@ export function evaluateProvenanceIntegrity(
     if (!VALID_SOURCES.has(m.source)) invalidSources += 1;
   }
 
-  const chain = verifyAuditChain(auditRepo);
+  // Cross-check the chain against the external anchor log. We deliberately do
+  // NOT consume `anchorResult.ok` — it folds in `chain.breaks.length === 0`,
+  // which is red-by-construction on the live brain's carried forks. The chain
+  // breaks go through the 3-state classifier below; only the ANCHOR breaks
+  // (all fail-closed) are taken from this result.
+  const anchorLogPath =
+    options.anchorLogPath ?? process.env.TEAMKB_ANCHOR_LOG ?? DEFAULT_ANCHOR_LOG_PATH;
+  const anchorResult = verifyAnchors(auditRepo, anchorLogPath);
+  const chain = anchorResult.chain;
+  const anchorCounts = countAnchorBreaks(anchorResult.anchorBreaks);
+  const anchorDiverged = anchorResult.anchorBreaks.length > 0;
+  // Bootstrap: a brain that has never anchored has nothing to diverge from.
+  const anchorStatus =
+    anchorResult.anchorCount === 0 ? 'no_anchors_yet' : anchorDiverged ? 'divergent' : 'consistent';
 
   // Partition the breaks the walker found into tamper signatures, documented
   // (byte-pinned) exceptions, and benign CHAIN_FORKs, using the merged 3-state
@@ -161,17 +241,30 @@ export function evaluateProvenanceIntegrity(
 
   // Pass on the SECURITY property: genuine tampering only. Benign CHAIN_FORKs
   // and byte-pinned documented exceptions do NOT fail the verdict; they are
-  // disclosed in `details` for honest reporting (010-AT-RISK R5).
-  const passed = contentHashMismatches === 0 && invalidSources === 0 && tamperSignatures === 0;
+  // disclosed in `details` for honest reporting (010-AT-RISK R5). ANY anchor
+  // divergence fails closed: the chain may verify internally clean after a
+  // full re-hash or a truncation — the anchor cross-check is exactly the
+  // witness that catches those (F2). Bootstrap (no anchors yet) is vacuously
+  // consistent, so `anchorDiverged` is false and does not fail.
+  const passed =
+    contentHashMismatches === 0 &&
+    invalidSources === 0 &&
+    tamperSignatures === 0 &&
+    !anchorDiverged;
 
   // Score: fraction of integrity checks that held. Only the GATING checks count
   // as failures (content-hash mismatch, invalid source, presence of tamper
-  // signatures); benign forks / documented exceptions are NOT failures, so they
-  // do not drag the score below the 1.0 threshold on an untampered-but-forked
-  // brain. The chain contributes exactly one gating check (tamper-free or not),
-  // matching the pre-fix denominator so a clean brain still scores 1.0.
-  const totalChecks = memories.length * 2 + 1;
-  const failedChecks = contentHashMismatches + invalidSources + (tamperSignatures > 0 ? 1 : 0);
+  // signatures, anchor divergence); benign forks / documented exceptions are
+  // NOT failures, so they do not drag the score below the 1.0 threshold on an
+  // untampered-but-forked brain. The chain contributes one gating check
+  // (tamper-free or not) and the anchor cross-check one more (consistent — or
+  // vacuously so at bootstrap — or not), so a clean brain still scores 1.0.
+  const totalChecks = memories.length * 2 + 2;
+  const failedChecks =
+    contentHashMismatches +
+    invalidSources +
+    (tamperSignatures > 0 ? 1 : 0) +
+    (anchorDiverged ? 1 : 0);
   const score = totalChecks === 0 ? 1 : (totalChecks - failedChecks) / totalChecks;
 
   return {
@@ -193,6 +286,18 @@ export function evaluateProvenanceIntegrity(
       documented_exceptions: documentedExceptions,
       // Whether a byte-pinned exception manifest was loaded for this run.
       exception_manifest_loaded: manifest !== null,
+      // ---- external-anchor cross-check (F2) — every break below GATES ----
+      // Snapshots in the anchor log this chain was cross-checked against.
+      anchor_count: anchorResult.anchorCount,
+      // 'no_anchors_yet' (bootstrap, vacuous pass) | 'consistent' | 'divergent'.
+      anchor_status: anchorStatus,
+      // Chain now has FEWER rows than an anchored snapshot recorded.
+      anchor_history_truncated: anchorCounts.historyTruncated,
+      // The head at an anchored position changed — the re-hash-forward rewrite
+      // that intra-chain verification alone cannot see.
+      anchor_history_rewritten: anchorCounts.historyRewritten,
+      // The witness log itself was edited or spliced (hash/link mismatch).
+      anchor_log_integrity_breaks: anchorCounts.logIntegrity,
     },
   };
 }


### PR DESCRIPTION
## What

- `evaluateProvenanceIntegrity` (packages/eval-surface/src/provenance-integrity.ts) now cross-checks the live audit chain against the external anchor log via `verifyAnchors`, composing the verdict instead of consuming the raw `verifyAnchors(...).ok` boolean. New options: `anchorLogPath` (fallback `$TEAMKB_ANCHOR_LOG`, default `~/.teamkb/audit/anchors.jsonl`). New details: `anchor_count`, `anchor_status` (`no_anchors_yet` | `consistent` | `divergent`), `anchor_history_truncated`, `anchor_history_rewritten`, `anchor_log_integrity_breaks`.
- CI smoke `provenance:ci` extended with the bootstrap assertion plus a second on-disk brain: anchored → `consistent` → truncated-after-anchoring → fail-closed.
- 5 new unit tests in the eval-surface suite covering the full anchor matrix.
- F1 runbook: `000-docs/045-OD-RNBK-anchor-remote-divergence-recovery.md` (+ `000-INDEX.md` entry) — operator procedure for the anchor witness remote.

## Why (decision rationale)

`verifyAnchors(...).ok` is `chain.breaks.length === 0 && anchorBreaks.length === 0`. The live brain carries ~155 benign hash-version migration breaks under the ratified D5 posture (carry-with-documented-exception, never re-hash), so the raw boolean is **red-by-construction** — false with zero tampering present. Meanwhile the evaluator never consulted anchors at all, so truncating the newest rows (which leaves the chain internally clean) was invisible to every gate.

The fix applies the already-ratified 3-state model: chain breaks go through `classifyChainBreaks` (benign forks + byte-pinned documented exceptions disclosed-not-failed; tamper signatures fail), and anchor breaks — for which there is no benign class, since benign forks are write-time artifacts anchored as-is — **always fail closed**, partitioned as `HISTORY_TRUNCATED` / `HISTORY_REWRITTEN` / anchor-log integrity. Bootstrap (no anchor log yet) reports itself and passes.

Chose composing the verdict in the evaluator over relaxing `verifyAnchors.ok` in the store: the store primitive stays strict for callers that want the raw view; verdict policy lives with the component that already owns the 3-state classification.

## Layers touched

- `packages/eval-surface` (evaluator + unit tests + `provenance:ci` smoke) — the only runtime change.
- `.github/workflows/ci.yml` — comment-only update on the moat-evals step.
- `000-docs/` — F1 runbook + index (docs only).
- Invariant change: the provenance-integrity verdict now ALSO gates on anchor consistency (scope below).

## How it works

`evaluateProvenanceIntegrity` calls `verifyAnchors(auditRepo, anchorLogPath)` once, reuses its embedded `verifyAuditChain` result for the existing 3-state chain classification, and counts `anchorBreaks` into three fail-closed buckets. `passed` adds `anchorBreaks.length === 0`; the score adds one anchor-consistency gating check (denominator `memories*2 + 2`), so clean and bootstrap brains still score 1.0.

## Verification & evidence

- Unit: `pnpm --filter @qmd-team-intent-kb/eval-surface test` → 32/32 (2 files). New tests: `bootstrap: a missing anchor log reports no_anchors_yet and does NOT fail`, `an anchored, untouched chain reads consistent and passes`, `FAILS CLOSED on an anchored-then-truncated chain even though the chain verifies internally clean` (asserts `tamper_signatures: 0` + `anchor_history_truncated > 0` — only the anchor cross-check catches it), `FAILS CLOSED when the head at an anchored position was rewritten`, `a benign CHAIN_FORK anchored as-is still PASSES with anchors present`.
- Smoke: `pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci` → exit 0; truncated-brain verdict printed `tamper_signatures: 0, anchor_status: divergent, anchor_history_truncated: 1, passed: false`.
- Workspace: `pnpm -r typecheck` clean; `pnpm -r test` 15 packages / 2119 tests green (one local flake on qmd-adapter's live-index retrieval test under parallel load; passes standalone on both baseline and this branch — not touched by this diff); `pnpm lint` clean; `pnpm format` applied.
- Honesty law: forbidden-claim scan on all new content — only negated uses of tamper-proof / non-repudiation; "append-only" qualified ("by protocol").

## Risk assessment

Fail-closed semantics widen: any brain whose chain diverges from its anchor log now FAILS provenance integrity where it previously passed silently. Scope: only brains that HAVE an anchor log (bootstrap unchanged, passes); the live brain's anchors were taken against current history, so no false red is expected there. A genuinely restored-from-backup brain will now correctly read `divergent` until reconciled per the runbook — that is the intended behavior, not a regression. No API surface removed; `verifyAnchors` itself is unchanged.

## Operational impact

None on deploys/env/migrations. Optional new env `TEAMKB_ANCHOR_LOG`. Evaluator consumers get five new details fields (additive). CI workflows unchanged except comments; `provenance:ci` (required moat-evals gate + nightly) now also proves the anchor scenarios.

## Follow-up & deferred

- Wiring `anchor_status: divergent` into an operator alert (the runbook's manual fetch/status check is the current cross-machine complement).
- Tenant-scoped anchor verification remains bundled with the existing global-chain design note (bead tr08.21).

Do NOT merge — review lane; merge is handled centrally.

**Refs:** #286 (Wave-1 epic · beads qmd-team-intent-kb-m8u.4 + m8u.3 runbook half)
**Governance links:** blueprint 019-PP-PLAN (umbrella) · Wave-0 decision 044-AT-DECR · reviewer law minimax-review.yml (fixed in #291)
