### PR TITLE
ci(review): fix the unparseable minimax-review.yml (unescaped apostrophes from the rename)

### DIFF
--- a/.github/workflows/minimax-review.yml
+++ b/.github/workflows/minimax-review.yml
@@ -83,7 +83,7 @@ jobs:
           # the MINIMAX_SYSTEM_PROMPT repo variable.
           MINIMAX_SYSTEM_PROMPT: >-
             ${{ vars.MINIMAX_SYSTEM_PROMPT || 'You are an advisory code reviewer
-            for Bob's Big Brain Registrar (formerly qmd-team-intent-kb), the deterministic GOVERN engine of
+            for Bob''s Big Brain Registrar (formerly qmd-team-intent-kb), the deterministic GOVERN engine of
             Bob''s Big Brain: a pnpm/TypeScript monorepo (packages/schema,
             policy-engine, common, qmd-adapter, store; apps/api, curator,
             git-exporter, edge-daemon) that consumes ICO''s spool of memory
@@ -153,7 +153,7 @@ jobs:
           INCLUDE_PR_BODY: 'true'
           MINIMAX_SYSTEM_PROMPT: >-
             ${{ vars.MINIMAX_ADVERSARIAL_PROMPT || 'You are an ADVERSARIAL
-            claims auditor for Bob's Big Brain Registrar (formerly qmd-team-intent-kb), the deterministic
+            claims auditor for Bob''s Big Brain Registrar (formerly qmd-team-intent-kb), the deterministic
             GOVERN engine of Bob''s Big Brain, where the costliest failure mode
             is a status claim that outruns its evidence. Assume the pull request
             overstates what it proves, then try to REFUTE every claim it makes —


### PR DESCRIPTION
## What
Escapes two apostrophes (`Bob's` → `Bob''s`) at lines 86 and 156 of `.github/workflows/minimax-review.yml`, inside the single-quoted `${{ }}` prompt expressions.

## Why
The rename commit a8f4999 left these two occurrences unescaped, making the whole workflow file unparseable. Every run since shows as a 0-second `push`-event failure with the file path shown instead of the workflow name — meaning **no PR on this repo has received its MiniMax review lanes since the rename**. The other three Bob's Big Brain repos escape correctly and run green.

## Layer
CI only — the advisory review workflow. No runtime code.

## Verification & evidence
- `python3 yaml.safe_load` parses the fixed file (it rejected the old one).
- The two MiniMax lanes on THIS PR run from the merge ref containing the fix — their appearance as real jobs (not 0s push failures) is the end-to-end proof.
- Broken-run evidence: workflow runs 29707789771 / 29707780981 / 29707741933 (0s, event=push, failure).

## Risk
None beyond CI: two-character escape change; advisory workflow, never a required check.

## Operational impact
Restores the advisory review lanes for open PRs #288/#289/#290 — after merge, a PR body edit (`edited` trigger) re-fires the lanes from the fixed merge ref.

**Refs:** #286 (Wave-1 program hygiene)