### PR TITLE
feat(eval): scheduled real-corpus governed retrieval eval anchor (GSB C1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,9 @@ secrets/*.private.hex
 !keys/*.pub
 .worktrees/
 
-# Retrieval eval JSON artifacts (vps.3) — emitted per run, uploaded by CI, never committed
-packages/qmd-adapter/eval-results/
+# Retrieval eval JSON artifacts (vps.3) — emitted per run, uploaded by CI, never committed.
+# The governed-anchor snapshot LOCK and FLOOR files (C1) are committed configuration,
+# not run artifacts, so they are explicitly un-ignored below.
+packages/qmd-adapter/eval-results/*
+!packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
+!packages/qmd-adapter/eval-results/governed-brain-v1-floor.json

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "dataset": "governed-brain-v1",
   "k": 10,
   "epsilon": 0.001,

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
@@ -1,0 +1,13 @@
+{
+  "dataset": "governed-brain-v1",
+  "k": 10,
+  "epsilon": 0.001,
+  "floors": {
+    "overall": 0.5595,
+    "lexical": 1,
+    "semantic": 0.3393
+  },
+  "measuredAtUtc": "2026-07-19T23:16:40.218Z",
+  "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
+  "note": "Per-stratum mean Recall@10 floors measured against the frozen governed-brain-v1 snapshot. Update ONLY alongside a deliberate re-measure (and lock update on refreeze)."
+}

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
@@ -1,7 +1,8 @@
 {
-  "tarballPath": "/home/jeremy/.teamkb/eval-anchor/kb-export-frozen-20260719T230939Z.tar.zst",
+  "schemaVersion": 1,
+  "tarballPath": "~/.teamkb/eval-anchor/kb-export-frozen-20260719T230939Z.tar.zst",
   "sha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
   "createdAtUtc": "2026-07-19T23:09:49Z",
   "fileCount": 17295,
-  "corpusNote": "Frozen tar.zst of the private ~/.teamkb/kb-export tree (17295 files, ~80 MB uncompressed) taken 2026-07-19 on the dev box. The tarball itself is NEVER committed — only this SHA-256 pin is. Override the path with GOVERNED_EVAL_SNAPSHOT; a hash mismatch makes the anchor refuse to run (exit 2). Refreezing requires updating this lock AND re-measuring governed-brain-v1-floor.json in the same change."
+  "corpusNote": "Frozen tar.zst of the private ~/.teamkb/kb-export tree (17295 files, ~80 MB uncompressed) taken 2026-07-19 on the dev box. The tarball itself is NEVER committed \u2014 only this SHA-256 pin is. Override the path with GOVERNED_EVAL_SNAPSHOT; a hash mismatch makes the anchor refuse to run (exit 2). Refreezing requires updating this lock AND re-measuring governed-brain-v1-floor.json in the same change."
 }

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
@@ -1,0 +1,7 @@
+{
+  "tarballPath": "/home/jeremy/.teamkb/eval-anchor/kb-export-frozen-20260719T230939Z.tar.zst",
+  "sha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
+  "createdAtUtc": "2026-07-19T23:09:49Z",
+  "fileCount": 17295,
+  "corpusNote": "Frozen tar.zst of the private ~/.teamkb/kb-export tree (17295 files, ~80 MB uncompressed) taken 2026-07-19 on the dev box. The tarball itself is NEVER committed — only this SHA-256 pin is. Override the path with GOVERNED_EVAL_SNAPSHOT; a hash mismatch makes the anchor refuse to run (exit 2). Refreezing requires updating this lock AND re-measuring governed-brain-v1-floor.json in the same change."
+}

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "reindex": "node dist/cli.js reindex",
     "search-canary": "node dist/cli.js canary",
-    "eval:retrieval:ci": "node dist/eval/ci-retrieval-ratchet.js"
+    "eval:retrieval:ci": "node dist/eval/ci-retrieval-ratchet.js",
+    "eval:governed:local": "node dist/eval/governed-eval-anchor.js"
   },
   "dependencies": {
     "@qmd-team-intent-kb/schema": "workspace:*",

--- a/packages/qmd-adapter/src/__tests__/governed-eval-anchor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/governed-eval-anchor.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the governed eval anchor's pure logic (GSB Track C1):
+ * snapshot lock verification (SHA-256 pin, fail-closed) and per-stratum floor
+ * comparison. The full harness needs the private frozen snapshot + the qmd
+ * binary and is box-only — CI never runs it, so these tests cover exactly the
+ * logic CI CAN verify, using a tiny fixture tarball built in-test (skipped
+ * where tar/zstd are unavailable).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  checkFloors,
+  proposeFloor,
+  sha256File,
+  verifySnapshotAgainstLock,
+  type SnapshotLock,
+} from '../eval/governed-eval-anchor.js';
+import type { StratifiedReport, StratumMetrics } from '../eval/stratified-report.js';
+
+const tmpRoots: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), 'governed-anchor-test-'));
+  tmpRoots.push(d);
+  return d;
+}
+afterAll(() => {
+  for (const d of tmpRoots) rmSync(d, { recursive: true, force: true });
+});
+
+function lockFor(path: string, sha256: string): SnapshotLock {
+  return {
+    tarballPath: path,
+    sha256,
+    createdAtUtc: '2026-07-19T00:00:00Z',
+    fileCount: 2,
+    corpusNote: 'test fixture',
+  };
+}
+
+function zstdTarAvailable(): boolean {
+  try {
+    execFileSync('tar', ['--version'], { stdio: 'ignore' });
+    execFileSync('zstd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('sha256File / verifySnapshotAgainstLock', () => {
+  it('computes the same SHA-256 as node:crypto over the bytes', () => {
+    const dir = tmp();
+    const p = join(dir, 'blob.bin');
+    writeFileSync(p, 'governed anchor fixture bytes');
+    const expected = createHash('sha256').update(readFileSync(p)).digest('hex');
+    expect(sha256File(p)).toBe(expected);
+  });
+
+  it('accepts a tarball whose hash matches the lock', () => {
+    const dir = tmp();
+    const p = join(dir, 'snap.tar.zst');
+    writeFileSync(p, 'pretend-tarball-contents');
+    const verdict = verifySnapshotAgainstLock(lockFor(p, sha256File(p)), p);
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) expect(verdict.sha256).toBe(sha256File(p));
+  });
+
+  it('refuses (fail-closed) when the tarball bytes drift from the locked hash', () => {
+    const dir = tmp();
+    const p = join(dir, 'snap.tar.zst');
+    writeFileSync(p, 'original bytes');
+    const lock = lockFor(p, sha256File(p));
+    writeFileSync(p, 'tampered bytes'); // corpus changed after the freeze
+    const verdict = verifySnapshotAgainstLock(lock, p);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toMatch(/mismatch/i);
+  });
+
+  it('refuses when the tarball is missing entirely', () => {
+    const dir = tmp();
+    const verdict = verifySnapshotAgainstLock(
+      lockFor(join(dir, 'nope.tar.zst'), 'deadbeef'),
+      join(dir, 'nope.tar.zst'),
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toMatch(/not found/);
+  });
+
+  it.skipIf(!zstdTarAvailable())(
+    'verifies a REAL tiny zstd tarball built in-test (round-trip)',
+    () => {
+      const dir = tmp();
+      const corpus = join(dir, 'kb-export', 'curated');
+      mkdirSync(corpus, { recursive: true });
+      writeFileSync(join(corpus, 'a.md'), '# doc a\n');
+      writeFileSync(join(corpus, 'b.md'), '# doc b\n');
+      const tarball = join(dir, 'kb-export-frozen-test.tar.zst');
+      execFileSync('tar', ['-C', dir, '--zstd', '-cf', tarball, 'kb-export']);
+
+      const good = verifySnapshotAgainstLock(lockFor(tarball, sha256File(tarball)), tarball);
+      expect(good.ok).toBe(true);
+
+      const bad = verifySnapshotAgainstLock(lockFor(tarball, '0'.repeat(64)), tarball);
+      expect(bad.ok).toBe(false);
+    },
+  );
+});
+
+function stratum(name: string, recall: number, n = 10): StratumMetrics {
+  return { stratum: name, queryCount: n, meanRecallAtK: recall, meanNdcgAtK: recall, mrr: recall };
+}
+
+function reportWith(overall: number, byKind: StratumMetrics[]): StratifiedReport {
+  return {
+    dataset: 'governed-brain-v1',
+    backend: 'test',
+    k: 10,
+    overall: stratum(
+      'overall',
+      overall,
+      byKind.reduce((s, k) => s + k.queryCount, 0),
+    ),
+    byKind,
+  };
+}
+
+describe('checkFloors', () => {
+  const floors = { overall: 0.8, lexical: 0.9, semantic: 0.7 };
+
+  it('holds when every stratum is at or above floor − epsilon', () => {
+    const sr = reportWith(0.8, [stratum('lexical', 0.8995), stratum('semantic', 0.71)]);
+    const checks = checkFloors(sr, floors, 0.001);
+    expect(checks.every((c) => c.held)).toBe(true);
+    // 0.8995 ≥ 0.9 − 0.001 — inside the epsilon slack, not a regression.
+    expect(checks.find((c) => c.stratum === 'lexical')?.held).toBe(true);
+  });
+
+  it('flags exactly the regressed stratum', () => {
+    const sr = reportWith(0.8, [stratum('lexical', 0.95), stratum('semantic', 0.5)]);
+    const checks = checkFloors(sr, floors, 0.001);
+    const failed = checks.filter((c) => !c.held);
+    expect(failed.map((c) => c.stratum)).toEqual(['semantic']);
+    expect(failed[0]?.floor).toBeCloseTo(0.699, 10);
+  });
+
+  it('treats a stratum missing from the report as measured 0 (regression, not pass)', () => {
+    const sr = reportWith(0.9, [stratum('lexical', 0.95)]); // semantic vanished
+    const checks = checkFloors(sr, floors, 0.001);
+    const semantic = checks.find((c) => c.stratum === 'semantic');
+    expect(semantic?.measured).toBe(0);
+    expect(semantic?.held).toBe(false);
+  });
+
+  it('checks the overall floor against the report overall row', () => {
+    const sr = reportWith(0.5, [stratum('lexical', 0.95), stratum('semantic', 0.95)]);
+    const checks = checkFloors(sr, { overall: 0.8 }, 0.001);
+    expect(checks).toHaveLength(1);
+    expect(checks[0]?.held).toBe(false);
+  });
+});
+
+describe('proposeFloor', () => {
+  it('captures overall + every observed stratum, rounded to 4 places', () => {
+    const sr = reportWith(0.81234567, [
+      stratum('lexical', 0.9999999),
+      stratum('semantic', 0.7123449),
+    ]);
+    const proposed = proposeFloor(sr, 'abc123');
+    expect(proposed.dataset).toBe('governed-brain-v1');
+    expect(proposed.snapshotSha256).toBe('abc123');
+    expect(proposed.floors['overall']).toBe(0.8123);
+    expect(proposed.floors['lexical']).toBe(1);
+    expect(proposed.floors['semantic']).toBe(0.7123);
+    expect(proposed.epsilon).toBeGreaterThan(0);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/governed-eval-anchor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/governed-eval-anchor.test.ts
@@ -35,6 +35,7 @@ afterAll(() => {
 
 function lockFor(path: string, sha256: string): SnapshotLock {
   return {
+    schemaVersion: 1,
     tarballPath: path,
     sha256,
     createdAtUtc: '2026-07-19T00:00:00Z',

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -67,6 +67,9 @@ import { stratify, formatStratifiedReport } from './stratified-report.js';
 import type { StratifiedReport } from './stratified-report.js';
 import { qmdRetrievalFn } from './qmd-retrieval.js';
 import { GOVERNED_BRAIN_V1_DATASET } from './datasets/governed-brain-v1.js';
+// Deliberate coupling: the synthetic ratchet's epsilon is the project's one
+// canonical regression-slack value; the anchor reuses it so the two gates can
+// never drift apart silently.
 import { RATCHET_EPSILON } from './datasets/synthetic-v1.js';
 
 /** The throwaway tenant the temp anchor index is bound to. Never the real brain's tenant. */
@@ -88,7 +91,14 @@ export const FLOOR_BASENAME = 'governed-brain-v1-floor.json';
 
 /** Shape of `eval-results/governed-brain-v1-snapshot.lock.json`. */
 export interface SnapshotLock {
-  /** Absolute default path of the frozen tarball on the eval box (override: GOVERNED_EVAL_SNAPSHOT). */
+  /** Lock-format version — bump on any breaking shape change. */
+  schemaVersion: number;
+  /**
+   * Default path of the frozen tarball on the eval box (override:
+   * GOVERNED_EVAL_SNAPSHOT). A leading `~/` resolves against the runtime
+   * home directory so the committed lock carries no box-specific username —
+   * the binding content of the lock is the SHA-256, not the path.
+   */
   tarballPath: string;
   /** SHA-256 (hex) of the tarball — the pin. Mismatch = refuse to eval. */
   sha256: string;
@@ -100,6 +110,8 @@ export interface SnapshotLock {
 
 /** Shape of `eval-results/governed-brain-v1-floor.json`. */
 export interface GovernedFloor {
+  /** Floor-format version — bump on any breaking shape change. */
+  schemaVersion: number;
   dataset: string;
   k: number;
   /** Slack below each floor value before a measurement counts as a regression. */
@@ -110,6 +122,15 @@ export interface GovernedFloor {
   /** SHA-256 of the snapshot the floors were measured against. */
   snapshotSha256: string;
   note: string;
+}
+
+/**
+ * Expand a leading `~/` against the runtime home directory. The committed lock
+ * stores the tarball path in `~/`-form so no box-specific username lands in
+ * the repo; the SHA-256 pin — not the path — is what binds the snapshot.
+ */
+export function expandHome(p: string): string {
+  return p.startsWith('~/') ? join(homedir(), p.slice(2)) : p;
 }
 
 /** One stratum's floor verdict. */
@@ -177,6 +198,7 @@ export function proposeFloor(sr: StratifiedReport, snapshotSha256: string): Gove
     floors[s.stratum] = round4(s.meanRecallAtK);
   }
   return {
+    schemaVersion: 1,
     dataset: sr.dataset,
     k: sr.k,
     epsilon: RATCHET_EPSILON,
@@ -302,7 +324,7 @@ export async function runGovernedEvalAnchor(): Promise<number> {
     return 2;
   }
   const lock = JSON.parse(readFileSync(lockPath, 'utf8')) as SnapshotLock;
-  const tarballPath = process.env['GOVERNED_EVAL_SNAPSHOT'] ?? lock.tarballPath;
+  const tarballPath = expandHome(process.env['GOVERNED_EVAL_SNAPSHOT'] ?? lock.tarballPath);
 
   const verified = verifySnapshotAgainstLock(lock, tarballPath);
   if (!verified.ok) {

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -1,0 +1,488 @@
+#!/usr/bin/env node
+/**
+ * Governed retrieval eval ANCHOR (GSB blueprint Track C1).
+ *
+ * The synthetic PR-time ratchet (`ci-retrieval-ratchet.ts`) guards retrieval in
+ * CI, but only over a committed toy corpus. The REAL number — the hand-labeled
+ * `governed-brain-v1` query set whose gold ids are `qmd://` citations into the
+ * real `~/.teamkb/kb-export` — has never been enforced anywhere, because that
+ * corpus is private (~80 MB, never committed) and lives only on the dev box.
+ *
+ * This script makes the real number a scheduled, deterministic anchor:
+ *
+ *   1. Resolve a FROZEN corpus snapshot: a tar.zst of `kb-export` pinned by a
+ *      committed lock file (`eval-results/governed-brain-v1-snapshot.lock.json`)
+ *      carrying its SHA-256. The tarball itself stays under
+ *      `~/.teamkb/eval-anchor/` on the box — only the hash is committed.
+ *      Hash mismatch = exit 2: never eval an unpinned corpus.
+ *   2. Extract to a temp dir, build a THROWAWAY index there (TEAMKB_BASE_PATH
+ *      isolation — the live `~/.teamkb` is never read or written), and run all
+ *      governed-brain-v1 queries through the production `adapter.query()` path.
+ *   3. Compare per-stratum Recall@10 against the committed floor file
+ *      (`eval-results/governed-brain-v1-floor.json`), with the same epsilon
+ *      slack as the synthetic ratchet. Regression = exit 1.
+ *   4. No floor file yet = exit 3 with a proposed floor printed + written —
+ *      never an invented passing verdict.
+ *   5. Optionally (GOVERNED_EVAL_LIVE=1) also run the same queries against a
+ *      temp index built from the LIVE kb-export — informational only, clearly
+ *      labeled "live (unfrozen)", never part of the verdict.
+ *
+ * Determinism: frozen corpus + fixed queries + pinned workspace qmd = a stable
+ * floor. The live corpus drifts daily (that is its job), which is exactly why
+ * the anchor evals the frozen snapshot by default.
+ *
+ * This is NOT a CI gate — it runs on the dev box via the
+ * `bbb-eval-governed.timer` systemd user timer (the corpus can never reach a
+ * GitHub runner). The synthetic ratchet remains the PR-time gate.
+ *
+ * Run: `pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:governed:local`
+ * (puts the pinned workspace qmd on PATH; `pnpm -r build` first).
+ *
+ * Exit codes: 0 = floor held; 1 = a stratum regressed (or unexpected error);
+ * 2 = qmd/snapshot unavailable or hash mismatch or empty index (fail loud);
+ * 3 = no committed floor yet (proposed floor emitted).
+ *
+ * @module eval/governed-eval-anchor
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { QmdAdapter } from '../adapter.js';
+import { reindex } from '../reindex/reindex.js';
+import { runEval } from './run-eval.js';
+import { stratify, formatStratifiedReport } from './stratified-report.js';
+import type { StratifiedReport } from './stratified-report.js';
+import { qmdRetrievalFn } from './qmd-retrieval.js';
+import { GOVERNED_BRAIN_V1_DATASET } from './datasets/governed-brain-v1.js';
+import { RATCHET_EPSILON } from './datasets/synthetic-v1.js';
+
+/** The throwaway tenant the temp anchor index is bound to. Never the real brain's tenant. */
+const ANCHOR_TENANT = 'governed-eval-anchor';
+
+/**
+ * qmd executor timeout for the anchor. The DEFAULT_TIMEOUT (30 s) is tuned for
+ * interactive search; a cold `qmd collection add` over the real corpus (~17k
+ * files — guides alone is ~10k) takes minutes. Measured 2026-07-19: kb-guides
+ * registration alone was ~65 s on the dev box.
+ */
+const ANCHOR_QMD_TIMEOUT_MS = 600_000;
+
+/** The committed lock file pinning the frozen snapshot (relative to the package root). */
+export const SNAPSHOT_LOCK_BASENAME = 'governed-brain-v1-snapshot.lock.json';
+
+/** The committed per-stratum floor file (relative to the package root). */
+export const FLOOR_BASENAME = 'governed-brain-v1-floor.json';
+
+/** Shape of `eval-results/governed-brain-v1-snapshot.lock.json`. */
+export interface SnapshotLock {
+  /** Absolute default path of the frozen tarball on the eval box (override: GOVERNED_EVAL_SNAPSHOT). */
+  tarballPath: string;
+  /** SHA-256 (hex) of the tarball — the pin. Mismatch = refuse to eval. */
+  sha256: string;
+  createdAtUtc: string;
+  /** Files inside the snapshot's kb-export tree at freeze time. */
+  fileCount: number;
+  corpusNote: string;
+}
+
+/** Shape of `eval-results/governed-brain-v1-floor.json`. */
+export interface GovernedFloor {
+  dataset: string;
+  k: number;
+  /** Slack below each floor value before a measurement counts as a regression. */
+  epsilon: number;
+  /** Per-stratum mean Recall@10 floors (e.g. lexical / semantic / overall). */
+  floors: Record<string, number>;
+  measuredAtUtc: string;
+  /** SHA-256 of the snapshot the floors were measured against. */
+  snapshotSha256: string;
+  note: string;
+}
+
+/** One stratum's floor verdict. */
+export interface FloorCheck {
+  stratum: string;
+  measured: number;
+  baseline: number;
+  floor: number;
+  held: boolean;
+}
+
+/** Streaming-free SHA-256 of a file (hex). The snapshot is ~80 MB — fine in one read. */
+export function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/** Verify a tarball against its committed lock. Pure verdict — no side effects. */
+export function verifySnapshotAgainstLock(
+  lock: SnapshotLock,
+  tarballPath: string,
+): { ok: true; sha256: string } | { ok: false; reason: string } {
+  if (!existsSync(tarballPath)) {
+    return { ok: false, reason: `snapshot tarball not found: ${tarballPath}` };
+  }
+  const actual = sha256File(tarballPath);
+  if (actual !== lock.sha256) {
+    return {
+      ok: false,
+      reason:
+        `snapshot SHA-256 mismatch for ${tarballPath}:\n` +
+        `  locked:   ${lock.sha256}\n` +
+        `  actual:   ${actual}\n` +
+        'Refusing to eval an unpinned corpus. If the snapshot was intentionally ' +
+        'refrozen, update the lock file AND re-measure the floor in the same change.',
+    };
+  }
+  return { ok: true, sha256: actual };
+}
+
+/**
+ * Compare a stratified report against the committed per-stratum floors.
+ * A stratum listed in the floors but absent from the report measures 0 —
+ * a vanished stratum is a regression, not a pass.
+ */
+export function checkFloors(
+  sr: StratifiedReport,
+  floors: Record<string, number>,
+  epsilon: number,
+): FloorCheck[] {
+  return Object.entries(floors)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([stratum, baseline]) => {
+      const metrics =
+        stratum === 'overall' ? sr.overall : sr.byKind.find((s) => s.stratum === stratum);
+      const measured = metrics?.meanRecallAtK ?? 0;
+      const floor = baseline - epsilon;
+      return { stratum, measured, baseline, floor, held: measured >= floor };
+    });
+}
+
+/** Build a proposed floor file from measured numbers (first run / refreeze). */
+export function proposeFloor(sr: StratifiedReport, snapshotSha256: string): GovernedFloor {
+  const floors: Record<string, number> = { overall: round4(sr.overall.meanRecallAtK) };
+  for (const s of sr.byKind) {
+    floors[s.stratum] = round4(s.meanRecallAtK);
+  }
+  return {
+    dataset: sr.dataset,
+    k: sr.k,
+    epsilon: RATCHET_EPSILON,
+    floors,
+    measuredAtUtc: new Date().toISOString(),
+    snapshotSha256,
+    note:
+      'Per-stratum mean Recall@10 floors measured against the frozen governed-brain-v1 ' +
+      'snapshot. Update ONLY alongside a deliberate re-measure (and lock update on refreeze).',
+  };
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}
+
+/** Package root (works from src via tsx AND from dist compiled). */
+function packageRootDir(): string {
+  const hereDir = dirname(fileURLToPath(import.meta.url));
+  return join(hereDir, '..', '..');
+}
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract the frozen tarball and build a throwaway index over it.
+ * Returns the ready adapter's export dir inside `tmpBase`.
+ * TEAMKB_BASE_PATH MUST already point at `tmpBase` before calling — the
+ * adapter's executor snapshots the tenant env at construction time.
+ */
+function extractSnapshot(tarballPath: string, tmpBase: string): string {
+  execFileSync('tar', ['-x', '--zstd', '-f', tarballPath, '-C', tmpBase], { stdio: 'inherit' });
+  const exportDir = join(tmpBase, 'kb-export');
+  if (!existsSync(exportDir)) {
+    throw new Error(
+      `snapshot extracted but ${exportDir} is missing — the tarball must contain kb-export/ at its root`,
+    );
+  }
+  return exportDir;
+}
+
+/** Build a temp index over `exportDir` and run the full governed-brain-v1 set. */
+async function evalCorpus(
+  exportDir: string,
+  backendLabel: string,
+): Promise<
+  { ok: true; sr: StratifiedReport; perQuery: EvalPerQuery[] } | { ok: false; reason: string }
+> {
+  const adapter = new QmdAdapter({
+    tenantId: ANCHOR_TENANT,
+    exportDir,
+    timeout: ANCHOR_QMD_TIMEOUT_MS,
+  });
+  const built = await reindex(adapter);
+  if (!built.ok) {
+    return { ok: false, reason: `index build failed: ${built.error.code}: ${built.error.message}` };
+  }
+  const retrieve = qmdRetrievalFn(adapter, ANCHOR_TENANT, 'curated');
+  const report = await runEval(GOVERNED_BRAIN_V1_DATASET, retrieve, {
+    k: 10,
+    backend: backendLabel,
+  });
+  if (!report.perQuery.some((r) => r.retrieved.length > 0)) {
+    return {
+      ok: false,
+      reason:
+        'every query returned 0 hits against the freshly built index — the index is ' +
+        'empty/misbuilt, not a real score',
+    };
+  }
+  return {
+    ok: true,
+    sr: stratify(report, GOVERNED_BRAIN_V1_DATASET.queries),
+    perQuery: report.perQuery.map((q) => ({
+      id: q.id,
+      kind: q.kind ?? 'untagged',
+      query: q.query,
+      hit: q.recallAtK > 0,
+      recallAtK: q.recallAtK,
+      retrievedTop3: q.retrieved.slice(0, 3),
+    })),
+  };
+}
+
+interface EvalPerQuery {
+  id: string;
+  kind: string;
+  query: string;
+  hit: boolean;
+  recallAtK: number;
+  retrievedTop3: string[];
+}
+
+/**
+ * The full anchor run. Returns the process exit code (0 held / 1 regressed /
+ * 2 unavailable-or-unpinned / 3 no floor yet).
+ */
+export async function runGovernedEvalAnchor(): Promise<number> {
+  if (!qmdAvailable()) {
+    console.error(
+      'qmd binary not on PATH — run via ' +
+        '`pnpm --filter @qmd-team-intent-kb/qmd-adapter eval:governed:local` so the ' +
+        'pinned workspace qmd resolves.',
+    );
+    return 2;
+  }
+
+  const resultsDir = join(packageRootDir(), 'eval-results');
+  const lockPath = join(resultsDir, SNAPSHOT_LOCK_BASENAME);
+  if (!existsSync(lockPath)) {
+    console.error(
+      `snapshot lock file not found: ${lockPath}\n` +
+        'The anchor never evals an unpinned corpus. Freeze a snapshot ' +
+        '(tar -C ~/.teamkb -cf - kb-export | zstd) and commit its lock first.',
+    );
+    return 2;
+  }
+  const lock = JSON.parse(readFileSync(lockPath, 'utf8')) as SnapshotLock;
+  const tarballPath = process.env['GOVERNED_EVAL_SNAPSHOT'] ?? lock.tarballPath;
+
+  const verified = verifySnapshotAgainstLock(lock, tarballPath);
+  if (!verified.ok) {
+    console.error(verified.reason);
+    return 2;
+  }
+
+  // Isolated temp base — TEAMKB_BASE_PATH drives every qmd index/registry path,
+  // so nothing here can read or write the real `~/.teamkb`. MUST be set BEFORE
+  // constructing QmdAdapter (its executor snapshots env at construction).
+  const tmpBase = mkdtempSync(join(tmpdir(), 'teamkb-governed-anchor-'));
+  process.env['TEAMKB_BASE_PATH'] = tmpBase;
+
+  try {
+    const exportDir = extractSnapshot(tarballPath, tmpBase);
+    const frozen = await evalCorpus(exportDir, 'qmd-bm25+fts5-rrf (frozen snapshot)');
+    if (!frozen.ok) {
+      console.error(frozen.reason);
+      return 2;
+    }
+
+    console.log(
+      `\n=== Governed Second Brain — REAL-corpus retrieval anchor (${frozen.sr.dataset}) ===`,
+    );
+    console.log(`snapshot: ${tarballPath}`);
+    console.log(`sha256:   ${verified.sha256}  ·  frozen ${lock.createdAtUtc}`);
+    console.log(`temp index: ${tmpBase}  ·  tenant: ${ANCHOR_TENANT}\n`);
+    console.log(formatStratifiedReport(frozen.sr));
+
+    const floorPath = join(resultsDir, FLOOR_BASENAME);
+    if (!existsSync(floorPath)) {
+      const proposed = proposeFloor(frozen.sr, verified.sha256);
+      const proposedPath = join(resultsDir, 'governed-brain-v1-floor.proposed.json');
+      mkdirSync(resultsDir, { recursive: true });
+      writeFileSync(proposedPath, `${JSON.stringify(proposed, null, 2)}\n`);
+      console.log(
+        `\nNO FLOOR YET — ${floorPath} does not exist. Measured numbers above are ` +
+          'REPORTED, not judged (a first run must never invent a passing verdict).',
+      );
+      console.log(`proposed floor written: ${proposedPath}`);
+      console.log('proposed floor JSON:');
+      console.log(JSON.stringify(proposed, null, 2));
+      writeArtifact(resultsDir, frozen.sr, verified.sha256, lock, null, [], frozen.perQuery);
+      return 3;
+    }
+
+    const floor = JSON.parse(readFileSync(floorPath, 'utf8')) as GovernedFloor;
+    const checks = checkFloors(frozen.sr, floor.floors, floor.epsilon);
+
+    console.log(`\n=== floor (per-stratum Recall@10 ≥ floor − ${floor.epsilon}) ===`);
+    for (const c of checks) {
+      console.log(
+        `  ${c.stratum.padEnd(12)} measured=${c.measured.toFixed(4)}  ` +
+          `floor=${c.baseline.toFixed(4)}  min=${c.floor.toFixed(4)}  ` +
+          `${c.held ? 'OK' : 'REGRESSED'}`,
+      );
+    }
+    if (floor.snapshotSha256 !== verified.sha256) {
+      console.warn(
+        'WARN: the floor was measured against a DIFFERENT snapshot ' +
+          `(floor: ${floor.snapshotSha256.slice(0, 12)}…, current: ${verified.sha256.slice(0, 12)}…). ` +
+          'Re-measure the floor after refreezing.',
+      );
+    }
+
+    // Informational live run — never part of the verdict, off by default so the
+    // frozen anchor stays the deterministic path.
+    await maybeRunLiveInformational();
+
+    writeArtifact(resultsDir, frozen.sr, verified.sha256, lock, floor, checks, frozen.perQuery);
+
+    const regressed = checks.filter((c) => !c.held);
+    if (regressed.length > 0) {
+      console.error(
+        `\nANCHOR FAILED — ${regressed.length} stratum/strata regressed below the committed floor:`,
+      );
+      for (const c of regressed) {
+        console.error(
+          `  ${c.stratum}: ${c.measured.toFixed(4)} < ${c.floor.toFixed(4)}. ` +
+            'Investigate the retrieval change; if it is a legitimate improvement elsewhere, ' +
+            're-measure and update the floor file in the same PR.',
+        );
+      }
+      return 1;
+    }
+
+    console.log('\nANCHOR PASS — no stratum regressed below its committed floor.');
+    return 0;
+  } finally {
+    rmSync(tmpBase, { recursive: true, force: true });
+  }
+}
+
+/**
+ * GOVERNED_EVAL_LIVE=1: run the same query set against a temp index built from
+ * a COPY of the live kb-export. Numbers drift with the corpus — labeled as such
+ * and never gated. Any failure here is reported and swallowed.
+ */
+async function maybeRunLiveInformational(): Promise<void> {
+  if (process.env['GOVERNED_EVAL_LIVE'] !== '1') return;
+  const liveExport = join(homedir(), '.teamkb', 'kb-export');
+  if (!existsSync(liveExport)) {
+    console.log('\n(live run requested but ~/.teamkb/kb-export does not exist — skipped)');
+    return;
+  }
+  const liveTmp = mkdtempSync(join(tmpdir(), 'teamkb-governed-live-'));
+  process.env['TEAMKB_BASE_PATH'] = liveTmp;
+  try {
+    const exportCopy = join(liveTmp, 'kb-export');
+    cpSync(liveExport, exportCopy, { recursive: true });
+    const live = await evalCorpus(exportCopy, 'qmd-bm25+fts5-rrf (live, unfrozen)');
+    if (!live.ok) {
+      console.warn(`\nlive (unfrozen, informational) run failed: ${live.reason}`);
+      return;
+    }
+    console.log('\n=== live (unfrozen, informational — NOT the anchor verdict) ===');
+    console.log(formatStratifiedReport(live.sr));
+  } catch (err: unknown) {
+    console.warn('\nlive (unfrozen, informational) run crashed:', err);
+  } finally {
+    rmSync(liveTmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * JSON artifact mirroring the synthetic ratchet's `writeEvalArtifact`: metrics,
+ * snapshot pin, floors + verdicts, per-query outcomes. Evidence, not the gate —
+ * a write failure never flips the verdict. Path override: GOVERNED_EVAL_JSON_PATH.
+ */
+function writeArtifact(
+  resultsDir: string,
+  sr: StratifiedReport,
+  snapshotSha256: string,
+  lock: SnapshotLock,
+  floor: GovernedFloor | null,
+  checks: FloorCheck[],
+  perQuery: EvalPerQuery[],
+): void {
+  const outPath =
+    process.env['GOVERNED_EVAL_JSON_PATH'] ?? join(resultsDir, 'governed-brain-v1.json');
+  const artifact = {
+    dataset: sr.dataset,
+    backend: sr.backend,
+    k: sr.k,
+    generatedAt: new Date().toISOString(),
+    snapshot: {
+      tarballPath: lock.tarballPath,
+      sha256: snapshotSha256,
+      createdAtUtc: lock.createdAtUtc,
+      fileCount: lock.fileCount,
+    },
+    overall: sr.overall,
+    byKind: sr.byKind,
+    floor: floor
+      ? { epsilon: floor.epsilon, floors: floor.floors, checks, pass: checks.every((c) => c.held) }
+      : null,
+    perQuery,
+  };
+  try {
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`);
+    console.log(`\neval artifact written: ${outPath}`);
+  } catch (err: unknown) {
+    console.error(`WARN could not write eval artifact to ${outPath}:`, err);
+  }
+}
+
+/** Entry point — resolve the exit code and terminate. */
+export async function main(): Promise<void> {
+  let code: number;
+  try {
+    code = await runGovernedEvalAnchor();
+  } catch (err: unknown) {
+    console.error('governed eval anchor crashed:', err);
+    code = 1;
+  }
+  process.exit(code);
+}
+
+// Direct-execution guard — run only as the process entry, not on import.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  void main();
+}


### PR DESCRIPTION
## What

A scheduled, real-corpus retrieval eval **anchor** (GSB blueprint Track C1): a new box-only harness `packages/qmd-adapter/src/eval/governed-eval-anchor.ts` (package script `eval:governed:local`) that runs the hand-labeled `governed-brain-v1` query set (42 queries; gold ids are real `qmd://` citations) against a **frozen, SHA-256-pinned snapshot** of the private `~/.teamkb/kb-export` corpus and enforces per-stratum Recall@10 floors, plus:

- `eval-results/governed-brain-v1-snapshot.lock.json` — the committed pin (path, SHA-256, file count, freeze timestamp). The tarball itself never leaves the dev box.
- `eval-results/governed-brain-v1-floor.json` — the committed per-stratum floors, measured from the first real run.
- A `.gitignore` refinement: `eval-results/*` stays ignored (run artifacts) while exactly the lock + floor files are un-ignored (committed configuration).
- 10 unit tests for the CI-verifiable logic (lock verification incl. a real tiny zstd tarball built in-test, floor comparison, proposed-floor generation).
- On-box (not in this diff): `~/bin/bbb-eval-governed.sh` wrapper + `bbb-eval-governed.{service,timer}` systemd **user** units (daily 05:00, `Persistent=true`), notify-lib `arm_fail_trap` → Slack `#cron-failures` on any nonzero exit, silent on success.

## Why + decision rationale

The synthetic PR-time ratchet (`ci-retrieval-ratchet.ts`) only guards a committed toy corpus; the REAL retrieval number was never enforced anywhere.

- **Frozen snapshot over live corpus**: the live `kb-export` drifts daily by design, so a floor over it cannot distinguish retrieval regressions from corpus changes. The frozen tar.zst + fixed queries + pinned workspace `@tobilu/qmd` 2.5.3 is deterministic — two consecutive runs produced byte-identical metrics. Live numbers remain available behind `GOVERNED_EVAL_LIVE=1`, clearly labeled "live (unfrozen, informational)", never gated.
- **Scheduled dev-box job over a GitHub runner**: the corpus is private (~80 MB, 17,295 files) and can never be committed or uploaded. The anchor is deliberately NOT wired into any CI workflow — the synthetic ratchet stays the PR-time gate; this is a nightly dead-man's-floor on the box that holds the data.
- **Fail-loud pinning**: hash mismatch or missing tarball = exit 2, never "eval whatever is there". Missing floor = exit 3 with a proposed floor emitted — a first run must never invent a passing verdict.

## Layers touched

- `packages/qmd-adapter` eval layer only (new script + tests + package script). No adapter/search/runtime code changed. No CI workflow changed. Invariants unchanged — the production `adapter.query()` path (qmd BM25 + native FTS5, RRF-fused) is what gets measured, not a re-implementation.

## How it works

1. Read the committed lock; resolve the tarball (`GOVERNED_EVAL_SNAPSHOT` env override), verify SHA-256 — mismatch = exit 2.
2. Extract to `mkdtemp`, set `TEAMKB_BASE_PATH` **before** constructing `QmdAdapter` (the executor snapshots tenant env at construction — same trap the synthetic ratchet documents), `reindex()` a throwaway tenant (`governed-eval-anchor`), run all 42 queries through `qmdRetrievalFn` at k=10. A 600 s executor timeout replaces the interactive 30 s default (cold `qmd collection add` over the 10k-file guides dir alone measured ~65 s).
3. Stratified report (`stratify`/`formatStratifiedReport`), compare each committed floor stratum at `floor − ε` (reuses `RATCHET_EPSILON = 0.001`); regression = exit 1, hold = exit 0. A stratum missing from the report measures 0 (regression, not a pass).
4. JSON artifact `eval-results/governed-brain-v1.json` (metrics, snapshot pin, floor verdicts, per-query outcomes) — evidence, not the gate; gitignored.

## Verification & evidence

Frozen-snapshot baseline (first run, exit 3 — measured, floors then committed from these exact numbers):

```
eval "governed-brain-v1" · backend=qmd-bm25+fts5-rrf (frozen snapshot) @k=10
  overall   n= 42  Recall@10=0.5595  nDCG@10=0.5426  MRR=0.5476
  lexical   n= 14  Recall@10=1.0000  nDCG@10=0.9411  MRR=0.9286
  semantic  n= 28  Recall@10=0.3393  nDCG@10=0.3433  MRR=0.3571
```

- Re-run with the committed floor: byte-identical metrics, `ANCHOR PASS`, **exit 0**.
- Snapshot pin: `sha256 0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b`, `~/.teamkb/eval-anchor/kb-export-frozen-20260719T230939Z.tar.zst` (17,295 files).
- Tamper check: pointing `GOVERNED_EVAL_SNAPSHOT` at a different file → SHA-256 mismatch refusal, **exit 2**.
- Timer live: `systemctl --user list-timers` → `Mon 2026-07-20 05:00:00 -06 … bbb-eval-governed.timer  bbb-eval-governed.service`.
- Wrapper pre-merge soak guard verified: on the main checkout (which predates this PR) it logged "pre-merge soak … skipping quietly" and exited 0 — no Slack until merge.
- Gates: `pnpm -r typecheck` clean; `eslint` clean; `pnpm format` applied; new tests 10/10; full `pnpm -r test` green across all 15 projects (2,124 tests).
- `git check-ignore` confirms the run artifact `eval-results/governed-brain-v1.json` stays untracked while lock + floor commit.

## Risk assessment

- **Low repo risk**: additive eval-only module; nothing imports it; not on any CI path. The exit-2 qmd-absent guard means it can never fake a pass on a cold machine.
- **Baseline honesty**: semantic Recall@10 = 0.3393 is a low absolute number — that is the known BM25 semantic recall wall the reranker track (Wave 0/044-AT-DECR) exists to address. The floor guards against *regression from here*, it does not claim sufficiency.
- **Snapshot is a single on-box file**: if `~/.teamkb/eval-anchor/` is lost, the anchor fails loudly (exit 2 → Slack) rather than silently passing; refreeze + re-measure restores it.

## Operational impact

- **New dev-box systemd user timer** `bbb-eval-governed.timer` (daily 05:00 local, `Persistent=true`) → `~/bin/bbb-eval-governed.sh` → runs from the MAIN checkout `~/000-projects/bobs-big-brain-registrar`. Silent on success (audit: `~/.local/state/bbb-eval-governed/{last-run.log,history.log}` + notify-lib `.beat`/`.ok` heartbeats, liveness-sweep visible); Slack `#cron-failures` on any nonzero exit (debounced). Until this PR merges to main, the wrapper soaks quietly (guard: script/floor absent → log + exit 0).
- **Snapshot location**: `~/.teamkb/eval-anchor/kb-export-frozen-20260719T230939Z.tar.zst` (~14.7 MB compressed). Not in any repo, not in backups' derived-skip path conflict (it lives outside `kb-export/`).
- **Floor update procedure**: on a deliberate retrieval improvement, re-run `eval:governed:local`, copy the measured numbers into `governed-brain-v1-floor.json` in the same PR. On refreeze: create a new tarball, update the lock (path + sha256 + fileCount + createdAtUtc) AND re-measure the floor in the same change — the anchor warns when floor and snapshot hashes diverge and refuses entirely on lock/tarball mismatch.
- No env, migration, dependency, or deploy-order changes.

## Follow-up & deferred

- Re-measure the floor after the reranker track lands (the semantic stratum is precisely what it should move).
- Optional: wire the nightly JSON artifact into a tracked history series if trend analysis is wanted beyond `history.log`.

**Refs:** #286 (Wave-1 epic · bead qmd-team-intent-kb-m8u.2)

---
## Review response (2026-07-19)
- **Defect lane:** all three findings addressed in the follow-up commit — the lock now stores a `~/`-form path expanded at runtime (no box username in the repo; SHA-256 remains the binding pin), both committed JSONs + interfaces gained `schemaVersion: 1`, and the `RATCHET_EPSILON` import is annotated as deliberate coupling. Re-verified with a full real-corpus anchor run: byte-identical metrics, ANCHOR PASS exit 0.
- **Adversarial phrasing corrections, accepted:** "byte-identical" is an observed dev-box property of a design built for determinism (frozen pinned corpus + fixed queries + pinned qmd), not a diff-provable invariant — expect re-measurement after any qmd bump. The timer/wrapper bullets are **operational, post-merge evidence on the eval box**, not gated by this diff. The `governed-brain-v1` dataset file predates this PR; this diff proves the anchor consumes its 42 queries, not the hand-labeling itself.
