### PR TITLE
feat(freshness): promoted memories become promptly searchable (D1) and index staleness is observable (D2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,12 @@ jobs:
           export TEAMKB_BASE_PATH="$FIXTURE"
           export TEAMKB_TENANT_ID="ci-canary"
           node packages/qmd-adapter/dist/cli.js reindex
-          node packages/qmd-adapter/dist/cli.js canary
+          # --max-staleness-seconds (D2): also fail if a promotion has waited
+          # >24h to become searchable. On this ephemeral fixture there is no
+          # brain DB, so the gate reports "unmeasured" and passes — the
+          # assertion bites on the live-brain canary (runbook 027-OD-OPSM),
+          # which runs this same CLI against the real ~/.teamkb.
+          node packages/qmd-adapter/dist/cli.js canary --max-staleness-seconds 86400
 
       - name: Dependency audit
         run: pnpm audit --audit-level=moderate

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,7 +29,8 @@
     "@qmd-team-intent-kb/store": "workspace:*",
     "@qmd-team-intent-kb/curator": "workspace:*",
     "@qmd-team-intent-kb/policy-engine": "workspace:*",
-    "@qmd-team-intent-kb/qmd-adapter": "workspace:*"
+    "@qmd-team-intent-kb/qmd-adapter": "workspace:*",
+    "@qmd-team-intent-kb/git-exporter": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/apps/api/src/__tests__/health.test.ts
+++ b/apps/api/src/__tests__/health.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import type Database from 'better-sqlite3';
-import { createTestDatabase, PolicyRepository } from '@qmd-team-intent-kb/store';
+import {
+  createTestDatabase,
+  PolicyRepository,
+  IndexStateRepository,
+  MemoryRepository,
+} from '@qmd-team-intent-kb/store';
 import { buildRecommendedPolicy } from '@qmd-team-intent-kb/policy-engine';
 import type { PolicyRule } from '@qmd-team-intent-kb/schema';
 import { buildApp } from '../app.js';
+import { makeMemory } from './fixtures.js';
 
 const NOW = '2026-07-17T00:00:00.000Z';
 
@@ -92,5 +98,31 @@ describe('GET /api/health', () => {
     new PolicyRepository(db).insert({ ...partial, rules: [], enabled: false });
     const res = await app.inject({ method: 'GET', url: '/api/health' });
     expect(res.json<{ policyDormancy: unknown[] }>().policyDormancy).toEqual([]);
+  });
+
+  // ─── Index staleness surfacing (D2) ────────────────────────────────────────
+
+  it('reports indexStalenessSeconds null before measurement starts', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.json<{ indexStalenessSeconds: number | null }>().indexStalenessSeconds).toBeNull();
+  });
+
+  it('reports 0 staleness when the index has absorbed every promotion', async () => {
+    new IndexStateRepository(db).markIndexed('acme', NOW);
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.json<{ indexStalenessSeconds: number | null }>().indexStalenessSeconds).toBe(0);
+  });
+
+  it('reports positive staleness when a promotion post-dates the last index run — never degrading liveness', async () => {
+    new IndexStateRepository(db).markIndexed('acme', NOW);
+    // A promotion 1ms after the last index run → measured stale.
+    new MemoryRepository(db).insert(
+      makeMemory({ tenantId: 'acme', promotedAt: '2026-07-17T00:00:00.001Z' }),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    const body = res.json<{ status: string; indexStalenessSeconds: number | null }>();
+    expect(body.indexStalenessSeconds).toBeGreaterThan(0);
+    expect(body.status).toBe('healthy'); // staleness is an operator signal, not an outage
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/apps/api/src/__tests__/promote-then-search.qmd-integration.test.ts
+++ b/apps/api/src/__tests__/promote-then-search.qmd-integration.test.ts
@@ -1,0 +1,160 @@
+/**
+ * D1 acceptance: a promoted memory becomes retrievable IMMEDIATELY.
+ *
+ * Drives the REAL path end-to-end against the real qmd binary: a candidate is
+ * promoted through `POST /api/candidates/:id/promote` with the production
+ * `buildIndexRefresher` wired (exactly as `main.ts` wires it), and the adapter
+ * then finds the new memory — with NO manual export/reindex call in the test
+ * body. Before D1 this exact sequence returned 0 hits until the next daemon
+ * cycle / nightly govern pass ran.
+ *
+ * Also asserts the D2 side: the completed chain records `last_indexed_at`, so
+ * the staleness gauge reads 0 (fresh) — proving the FULL export→reindex chain
+ * ran (the gauge is only marked on full success), not just the native-FTS5
+ * fusion half masking a broken qmd path.
+ *
+ * Isolation mirrors adapter-qmd-integration.test.ts: TEAMKB_BASE_PATH is
+ * repointed at a tmp dir so the tenant's qmd registry/index never touch the
+ * operator's real ~/.teamkb. Skipped when qmd is not on PATH (CI puts the
+ * pinned workspace bin on PATH).
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+
+import {
+  createTestDatabase,
+  CandidateRepository,
+  IndexStateRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import { buildApp } from '../app.js';
+import { buildIndexRefresher } from '../services/index-refresher.js';
+import { makeCandidate } from './fixtures.js';
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_QMD = qmdAvailable();
+const TENANT = 'promote-search-e2e';
+
+describe.skipIf(!HAS_QMD)('promote → search immediately (D1, real qmd)', () => {
+  let workDir: string;
+  let exportDir: string;
+  let originalBasePath: string | undefined;
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let adapter: QmdAdapter;
+  let indexStateRepo: IndexStateRepository;
+
+  beforeEach(async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'promote-search-int-'));
+    exportDir = join(workDir, 'kb-export');
+    originalBasePath = process.env['TEAMKB_BASE_PATH'];
+    process.env['TEAMKB_BASE_PATH'] = join(workDir, 'teamkb');
+
+    db = createTestDatabase();
+    indexStateRepo = new IndexStateRepository(db);
+    adapter = new QmdAdapter({
+      tenantId: TENANT,
+      exportDir,
+      stalenessProbe: () => indexStateRepo.stalenessSeconds(TENANT),
+    });
+    // The production wiring from main.ts: refresher over the same db + adapter.
+    const indexRefresher = buildIndexRefresher({ db, adapter, exportDir });
+    app = buildApp({ db, silent: true, qmdAdapter: adapter, indexRefresher });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+    if (originalBasePath === undefined) delete process.env['TEAMKB_BASE_PATH'];
+    else process.env['TEAMKB_BASE_PATH'] = originalBasePath;
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('a memory promoted via the API is retrievable with no manual reindex', async () => {
+    const candidate = makeCandidate({
+      tenantId: TENANT,
+      title: 'Zephyr turbine maintenance cadence',
+      content:
+        'The zephyr turbine maintenance cadence is quarterly: inspect the ' +
+        'flux capacitor housing, torque the manifold bolts, and log the ' +
+        'inspection receipt in the maintenance ledger.',
+    });
+    new CandidateRepository(db).insert(candidate, computeContentHash(candidate.content));
+
+    // Promote through the real route (dev mode = admin; gating covered elsewhere).
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/candidates/${candidate.id}/promote?tenantId=${TENANT}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const memory = res.json() as { id: string; lifecycle: string };
+    expect(memory.lifecycle).toBe('active');
+
+    // NO manual export/reindex here — that is the point of D1.
+    const found = await adapter.query('zephyr turbine maintenance', 'all', TENANT);
+    expect(found.ok).toBe(true);
+    if (found.ok) {
+      expect(found.value.length).toBeGreaterThan(0);
+      // The hit is the exported markdown of the promoted memory, cited via qmd://.
+      expect(found.value.some((r) => r.file.startsWith('qmd://'))).toBe(true);
+    }
+
+    // D2 cross-check: the chain recorded completion, so staleness is 0 (fresh).
+    // This proves the FULL export→reindex chain ran — the gauge is only marked
+    // on full success, so a broken qmd path masked by native-FTS5 fusion would
+    // leave this null/positive.
+    expect(indexStateRepo.stalenessSeconds(TENANT)).toBe(0);
+
+    // And the health surfaces agree end-to-end.
+    const health = await adapter.health();
+    expect(health.stalenessSeconds).toBe(0);
+    const apiHealth = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(apiHealth.json<{ indexStalenessSeconds: number | null }>().indexStalenessSeconds).toBe(
+      0,
+    );
+  }, 60_000);
+
+  it('a failed refresh leaves the promotion durable and the staleness gauge honest', async () => {
+    // A refresher whose chain always fails — the memory must still promote (200)
+    // and the gauge must NOT be marked fresh.
+    const failingRefresher = {
+      refreshAfterPromotion: async () => ({ ok: false, error: 'synthetic chain failure' }),
+    };
+    const app2 = buildApp({ db, silent: true, indexRefresher: failingRefresher });
+    await app2.ready();
+    try {
+      const candidate = makeCandidate({
+        tenantId: TENANT,
+        content: 'Distinct content for the failed-refresh path with enough length to pass.',
+      });
+      new CandidateRepository(db).insert(candidate, computeContentHash(candidate.content));
+
+      const res = await app2.inject({
+        method: 'POST',
+        url: `/api/candidates/${candidate.id}/promote?tenantId=${TENANT}`,
+      });
+      expect(res.statusCode).toBe(200); // promotion durable despite refresh failure
+
+      // Never marked → still unmeasured (no index_state row was ever written).
+      expect(indexStateRepo.stalenessSeconds(TENANT)).toBeNull();
+    } finally {
+      await app2.close();
+    }
+  }, 30_000);
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import { PolicyService } from './services/policy-service.js';
 import { HealthService } from './services/health-service.js';
 import { SearchService } from './services/search-service.js';
 import type { QmdQueryPort } from './services/search-service.js';
+import type { IndexRefresher } from './services/index-refresher.js';
 import { registerCandidateRoutes } from './routes/candidates.js';
 import { registerMemoryRoutes } from './routes/memories.js';
 import { registerPolicyRoutes } from './routes/policies.js';
@@ -85,6 +86,15 @@ export interface AppDependencies {
    * text-match over the curated store.
    */
   qmdAdapter?: QmdQueryPort;
+  /**
+   * Optional post-promotion index refresher (D1). When provided, a successful
+   * `POST /api/candidates/:id/promote` triggers the export→reindex chain AFTER
+   * the promotion transaction commits, so the new memory is searchable
+   * immediately instead of waiting for the next daemon cycle / nightly govern.
+   * Omitted (tests / no-qmd deployments) → promotion behavior is unchanged and
+   * the D2 staleness gauge reports the accumulating drift.
+   */
+  indexRefresher?: IndexRefresher;
 }
 
 /**
@@ -157,7 +167,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   // hook is active would be missing from the generated spec.
   void app.register(async (scope) => {
     registerHealthRoutes(scope, healthService);
-    registerCandidateRoutes(scope, candidateService, promotionService);
+    registerCandidateRoutes(scope, candidateService, promotionService, deps.indexRefresher);
     registerMemoryRoutes(scope, memoryService, memoryRepo);
     registerPolicyRoutes(scope, policyService);
     registerAuditRoutes(scope, auditRepo);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -21,13 +21,15 @@
  *   TEAMKB_REVOKED_FILE — durable revoke-by-actor list (default ~/.teamkb/revoked-actors.json)
  */
 import { resolve } from 'node:path';
-import { createDatabase } from '@qmd-team-intent-kb/store';
+import { createDatabase, IndexStateRepository } from '@qmd-team-intent-kb/store';
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
 import { loadTokenRecords } from './auth/token-registry.js';
 import type { QmdQueryPort } from './services/search-service.js';
+import { buildIndexRefresher } from './services/index-refresher.js';
+import type { IndexRefresher } from './services/index-refresher.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -37,12 +39,24 @@ async function main(): Promise<void> {
   // index is unavailable, run SQLite-only so the surface still answers.
   const tenantId = process.env['TEAMKB_TENANT_ID']?.trim() || 'intent-solutions';
   const exportDir = resolve(process.env['TEAMKB_EXPORT_DIR'] ?? resolveTeamKbPath('kb-export'));
-  const adapter = new QmdAdapter({ tenantId, exportDir });
+  // Freshness probe (D2): adapter.health() reports stalenessSeconds from the
+  // governed store — seconds since the oldest promotion the index has not
+  // absorbed (null = measurement not started; see IndexStateRepository).
+  const indexStateRepo = new IndexStateRepository(db);
+  const adapter = new QmdAdapter({
+    tenantId,
+    exportDir,
+    stalenessProbe: () => indexStateRepo.stalenessSeconds(tenantId),
+  });
 
   let qmdAdapter: QmdQueryPort | undefined;
+  let indexRefresher: IndexRefresher | undefined;
   const health = await adapter.health();
   if (health.available) {
     qmdAdapter = adapter;
+    // D1: a promote through this API triggers export→reindex after the
+    // promotion commits, so the memory is searchable immediately.
+    indexRefresher = buildIndexRefresher({ db, adapter, exportDir });
     process.stderr.write(
       `[teamkb-api] qmd wired — cited search enabled (tenant=${tenantId}, qmd=${health.version ?? '?'})\n`,
     );
@@ -73,7 +87,14 @@ async function main(): Promise<void> {
   // Pass the real bind host so the no-auth dev path is refused off-loopback:
   // an empty registry on a tailnet/0.0.0.0 bind throws at boot rather than
   // serving every request as role=admin. Loopback stays the default.
-  const app = buildApp({ db, tokens, qmdAdapter, bindHost: config.host, revokedFile });
+  const app = buildApp({
+    db,
+    tokens,
+    qmdAdapter,
+    indexRefresher,
+    bindHost: config.host,
+    revokedFile,
+  });
   await app.ready();
 
   const shutdown = async (signal: string): Promise<void> => {

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { ApiError, badRequest } from '../errors.js';
 import type { CandidateService } from '../services/candidate-service.js';
 import type { PromotionService } from '../services/promotion-service.js';
+import type { IndexRefresher } from '../services/index-refresher.js';
 
 /**
  * Register candidate intake, retrieval, and promotion routes.
@@ -16,6 +17,7 @@ export function registerCandidateRoutes(
   app: FastifyInstance,
   service: CandidateService,
   promotionService: PromotionService,
+  indexRefresher?: IndexRefresher,
 ): void {
   app.post(
     '/api/candidates',
@@ -86,6 +88,31 @@ export function registerCandidateRoutes(
           { type: actorType, id: request.actor ?? 'admin' },
           typeof body.reason === 'string' ? body.reason : undefined,
         );
+
+        // D1: the promotion transaction has COMMITTED (promote() is atomic —
+        // R9), so trigger the export→reindex chain now, making the memory
+        // searchable without waiting for the next daemon cycle. Awaited so the
+        // 200 means "promoted AND absorbed" on the happy path; best-effort
+        // because the memory is already durable — a failed refresh degrades to
+        // "stale but promoted", which the D2 staleness gauge reports, and must
+        // never turn a successful promotion into an error response.
+        if (indexRefresher !== undefined) {
+          try {
+            const refreshed = await indexRefresher.refreshAfterPromotion(tenantId);
+            if (!refreshed.ok) {
+              request.log.warn(
+                { tenantId, skipped: refreshed.skipped, error: refreshed.error },
+                'post-promotion index refresh did not complete; memory searchable after next cycle',
+              );
+            }
+          } catch (refreshErr) {
+            request.log.warn(
+              { tenantId, err: refreshErr },
+              'post-promotion index refresh threw; memory searchable after next cycle',
+            );
+          }
+        }
+
         return reply.status(200).send(memory);
       } catch (err) {
         if (err instanceof ApiError) {

--- a/apps/api/src/services/health-service.ts
+++ b/apps/api/src/services/health-service.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { PolicyRepository } from '@qmd-team-intent-kb/store';
+import { PolicyRepository, IndexStateRepository } from '@qmd-team-intent-kb/store';
 import { findUncoveredRuleTypes } from '@qmd-team-intent-kb/policy-engine';
 
 /** One active policy that leaves registered rules unenforced (5bm.10). */
@@ -24,6 +24,15 @@ interface HealthStatus {
    * config signal an operator should act on, not a process outage.
    */
   policyDormancy: PolicyDormancy[];
+  /**
+   * Index freshness (D2): worst-case seconds since a promotion that is NOT yet
+   * reflected in the search index, across every tenant that has begun
+   * measurement. `null` = unmeasured (no export→reindex chain has recorded
+   * completion yet), `0` = fresh, `> 0` = promote→search latency in seconds.
+   * Like dormancy, this never affects liveness — a stale index is an operator
+   * signal (the nightly canary enforces the threshold), not a process outage.
+   */
+  indexStalenessSeconds: number | null;
 }
 
 /**
@@ -51,7 +60,21 @@ export class HealthService {
       dbConnected,
       version: '0.4.0',
       policyDormancy: dbConnected ? this.checkPolicyDormancy() : [],
+      indexStalenessSeconds: dbConnected ? this.checkIndexStaleness() : null,
     };
+  }
+
+  /**
+   * Worst-case index staleness across tenants (D2). Read-only; any failure
+   * (e.g. a pre-migration DB without the index_state table) degrades to null
+   * (unmeasured) rather than failing the health probe.
+   */
+  private checkIndexStaleness(): number | null {
+    try {
+      return new IndexStateRepository(this.db).worstStalenessSeconds();
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/apps/api/src/services/index-refresher.ts
+++ b/apps/api/src/services/index-refresher.ts
@@ -1,0 +1,111 @@
+import type Database from 'better-sqlite3';
+import { runExport } from '@qmd-team-intent-kb/git-exporter';
+import {
+  MemoryRepository,
+  ExportStateRepository,
+  IndexStateRepository,
+} from '@qmd-team-intent-kb/store';
+import { reindex, type QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+
+/** Outcome of one post-promotion refresh — for logging/tests, never thrown. */
+export interface RefreshOutcome {
+  /** True when the FULL export→reindex chain completed and was recorded. */
+  ok: boolean;
+  /** Set when the refresh was skipped (with why) rather than attempted. */
+  skipped?: string;
+  /** Set when a step failed (with the failing step's message). */
+  error?: string;
+}
+
+/**
+ * Port the promote route calls after a promotion COMMITS (D1). Kept as an
+ * interface so tests can inject a fake and deployments without qmd can omit it.
+ */
+export interface IndexRefresher {
+  refreshAfterPromotion(tenantId: string): Promise<RefreshOutcome>;
+}
+
+/** Wiring for {@link buildIndexRefresher}. */
+export interface IndexRefresherOptions {
+  db: Database.Database;
+  /** The tenant-bound adapter the API already constructed for cited search. */
+  adapter: QmdAdapter;
+  /** git-exporter output dir — the same tree the adapter indexes. */
+  exportDir: string;
+  /** Export-state target id. Default matches the daemon/plugin: kb-export-default. */
+  exportTargetId?: string;
+  nowFn?: () => string;
+  log?: (msg: string) => void;
+}
+
+/**
+ * The D1 promote→searchable bridge for the API path.
+ *
+ * The curator-batch and plugin-govern paths already chain
+ * promote → `runExport` → `ensureCollections`+`update` (edge-daemon cycle steps
+ * 3–4; plugin `govern.ts` steps 3–4). The API's one-shot
+ * `POST /api/candidates/:id/promote` had NO such step — a promoted memory sat
+ * unsearchable until the next daemon cycle / nightly govern. This service
+ * composes the SAME primitives (`runExport` + the `reindex` primitive the
+ * canary/CLI already use — reuse, not reinvention) so the route can trigger a
+ * scoped index update immediately AFTER the promotion transaction commits.
+ *
+ * Never inside the transaction: `promote()` commits the memory + its receipt
+ * atomically (R9); this chain reads that committed state. Never throws: the
+ * memory is already durable, so a failed refresh must degrade to "stale but
+ * promoted" — which the D2 staleness gauge then reports — not fail the request.
+ *
+ * On FULL success it records `last_indexed_at` (IndexStateRepository), zeroing
+ * the tenant's staleness gauge; on any failure the gauge keeps reporting stale
+ * until the next successful chain (daemon cycle / govern pass) absorbs it.
+ */
+export function buildIndexRefresher(opts: IndexRefresherOptions): IndexRefresher {
+  const memoryRepo = new MemoryRepository(opts.db);
+  const exportStateRepo = new ExportStateRepository(opts.db);
+  const indexStateRepo = new IndexStateRepository(opts.db);
+  const targetId = opts.exportTargetId ?? 'kb-export-default';
+  const nowFn = opts.nowFn ?? ((): string => new Date().toISOString());
+  const log = opts.log ?? ((msg: string): void => void process.stderr.write(`${msg}\n`));
+
+  return {
+    async refreshAfterPromotion(tenantId: string): Promise<RefreshOutcome> {
+      // The adapter's qmd registry + index are bound to ONE tenant. A promotion
+      // in any other tenant cannot be absorbed by this adapter — skip rather
+      // than reindex the wrong scope. The promotion still moves that tenant's
+      // derived staleness, so the drift stays observable (D2).
+      if (tenantId !== opts.adapter.boundTenantId) {
+        return {
+          ok: false,
+          skipped: `adapter is bound to tenant ${opts.adapter.boundTenantId}, not ${tenantId}`,
+        };
+      }
+
+      // Watermark BEFORE the chain runs: a promotion landing mid-chain may not
+      // be absorbed, so marking with the pre-chain instant can only
+      // under-claim freshness, never over-claim it.
+      const indexedAt = nowFn();
+      try {
+        runExport(
+          memoryRepo,
+          exportStateRepo,
+          { outputDir: opts.exportDir, targetId, tenantId },
+          nowFn,
+        );
+
+        const reindexed = await reindex(opts.adapter);
+        if (!reindexed.ok) {
+          const msg = `${reindexed.error.code}: ${reindexed.error.message}`;
+          log(`[index-refresher] reindex failed (tenant=${tenantId}): ${msg}`);
+          return { ok: false, error: msg };
+        }
+
+        indexStateRepo.markIndexed(tenantId, indexedAt);
+        return { ok: true };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        log(`[index-refresher] refresh failed (tenant=${tenantId}): ${msg}`);
+        return { ok: false, error: msg };
+      }
+    },
+  };
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,12 +9,29 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../../packages/schema" },
-    { "path": "../../packages/common" },
-    { "path": "../../packages/store" },
-    { "path": "../../packages/policy-engine" },
-    { "path": "../../packages/test-fixtures" },
-    { "path": "../../packages/qmd-adapter" },
-    { "path": "../curator" }
+    {
+      "path": "../../packages/schema"
+    },
+    {
+      "path": "../../packages/common"
+    },
+    {
+      "path": "../../packages/store"
+    },
+    {
+      "path": "../../packages/policy-engine"
+    },
+    {
+      "path": "../../packages/test-fixtures"
+    },
+    {
+      "path": "../../packages/qmd-adapter"
+    },
+    {
+      "path": "../curator"
+    },
+    {
+      "path": "../git-exporter"
+    }
   ]
 }

--- a/apps/edge-daemon/src/__tests__/cycle.test.ts
+++ b/apps/edge-daemon/src/__tests__/cycle.test.ts
@@ -212,6 +212,43 @@ describe('runCycle', () => {
     expect(result.indexUpdate).toBeNull();
   });
 
+  it('records last_indexed_at (freshness consumption, D1/D2) on a successful index update', async () => {
+    const mockAdapter = {
+      ensureCollections: async () => ({ ok: true as const, value: [] }),
+      update: async () => ({ ok: true as const, value: undefined }),
+    };
+    const indexConfig = makeConfig({ spoolDir, enableExport: false, enableIndexUpdate: true });
+
+    const result = await runCycle(
+      indexConfig,
+      { ...deps, qmdAdapter: mockAdapter as never },
+      logger,
+    );
+
+    expect(result.indexUpdate!.ok).toBe(true);
+    const state = deps.indexStateRepo!.get(TENANT);
+    expect(state).not.toBeNull();
+    // The fixture nowFn is frozen — the watermark is the (pre-update) cycle clock.
+    expect(state!.lastIndexedAt).toBe(NOW);
+  });
+
+  it('does NOT record last_indexed_at when the index update fails (gauge must stay stale)', async () => {
+    const mockAdapter = {
+      ensureCollections: async () => ({ ok: true as const, value: [] }),
+      update: async () => ({ ok: false as const, error: { message: 'qmd unreachable' } }),
+    };
+    const indexConfig = makeConfig({ spoolDir, enableExport: false, enableIndexUpdate: true });
+
+    const result = await runCycle(
+      indexConfig,
+      { ...deps, qmdAdapter: mockAdapter as never },
+      logger,
+    );
+
+    expect(result.indexUpdate!.ok).toBe(false);
+    expect(deps.indexStateRepo!.get(TENANT)).toBeNull();
+  });
+
   it('records timestamps correctly', async () => {
     let callCount = 0;
     const timedConfig = makeConfig({

--- a/apps/edge-daemon/src/__tests__/fixtures.ts
+++ b/apps/edge-daemon/src/__tests__/fixtures.ts
@@ -6,6 +6,7 @@ import {
   PolicyRepository,
   AuditRepository,
   ExportStateRepository,
+  IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
 import type Database from 'better-sqlite3';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
@@ -29,6 +30,9 @@ export function makeDeps(db: Database.Database): DaemonDependencies {
     policyRepo: new PolicyRepository(db),
     auditRepo: new AuditRepository(db),
     exportStateRepo: new ExportStateRepository(db),
+    // Mirrors production wiring (main.ts): a successful index update records
+    // last_indexed_at, which the D2 staleness gauge consumes.
+    indexStateRepo: new IndexStateRepository(db),
   };
 }
 

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -269,6 +269,7 @@ async function indexUpdateStep(
   config: DaemonConfig,
   deps: DaemonDependencies,
   logger: DaemonLogger,
+  nowFn: () => string,
   result: CycleResult,
 ): Promise<void> {
   if (!config.enableIndexUpdate || !deps.qmdAdapter) return;
@@ -279,6 +280,11 @@ async function indexUpdateStep(
     maxJitterMs: config.retryMaxJitterMs,
     sleepFn: config.sleepFn,
   };
+  // Capture the freshness watermark BEFORE the index update runs: a promotion
+  // landing mid-update may or may not be absorbed, so marking with the
+  // pre-update instant can only UNDER-claim freshness (it stays "dirty" and is
+  // re-absorbed next cycle) — never over-claim it.
+  const indexedAt = nowFn();
   try {
     await withRetry(async () => {
       const ensureResult = await adapter.ensureCollections();
@@ -291,6 +297,16 @@ async function indexUpdateStep(
       }
     }, retryOpts);
     result.indexUpdate = { ok: true };
+    // Freshness consumption (D1/D2): the export→reindex chain COMPLETED, so
+    // record it — this is what clears the derived index-dirty state and zeroes
+    // the staleness gauge. Only on full success; a failed update must leave
+    // the gauge reporting stale.
+    try {
+      deps.indexStateRepo?.markIndexed(config.tenantId, indexedAt);
+    } catch (markErr) {
+      const msg = markErr instanceof Error ? markErr.message : String(markErr);
+      logger.warn(`Index-state mark failed (staleness gauge may over-report): ${msg}`);
+    }
     logger.info('Index update complete');
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -344,7 +360,7 @@ export async function runCycle(
 
   stalenessStep(config, deps, logger, nowFn, result);
   await exportStep(config, deps, logger, nowFn, result);
-  await indexUpdateStep(config, deps, logger, result);
+  await indexUpdateStep(config, deps, logger, nowFn, result);
 
   result.completedAt = nowFn();
   return result;

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -7,6 +7,7 @@ import {
   PolicyRepository,
   AuditRepository,
   ExportStateRepository,
+  IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
@@ -44,6 +45,9 @@ async function main(): Promise<void> {
     policyRepo: new PolicyRepository(db),
     auditRepo: new AuditRepository(db),
     exportStateRepo: new ExportStateRepository(db),
+    // Freshness consumption (D1/D2): a successful cycle index-update records
+    // last_indexed_at, clearing the derived index-dirty state for the tenant.
+    indexStateRepo: new IndexStateRepository(db),
     // Point the adapter at the SAME dir the exporter writes to (resolved to
     // absolute so qmd's collection sources match git-exporter's output
     // regardless of cwd). git-exporter's file-writer resolves the same

--- a/apps/edge-daemon/src/types.ts
+++ b/apps/edge-daemon/src/types.ts
@@ -6,6 +6,7 @@ import type {
   PolicyRepository,
   AuditRepository,
   ExportStateRepository,
+  IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
 import type { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import type { RepoContext } from '@qmd-team-intent-kb/repo-resolver';
@@ -64,6 +65,14 @@ export interface DaemonDependencies {
   exportStateRepo: ExportStateRepository;
   /** Optional — skip index update if absent. */
   qmdAdapter?: QmdAdapter;
+  /**
+   * Optional — when present, a SUCCESSFUL index update records
+   * `last_indexed_at` for the tenant (D1/D2 freshness consumption: the daemon's
+   * cycle is the poll loop that absorbs pending promotions, so it is the one
+   * that clears the derived index-dirty state and keeps the staleness gauge
+   * honest). Absent (legacy/test wiring) → freshness simply stays unmeasured.
+   */
+  indexStateRepo?: IndexStateRepository;
   /**
    * Pre-resolved repo context, stashed at daemon startup.
    *

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -25,8 +25,9 @@
     "eval:retrieval:ci": "node dist/eval/ci-retrieval-ratchet.js"
   },
   "dependencies": {
-    "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*",
     "better-sqlite3": "^12.11.1"
   },
   "devDependencies": {

--- a/packages/qmd-adapter/src/__tests__/cli.test.ts
+++ b/packages/qmd-adapter/src/__tests__/cli.test.ts
@@ -139,4 +139,68 @@ describe('run', () => {
     expect(code).toBe(2);
     expect(errs.join('\n')).toContain('usage:');
   });
+
+  // ─── canary --max-staleness-seconds (D2 staleness gate) ────────────────────
+
+  it('canary fails (1) when measured staleness exceeds --max-staleness-seconds', async () => {
+    const { mock, makeAdapter } = makeInjected();
+    for (const _ of DEFAULT_CANARY_CONTROLS) mock.queueSuccess(hitsJson(3)); // controls all pass
+    const logs: string[] = [];
+
+    const code = await run(['canary', '--max-staleness-seconds', '86400'], {
+      env,
+      makeAdapter,
+      makeStalenessProbe: () => () => 90_000,
+      log: (m) => logs.push(m),
+    });
+
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain('index staleness -> 90000s (max 86400s)');
+  });
+
+  it('canary passes (0) when staleness is within the threshold', async () => {
+    const { mock, makeAdapter } = makeInjected();
+    for (const _ of DEFAULT_CANARY_CONTROLS) mock.queueSuccess(hitsJson(3));
+
+    const code = await run(['canary', '--max-staleness-seconds', '86400'], {
+      env,
+      makeAdapter,
+      makeStalenessProbe: () => () => 60,
+    });
+
+    expect(code).toBe(0);
+  });
+
+  it('canary passes (0) on unmeasured staleness — e.g. the CI fixture brain with no DB', async () => {
+    const { mock, makeAdapter } = makeInjected();
+    for (const _ of DEFAULT_CANARY_CONTROLS) mock.queueSuccess(hitsJson(3));
+    const logs: string[] = [];
+
+    // The default probe against an env with no brain DB yields null (unmeasured);
+    // modeled here with an explicit null probe.
+    const code = await run(['canary', '--max-staleness-seconds', '86400'], {
+      env,
+      makeAdapter,
+      makeStalenessProbe: () => () => null,
+      log: (m) => logs.push(m),
+    });
+
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain('index staleness -> unmeasured');
+  });
+
+  it('canary returns 2 (usage error) on an invalid --max-staleness-seconds value', async () => {
+    const { makeAdapter } = makeInjected();
+    const errs: string[] = [];
+
+    const code = await run(['canary', '--max-staleness-seconds', 'tomorrow'], {
+      env,
+      makeAdapter,
+      errLog: (m) => errs.push(m),
+    });
+
+    // A typo'd threshold must be a loud usage error, never a silently skipped gate.
+    expect(code).toBe(2);
+    expect(errs.join('\n')).toContain('--max-staleness-seconds');
+  });
 });

--- a/packages/qmd-adapter/src/__tests__/health-check.test.ts
+++ b/packages/qmd-adapter/src/__tests__/health-check.test.ts
@@ -46,4 +46,38 @@ describe('checkHealth', () => {
     // version and collections may be null/empty but no throw
     expect(typeof status.initialized).toBe('boolean');
   });
+
+  // ─── stalenessSeconds (D2) ─────────────────────────────────────────────────
+
+  it('reports stalenessSeconds null when no probe is wired (unmeasured)', async () => {
+    mock.queueSuccess('qmd 2.0.1');
+    mock.queueSuccess('kb-curated');
+    const status = await checkHealth(mock);
+    expect(status.stalenessSeconds).toBeNull();
+  });
+
+  it('reports the probe-measured staleness alongside qmd health', async () => {
+    mock.queueSuccess('qmd 2.0.1');
+    mock.queueSuccess('kb-curated');
+    const status = await checkHealth(mock, () => 4200);
+    expect(status.stalenessSeconds).toBe(4200);
+    expect(status.available).toBe(true);
+  });
+
+  it('reports staleness even when qmd is unavailable (independent signals)', async () => {
+    mock.setAvailable(false);
+    const status = await checkHealth(mock, () => 99);
+    expect(status.available).toBe(false);
+    expect(status.stalenessSeconds).toBe(99);
+  });
+
+  it('degrades a throwing probe to null instead of failing the health check', async () => {
+    mock.queueSuccess('qmd 2.0.1');
+    mock.queueSuccess('kb-curated');
+    const status = await checkHealth(mock, () => {
+      throw new Error('store locked');
+    });
+    expect(status.stalenessSeconds).toBeNull();
+    expect(status.available).toBe(true);
+  });
 });

--- a/packages/qmd-adapter/src/__tests__/search-canary.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-canary.test.ts
@@ -137,6 +137,79 @@ describe('runSearchCanary', () => {
       expect(report.healed?.recheckHealthy).toBe(false);
     });
   });
+
+  describe('staleness gate (D2)', () => {
+    const controls = [{ query: 'audit chain receipts' }];
+
+    it('fails the canary when measured staleness exceeds the threshold', async () => {
+      mock.queueSuccess(hitsJson(3)); // controls pass — staleness alone fails the run
+
+      const report = await runSearchCanary(adapter, TENANT, {
+        controls,
+        maxStalenessSeconds: 86_400,
+        stalenessProbe: () => 90_000,
+      });
+
+      expect(report.healthy).toBe(false);
+      expect(report.staleness).toEqual({
+        stalenessSeconds: 90_000,
+        maxStalenessSeconds: 86_400,
+        passed: false,
+      });
+      expect(report.controls[0]?.passed).toBe(true);
+    });
+
+    it('passes when staleness is within the threshold', async () => {
+      mock.queueSuccess(hitsJson(3));
+
+      const report = await runSearchCanary(adapter, TENANT, {
+        controls,
+        maxStalenessSeconds: 86_400,
+        stalenessProbe: () => 120,
+      });
+
+      expect(report.healthy).toBe(true);
+      expect(report.staleness?.passed).toBe(true);
+    });
+
+    it('passes on unmeasured (null) staleness — fail-open before measurement starts', async () => {
+      mock.queueSuccess(hitsJson(3));
+
+      const report = await runSearchCanary(adapter, TENANT, {
+        controls,
+        maxStalenessSeconds: 86_400,
+        stalenessProbe: () => null,
+      });
+
+      expect(report.healthy).toBe(true);
+      expect(report.staleness).toEqual({
+        stalenessSeconds: null,
+        maxStalenessSeconds: 86_400,
+        passed: true,
+      });
+    });
+
+    it('degrades a throwing probe to unmeasured instead of crashing the canary', async () => {
+      mock.queueSuccess(hitsJson(3));
+
+      const report = await runSearchCanary(adapter, TENANT, {
+        controls,
+        maxStalenessSeconds: 86_400,
+        stalenessProbe: () => {
+          throw new Error('store locked');
+        },
+      });
+
+      expect(report.healthy).toBe(true);
+      expect(report.staleness?.stalenessSeconds).toBeNull();
+    });
+
+    it('emits no staleness block when the gate is not requested', async () => {
+      mock.queueSuccess(hitsJson(3));
+      const report = await runSearchCanary(adapter, TENANT, { controls });
+      expect(report.staleness).toBeUndefined();
+    });
+  });
 });
 
 describe('formatCanaryReport', () => {
@@ -160,5 +233,28 @@ describe('formatCanaryReport', () => {
     expect(out).toContain('SEARCH DEGRADED');
     expect(out).toContain('[FAIL]');
     expect(out).toContain('0 hits');
+  });
+
+  it('renders a failed staleness gate', () => {
+    const out = formatCanaryReport({
+      healthy: false,
+      tenantId: 'local',
+      controls: [{ query: 'audit chain receipts', minHits: 1, hits: 3, passed: true }],
+      staleness: { stalenessSeconds: 90_000, maxStalenessSeconds: 86_400, passed: false },
+    });
+    expect(out).toContain('SEARCH DEGRADED');
+    expect(out).toContain('index staleness -> 90000s (max 86400s)');
+    expect(out).toContain('[FAIL] index staleness');
+  });
+
+  it('renders an unmeasured staleness gate as passing', () => {
+    const out = formatCanaryReport({
+      healthy: true,
+      tenantId: 'local',
+      controls: [{ query: 'audit chain receipts', minHits: 1, hits: 3, passed: true }],
+      staleness: { stalenessSeconds: null, maxStalenessSeconds: 86_400, passed: true },
+    });
+    expect(out).toContain('SEARCH HEALTHY');
+    expect(out).toContain('index staleness -> unmeasured');
   });
 });

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -30,6 +30,8 @@ export class QmdAdapter {
   private readonly exportDir: string;
   /** The single tenant this adapter's qmd registry + index are bound to. */
   private readonly tenantId: string;
+  /** Optional index-freshness probe (D2) — see QmdAdapterConfig.stalenessProbe. */
+  private readonly stalenessProbe?: () => number | null;
 
   /** The tenant this adapter serves (read-only; used by the search canary's fail-closed guard). */
   get boundTenantId(): string {
@@ -39,6 +41,7 @@ export class QmdAdapter {
   constructor(config: QmdAdapterConfig, executor?: QmdExecutor) {
     this.exportDir = config.exportDir;
     this.tenantId = config.tenantId;
+    this.stalenessProbe = config.stalenessProbe;
     this.executor =
       executor ??
       new RealQmdExecutor({
@@ -130,9 +133,9 @@ export class QmdAdapter {
     }
   }
 
-  /** Check health of qmd and index state */
+  /** Check health of qmd and index state (incl. stalenessSeconds when a probe is wired). */
   async health(): Promise<QmdHealthStatus> {
-    return checkHealth(this.executor);
+    return checkHealth(this.executor, this.stalenessProbe);
   }
 
   /** Update the index */

--- a/packages/qmd-adapter/src/canary/search-canary.ts
+++ b/packages/qmd-adapter/src/canary/search-canary.ts
@@ -1,5 +1,5 @@
 import type { SearchScope } from '@qmd-team-intent-kb/schema';
-import type { QmdError } from '../types.js';
+import type { QmdError, StalenessProbe } from '../types.js';
 import type { QmdAdapter } from '../adapter.js';
 import { reindex } from '../reindex/reindex.js';
 
@@ -52,13 +52,34 @@ export interface CanaryControlResult {
   error?: QmdError;
 }
 
+/** Index-staleness gate outcome (D2). */
+export interface CanaryStalenessResult {
+  /**
+   * Measured staleness in seconds — `null` means unmeasured (no probe data /
+   * measurement not started), which PASSES: the gate asserts on measured
+   * staleness only, never on the absence of measurement.
+   */
+  stalenessSeconds: number | null;
+  /** The threshold the gate enforced. */
+  maxStalenessSeconds: number;
+  /** `stalenessSeconds === null || stalenessSeconds <= maxStalenessSeconds`. */
+  passed: boolean;
+}
+
 /** Aggregate canary outcome. */
 export interface SearchCanaryReport {
-  /** True only when EVERY control passed. */
+  /** True only when EVERY control passed (and the staleness gate, when enabled). */
   healthy: boolean;
   /** The tenant the canary ran against, for diagnosis. */
   tenantId: string;
   controls: CanaryControlResult[];
+  /**
+   * Set when a staleness gate was requested (`maxStalenessSeconds` +
+   * `stalenessProbe`). A failed gate makes the whole canary unhealthy: promoted
+   * memories older than the threshold that search cannot see yet is the same
+   * "retrievability degraded" class as a 0-hit control.
+   */
+  staleness?: CanaryStalenessResult;
   /** Set when `heal` was requested and a self-heal reindex was attempted. */
   healed?: {
     attempted: boolean;
@@ -111,6 +132,37 @@ export interface SearchCanaryOptions {
    * degradation is never silent even when auto-repaired).
    */
   heal?: boolean;
+  /**
+   * Index-staleness gate (D2): fail the canary when the measured
+   * `stalenessSeconds` exceeds this threshold. Requires `stalenessProbe`; when
+   * either is absent the gate is skipped (no `staleness` block in the report).
+   */
+  maxStalenessSeconds?: number;
+  /**
+   * Freshness probe supplying the measured staleness — the adapter layer is
+   * store-free, so the caller that owns the governed store injects it (the CLI
+   * wires `IndexStateRepository.stalenessSeconds`). `null` = unmeasured, which
+   * PASSES the gate (fail-open on fresh deploys; see IndexStateRepository).
+   */
+  stalenessProbe?: StalenessProbe;
+}
+
+/** Evaluate the staleness gate; a throwing probe degrades to unmeasured (null). */
+function runStalenessGate(
+  maxStalenessSeconds: number,
+  probe: StalenessProbe,
+): CanaryStalenessResult {
+  let stalenessSeconds: number | null;
+  try {
+    stalenessSeconds = probe();
+  } catch {
+    stalenessSeconds = null;
+  }
+  return {
+    stalenessSeconds,
+    maxStalenessSeconds,
+    passed: stalenessSeconds === null || stalenessSeconds <= maxStalenessSeconds,
+  };
 }
 
 /**
@@ -136,6 +188,15 @@ export async function runSearchCanary(
 ): Promise<SearchCanaryReport> {
   const controls = options.controls ?? DEFAULT_CANARY_CONTROLS;
 
+  // Staleness gate (D2), evaluated ONCE up front: it reads the governed store,
+  // not the index, so a heal's reindex cannot change the measured value — only
+  // the chain owner's `markIndexed` (export→reindex completion) clears it.
+  const staleness =
+    options.maxStalenessSeconds !== undefined && options.stalenessProbe !== undefined
+      ? runStalenessGate(options.maxStalenessSeconds, options.stalenessProbe)
+      : undefined;
+  const stalenessPassed = staleness?.passed ?? true;
+
   // Fail-closed tenant guard, preserved from when the canary probed the fused
   // query() surface (which refuses mismatched tenants): a canary pointed at
   // the wrong tenant reports degraded without touching the executor at all.
@@ -149,6 +210,7 @@ export async function runSearchCanary(
         hits: 0,
         passed: false,
       })),
+      staleness,
     };
   }
 
@@ -156,7 +218,7 @@ export async function runSearchCanary(
   const firstHealthy = firstPass.every((c) => c.passed);
 
   if (firstHealthy || !options.heal) {
-    return { healthy: firstHealthy, tenantId, controls: firstPass };
+    return { healthy: firstHealthy && stalenessPassed, tenantId, controls: firstPass, staleness };
   }
 
   // Unhealthy + heal requested: attempt an idempotent reindex, then re-check.
@@ -165,9 +227,10 @@ export async function runSearchCanary(
   const recheckHealthy = secondPass.every((c) => c.passed);
 
   return {
-    healthy: recheckHealthy,
+    healthy: recheckHealthy && stalenessPassed,
     tenantId,
     controls: secondPass,
+    staleness,
     healed: { attempted: true, reindexOk: reindexResult.ok, recheckHealthy },
   };
 }
@@ -182,6 +245,12 @@ export function formatCanaryReport(report: SearchCanaryReport): string {
     const err = c.error ? ` [${c.error.code}: ${c.error.message}]` : '';
     return `  [${status}] "${c.query}" -> ${c.hits} hits (min ${c.minHits})${err}`;
   });
+  if (report.staleness) {
+    const s = report.staleness;
+    const status = s.passed ? 'OK ' : 'FAIL';
+    const value = s.stalenessSeconds === null ? 'unmeasured' : `${s.stalenessSeconds}s`;
+    lines.push(`  [${status}] index staleness -> ${value} (max ${s.maxStalenessSeconds}s)`);
+  }
   if (report.healed) {
     lines.push(
       `  heal: attempted, reindexOk=${report.healed.reindexOk}, recheckHealthy=${report.healed.recheckHealthy}`,

--- a/packages/qmd-adapter/src/cli.ts
+++ b/packages/qmd-adapter/src/cli.ts
@@ -5,6 +5,12 @@
  *   node dist/cli.js reindex            # rebuild the derived qmd-index from kb-export (idempotent)
  *   node dist/cli.js canary             # run known-positive controls; exit 1 if any returns 0 hits
  *   node dist/cli.js canary --heal      # canary; on failure, reindex once and re-check
+ *   node dist/cli.js canary --max-staleness-seconds 86400
+ *                                       # ALSO fail if a promotion has waited longer than the
+ *                                       # threshold to become searchable (D2 staleness gate;
+ *                                       # measured from TEAMKB_DB_PATH / <base>/teamkb.db when
+ *                                       # present — no brain DB → gate reports "unmeasured" and
+ *                                       # passes, so the CI fixture canary stays green)
  *
  * Tenant + paths resolve from the same env the rest of INTKB uses:
  *   TEAMKB_TENANT_ID  (default: intent-solutions — the live brain's tenant)
@@ -19,11 +25,15 @@
  * nightly / an operator sees it; `reindex` is the repeatable, idempotent
  * rebuild of the derived index (never touches teamkb.db or brain/raw).
  */
+import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import Database from 'better-sqlite3';
 import { getTeamKbBasePath } from '@qmd-team-intent-kb/common';
+import { IndexStateRepository } from '@qmd-team-intent-kb/store';
 import { QmdAdapter } from './adapter.js';
+import type { StalenessProbe } from './types.js';
 import { reindex } from './reindex/reindex.js';
 import { runSearchCanary, formatCanaryReport } from './canary/search-canary.js';
 
@@ -51,6 +61,40 @@ export interface CliDeps {
   errLog?: (msg: string) => void;
   /** Adapter factory — defaults to the real `QmdAdapter`; tests inject a fake. */
   makeAdapter?: (tenantId: string, exportDir: string) => QmdAdapter;
+  /**
+   * Staleness-probe factory for the canary's D2 gate — defaults to
+   * {@link makeStoreStalenessProbe} (reads the live brain DB read-only); tests
+   * inject a fake.
+   */
+  makeStalenessProbe?: (tenantId: string, env: NodeJS.ProcessEnv) => StalenessProbe;
+}
+
+/**
+ * Build a staleness probe over the governed store (D2).
+ *
+ * Resolves the brain DB the same way apps/api does (`TEAMKB_DB_PATH`, else
+ * `<base>/teamkb.db`) and opens it READ-ONLY — a canary must never create or
+ * migrate a database as a side effect. Any failure (no DB file — e.g. the CI
+ * fixture brain — missing `index_state` table on an old store, locked file)
+ * degrades to `null` = unmeasured, which passes the gate.
+ */
+export function makeStoreStalenessProbe(
+  tenantId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): StalenessProbe {
+  return () => {
+    const dbPath = env['TEAMKB_DB_PATH']?.trim() || join(getTeamKbBasePath(), 'teamkb.db');
+    if (!existsSync(dbPath)) return null;
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      return new IndexStateRepository(db).stalenessSeconds(tenantId);
+    } catch {
+      return null;
+    } finally {
+      db?.close();
+    }
+  };
 }
 
 /**
@@ -84,12 +128,36 @@ export async function run(argv: string[], deps: CliDeps = {}): Promise<number> {
 
   if (command === 'canary') {
     const heal = rest.includes('--heal');
-    const report = await runSearchCanary(adapter, tenantId, { heal });
+
+    // D2 staleness gate: opt-in via --max-staleness-seconds. An invalid value
+    // is a usage error (exit 2), NOT a silently skipped gate — a typo'd
+    // threshold must never disable the assertion it was meant to enforce.
+    let maxStalenessSeconds: number | undefined;
+    const maxIdx = rest.indexOf('--max-staleness-seconds');
+    if (maxIdx !== -1) {
+      const raw = rest[maxIdx + 1];
+      const value = raw === undefined ? Number.NaN : Number(raw);
+      if (!Number.isFinite(value) || value < 0) {
+        errLog('usage: qmd-index canary [--heal] [--max-staleness-seconds <non-negative seconds>]');
+        return 2;
+      }
+      maxStalenessSeconds = value;
+    }
+    const stalenessProbe =
+      maxStalenessSeconds !== undefined
+        ? (deps.makeStalenessProbe ?? makeStoreStalenessProbe)(tenantId, env)
+        : undefined;
+
+    const report = await runSearchCanary(adapter, tenantId, {
+      heal,
+      maxStalenessSeconds,
+      stalenessProbe,
+    });
     log(formatCanaryReport(report));
     return report.healthy ? 0 : 1;
   }
 
-  errLog('usage: qmd-index <reindex|canary [--heal]>');
+  errLog('usage: qmd-index <reindex|canary [--heal] [--max-staleness-seconds <seconds>]>');
   return 2;
 }
 

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -58,6 +58,13 @@ export interface QmdAdapterConfig {
   nativeIndexPath?: string;
   /** Kill switch: serve qmd-only results with no native FTS5 fusion. */
   disableNativeFusion?: boolean;
+  /**
+   * Optional index-freshness probe (D2). Supplied by callers that own the
+   * governed store (API / edge-daemon / CLI); when set, `adapter.health()`
+   * reports `stalenessSeconds` from it. Absent → staleness is `null`
+   * (unmeasured). See `StalenessProbe` in types.ts for the contract.
+   */
+  stalenessProbe?: () => number | null;
 }
 
 /** Default configuration values */

--- a/packages/qmd-adapter/src/health/health-check.ts
+++ b/packages/qmd-adapter/src/health/health-check.ts
@@ -1,11 +1,43 @@
-import type { QmdHealthStatus } from '../types.js';
+import type { QmdHealthStatus, StalenessProbe } from '../types.js';
 import type { QmdExecutor } from '../executor/executor.js';
 
-/** Check qmd health — never throws, always returns structured status */
-export async function checkHealth(executor: QmdExecutor): Promise<QmdHealthStatus> {
+/**
+ * Evaluate the optional staleness probe without letting it break the health
+ * check — a throwing probe (e.g. the store DB is locked) degrades to `null`
+ * (unmeasured), never to a crashed probe endpoint.
+ */
+function probeStaleness(probe?: StalenessProbe): number | null {
+  if (probe === undefined) return null;
+  try {
+    return probe();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check qmd health — never throws, always returns structured status.
+ *
+ * `stalenessProbe` (D2) is evaluated even when the qmd binary is unavailable:
+ * index staleness is a property of the governed store vs the derived index, so
+ * a missing binary makes retrieval degraded AND (still) measurably stale — the
+ * two signals are independent.
+ */
+export async function checkHealth(
+  executor: QmdExecutor,
+  stalenessProbe?: StalenessProbe,
+): Promise<QmdHealthStatus> {
+  const stalenessSeconds = probeStaleness(stalenessProbe);
+
   const available = await executor.isAvailable();
   if (!available) {
-    return { available: false, version: null, initialized: false, collections: [] };
+    return {
+      available: false,
+      version: null,
+      initialized: false,
+      collections: [],
+      stalenessSeconds,
+    };
   }
 
   // Get version
@@ -36,5 +68,5 @@ export async function checkHealth(executor: QmdExecutor): Promise<QmdHealthStatu
     // Non-fatal
   }
 
-  return { available, version, initialized, collections };
+  return { available, version, initialized, collections, stalenessSeconds };
 }

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -1,5 +1,11 @@
 // Types
-export type { QmdError, CommandResult, QmdHealthStatus, QmdSearchResult } from './types.js';
+export type {
+  QmdError,
+  CommandResult,
+  QmdHealthStatus,
+  QmdSearchResult,
+  StalenessProbe,
+} from './types.js';
 
 // Config
 export type { QmdAdapterConfig } from './config.js';
@@ -104,6 +110,7 @@ export {
 export type {
   CanaryControl,
   CanaryControlResult,
+  CanaryStalenessResult,
   SearchCanaryReport,
   SearchCanaryOptions,
 } from './canary/search-canary.js';

--- a/packages/qmd-adapter/src/types.ts
+++ b/packages/qmd-adapter/src/types.ts
@@ -19,7 +19,29 @@ export interface QmdHealthStatus {
   version: string | null;
   initialized: boolean;
   collections: string[];
+  /**
+   * Index freshness (D2): seconds since the OLDEST promotion in the governed
+   * store that is NOT yet reflected in the search index.
+   *
+   * Contract (mirrors `IndexStateRepository.stalenessSeconds` in the store):
+   *   - `null` — unmeasured: no staleness probe was wired into this adapter,
+   *     or measurement has not begun (no export→reindex chain has ever
+   *     recorded completion for the tenant). Fail-open by design so a fresh
+   *     deploy does not false-alarm.
+   *   - `0`    — measured and fresh: the index has absorbed every promotion.
+   *   - `> 0`  — measured and stale: promote→search latency in seconds.
+   */
+  stalenessSeconds: number | null;
 }
+
+/**
+ * Injectable freshness probe (D2). The adapter layer is deliberately store-free,
+ * so callers that own the governed store (API, edge-daemon, CLI) supply this —
+ * typically `() => new IndexStateRepository(db).stalenessSeconds(tenantId)`.
+ * Must follow the null/0/positive contract on
+ * {@link QmdHealthStatus.stalenessSeconds}.
+ */
+export type StalenessProbe = () => number | null;
 
 /** A single search result from qmd */
 export interface QmdSearchResult {

--- a/packages/qmd-adapter/tsconfig.json
+++ b/packages/qmd-adapter/tsconfig.json
@@ -8,5 +8,15 @@
     "declarationMap": true
   },
   "include": ["src"],
-  "references": [{ "path": "../schema" }, { "path": "../common" }]
+  "references": [
+    {
+      "path": "../schema"
+    },
+    {
+      "path": "../common"
+    },
+    {
+      "path": "../store"
+    }
+  ]
 }

--- a/packages/store/src/__tests__/index-state-repository.test.ts
+++ b/packages/store/src/__tests__/index-state-repository.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { makeMemory } from '@qmd-team-intent-kb/test-fixtures';
+import { createTestDatabase } from '../database.js';
+import { MemoryRepository } from '../repositories/memory-repository.js';
+import { IndexStateRepository } from '../repositories/index-state-repository.js';
+
+const T0 = '2026-07-01T00:00:00.000Z';
+const T1 = '2026-07-01T01:00:00.000Z';
+const T2 = '2026-07-01T02:00:00.000Z';
+/** A "now" 1 hour after T2, in ms. */
+const NOW_MS = Date.parse('2026-07-01T03:00:00.000Z');
+
+describe('IndexStateRepository', () => {
+  let db: Database.Database;
+  let repo: IndexStateRepository;
+  let memories: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new IndexStateRepository(db);
+    memories = new MemoryRepository(db);
+  });
+
+  it('markIndexed stores state and get retrieves it', () => {
+    repo.markIndexed('team-alpha', T1);
+    const state = repo.get('team-alpha');
+    expect(state).not.toBeNull();
+    expect(state?.tenantId).toBe('team-alpha');
+    expect(state?.lastIndexedAt).toBe(T1);
+    expect((state?.updatedAt ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('markIndexed upserts — calling again advances lastIndexedAt', () => {
+    repo.markIndexed('team-alpha', T1);
+    repo.markIndexed('team-alpha', T2);
+    expect(repo.get('team-alpha')?.lastIndexedAt).toBe(T2);
+  });
+
+  it('get returns null for a tenant that never indexed', () => {
+    expect(repo.get('unknown')).toBeNull();
+  });
+
+  // ─── stalenessSeconds contract: null = unmeasured, 0 = fresh, >0 = stale ───
+
+  it('is null (unmeasured) when no index_state row exists — even with promotions pending', () => {
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T2 }));
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBeNull();
+  });
+
+  it('is 0 (fresh) when every promotion is at or before lastIndexedAt', () => {
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T0 }));
+    repo.markIndexed('team-alpha', T1);
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBe(0);
+  });
+
+  it('is 0 (fresh) when the tenant has no memories at all', () => {
+    repo.markIndexed('team-alpha', T1);
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBe(0);
+  });
+
+  it('reports seconds since the OLDEST un-indexed promotion', () => {
+    repo.markIndexed('team-alpha', T0);
+    // Two promotions after the last index: T1 (oldest) and T2. Staleness is
+    // measured from T1 — worst case, not most recent.
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T1 }));
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T2 }));
+    // NOW_MS is 2h after T1.
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBe(2 * 3600);
+  });
+
+  it('goes back to 0 after markIndexed absorbs the pending promotion', () => {
+    repo.markIndexed('team-alpha', T0);
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T1 }));
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBeGreaterThan(0);
+    repo.markIndexed('team-alpha', T2);
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBe(0);
+  });
+
+  it('is tenant-scoped — another tenant’s promotions do not bleed in', () => {
+    repo.markIndexed('team-alpha', T0);
+    memories.insert(makeMemory({ tenantId: 'team-beta', promotedAt: T2 }));
+    expect(repo.stalenessSeconds('team-alpha', NOW_MS)).toBe(0);
+  });
+
+  // ─── worstStalenessSeconds ─────────────────────────────────────────────────
+
+  it('worstStalenessSeconds is null when no tenant has begun measurement', () => {
+    memories.insert(makeMemory({ tenantId: 'team-alpha', promotedAt: T1 }));
+    expect(repo.worstStalenessSeconds(NOW_MS)).toBeNull();
+  });
+
+  it('worstStalenessSeconds returns the largest per-tenant staleness', () => {
+    // alpha: fresh. beta: stale since T1 (2h before NOW_MS).
+    repo.markIndexed('team-alpha', T2);
+    repo.markIndexed('team-beta', T0);
+    memories.insert(makeMemory({ tenantId: 'team-beta', promotedAt: T1 }));
+    expect(repo.worstStalenessSeconds(NOW_MS)).toBe(2 * 3600);
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -69,6 +69,8 @@ export type {
 } from './audit-verify-merge.js';
 export { ExportStateRepository } from './repositories/export-state-repository.js';
 export type { ExportState } from './repositories/export-state-repository.js';
+export { IndexStateRepository } from './repositories/index-state-repository.js';
+export type { IndexState } from './repositories/index-state-repository.js';
 export { MemoryLinksRepository } from './repositories/memory-links-repository.js';
 export type { MemoryLink, Neighbor, GraphNode } from './repositories/memory-links-repository.js';
 export { ImportBatchRepository } from './repositories/import-batch-repository.js';

--- a/packages/store/src/repositories/index-state-repository.ts
+++ b/packages/store/src/repositories/index-state-repository.ts
@@ -1,0 +1,153 @@
+import { z } from 'zod';
+import type Database from 'better-sqlite3';
+
+/** The last-successful-index tracking record for one tenant's search index. */
+export interface IndexState {
+  tenantId: string;
+  /** ISO-8601 UTC instant of the last COMPLETED export→reindex chain. */
+  lastIndexedAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before mapping to IndexState.
+ */
+const IndexStateRowSchema = z.object({
+  tenant_id: z.string(),
+  last_indexed_at: z.string(),
+  updated_at: z.string(),
+});
+
+/** Parse a raw SQLite row into a validated IndexState object. */
+function rowToState(row: unknown): IndexState {
+  const result = IndexStateRowSchema.safeParse(row);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`index_state row failed validation: ${issues.join('; ')}`);
+  }
+  const flat = result.data;
+  return {
+    tenantId: flat.tenant_id,
+    lastIndexedAt: flat.last_indexed_at,
+    updatedAt: flat.updated_at,
+  };
+}
+
+/**
+ * Tracks, per tenant, when the derived search index (kb-export markdown tree +
+ * qmd/FTS5 index) last caught up with the governed store — the store half of the
+ * D1/D2 freshness contract.
+ *
+ * Design choice — DERIVED dirty signal, not a written flag. The "index dirty"
+ * marker is not a column any promotion path has to remember to set: a tenant's
+ * index is dirty exactly when `curated_memories` holds a row whose `promoted_at`
+ * is newer than this table's `last_indexed_at`. `promoted_at` is written inside
+ * the promotion transaction (R9 — atomic with the memory + its receipt), so the
+ * dirty signal is set "at promotion commit" by construction, for EVERY caller
+ * (API promotion-service, curator batch, plugin govern sweep, merge-gate), and
+ * can never desync the way a dual-written boolean could. This table only records
+ * the CONSUME side: whoever completes the export→reindex chain calls
+ * `markIndexed`, which is what "clears" the dirty state.
+ *
+ * Timestamp contract: `lastIndexedAt` MUST be an ISO-8601 UTC string
+ * (`new Date().toISOString()` shape) so it is lexicographically comparable with
+ * `curated_memories.promoted_at`, which the promoter writes in that format.
+ * (Deliberately NOT `datetime('now')`, whose `YYYY-MM-DD HH:MM:SS` shape would
+ * break the string comparison.)
+ */
+export class IndexStateRepository {
+  private readonly stmtGet: Database.Statement;
+  private readonly stmtUpsert: Database.Statement;
+  private readonly stmtOldestUnindexed: Database.Statement;
+  private readonly stmtAll: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtGet = db.prepare(`
+      SELECT * FROM index_state WHERE tenant_id = ?
+    `);
+
+    this.stmtUpsert = db.prepare(`
+      INSERT INTO index_state (tenant_id, last_indexed_at, updated_at)
+      VALUES (@tenant_id, @last_indexed_at, datetime('now'))
+      ON CONFLICT(tenant_id) DO UPDATE SET
+        last_indexed_at = excluded.last_indexed_at,
+        updated_at = datetime('now')
+    `);
+
+    // The OLDEST promotion the index has not yet absorbed — worst-case
+    // staleness, not the most recent one.
+    this.stmtOldestUnindexed = db.prepare(`
+      SELECT MIN(promoted_at) AS oldest FROM curated_memories
+      WHERE tenant_id = ? AND promoted_at > ?
+    `);
+
+    this.stmtAll = db.prepare(`SELECT * FROM index_state`);
+  }
+
+  /** Return the index state for the given tenant, or null if never indexed. */
+  get(tenantId: string): IndexState | null {
+    const row = this.stmtGet.get(tenantId);
+    return row !== undefined ? rowToState(row) : null;
+  }
+
+  /**
+   * Record that the tenant's export→reindex chain COMPLETED at `lastIndexedAt`
+   * (ISO-8601 UTC — see the class doc's timestamp contract). Call only after the
+   * FULL chain succeeded; a half-run (export ok, reindex failed) must not mark,
+   * or the staleness gauge would report fresh over a stale index.
+   */
+  markIndexed(tenantId: string, lastIndexedAt: string): void {
+    this.stmtUpsert.run({
+      tenant_id: tenantId,
+      last_indexed_at: lastIndexedAt,
+    });
+  }
+
+  /**
+   * Seconds since the OLDEST promotion not yet reflected in the tenant's index.
+   *
+   * Return contract (D2, documented for `QmdHealthStatus.stalenessSeconds`):
+   *   - `null`  — staleness is UNMEASURED: no `index_state` row exists yet for
+   *               this tenant (no export→reindex chain has ever recorded
+   *               completion). Deliberately fail-open: on first deploy of this
+   *               table every pre-existing memory predates measurement, and
+   *               treating them all as "un-indexed" would fire a false
+   *               staleness alarm across every healthy brain. Measurement
+   *               starts with the first `markIndexed`.
+   *   - `0`     — measured and fresh: every promotion is at or before
+   *               `last_indexed_at`.
+   *   - `> 0`   — measured and stale: seconds elapsed (by `nowMs`) since the
+   *               oldest promotion the index has not absorbed.
+   */
+  stalenessSeconds(tenantId: string, nowMs: number = Date.now()): number | null {
+    const state = this.get(tenantId);
+    if (state === null) return null;
+
+    const row = this.stmtOldestUnindexed.get(tenantId, state.lastIndexedAt) as
+      { oldest: string | null } | undefined;
+    const oldest = row?.oldest ?? null;
+    if (oldest === null) return 0;
+
+    const oldestMs = Date.parse(oldest);
+    if (Number.isNaN(oldestMs)) return 0;
+    return Math.max(0, Math.floor((nowMs - oldestMs) / 1000));
+  }
+
+  /**
+   * The worst (largest) per-tenant staleness across every tenant that has begun
+   * measurement, or `null` when no tenant has an `index_state` row yet. The
+   * process-level health surface (`GET /api/health`) uses this because health is
+   * not tenant-scoped.
+   */
+  worstStalenessSeconds(nowMs: number = Date.now()): number | null {
+    const rows = this.stmtAll.all() as unknown[];
+    let worst: number | null = null;
+    for (const raw of rows) {
+      const state = rowToState(raw);
+      const s = this.stalenessSeconds(state.tenantId, nowMs);
+      if (s !== null && (worst === null || s > worst)) worst = s;
+    }
+    return worst;
+  }
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -428,4 +428,27 @@ CREATE INDEX IF NOT EXISTS idx_candidates_status_tenant ON candidates(status, te
     apply: applyCheckConstraintBackfill,
     rebuildsTable: true,
   },
+  {
+    // Index-freshness tracking (D1/D2 — promote→search latency observability).
+    //
+    // One row per tenant recording when the derived search index (kb-export
+    // markdown tree + qmd/FTS5 index) last COMPLETED its export→reindex chain.
+    // The "index dirty" signal is DERIVED, not stored: a tenant is dirty when
+    // any curated_memories.promoted_at is newer than last_indexed_at — see
+    // IndexStateRepository for the rationale (atomic-by-construction with the
+    // promotion transaction; no caller can forget to set it).
+    //
+    // last_indexed_at is an ISO-8601 UTC string written by app code (NOT
+    // datetime('now'), whose 'YYYY-MM-DD HH:MM:SS' shape would break the
+    // lexicographic comparison against promoted_at's toISOString format).
+    version: 10,
+    name: 'add_index_state',
+    sql: `
+CREATE TABLE IF NOT EXISTS index_state (
+  tenant_id TEXT PRIMARY KEY,
+  last_indexed_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+    `.trim(),
+  },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@qmd-team-intent-kb/curator':
         specifier: workspace:*
         version: link:../curator
+      '@qmd-team-intent-kb/git-exporter':
+        specifier: workspace:*
+        version: link:../git-exporter
       '@qmd-team-intent-kb/policy-engine':
         specifier: workspace:*
         version: link:../../packages/policy-engine
@@ -322,6 +325,9 @@ importers:
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../store
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1


### PR DESCRIPTION
## What

GSB blueprint tracks **D1 + D2**: close the promote→search latency gap on the API path, and make any remaining gap a first-class, measurable signal everywhere.

- **D1** — after `POST /api/candidates/:id/promote` commits, the API now triggers the export→reindex chain, so the new memory is retrievable immediately instead of waiting for the next daemon cycle / nightly govern pass.
- **D2** — a new per-tenant freshness record makes index staleness observable at three surfaces: `QmdHealthStatus.stalenessSeconds`, `GET /api/health` → `indexStalenessSeconds`, and the search canary (nightly gate: `--max-staleness-seconds 86400`).

## Why

A promoted memory that search cannot see is a governed write with no read — the exact "SEARCH DEGRADED silently" class the canary was built for, but on the write path. The curator-batch (edge-daemon) and plugin-govern paths already chained promote→export→reindex; the API one-shot promote did not, and nothing measured the drift.

**Verified about the plugin govern path** (read-only recon of `bobs-big-brain-plugin/src/govern.ts`, claims match code): `runGovernLocked` already runs the full chain — step 2 sweeps the inbox through the deterministic Curator (promote), step 3 `runExport` (file generation only), step 4 `adapter.ensureCollections()` + `adapter.update()` (graceful `indexError` degrade when qmd is absent), step 5 anchors the chain head — all under the brain's flock write lock. **No plugin change is needed for D1**; this PR does not touch the plugin repo.

## Layers touched

- `packages/store` — migration v10 (`index_state` table) + new `IndexStateRepository`. Purely additive; no existing table or row is modified.
- `packages/qmd-adapter` — `QmdHealthStatus.stalenessSeconds`, injectable `StalenessProbe` (adapter stays store-free for health; the CLI gains a store dep — package→package, no cycle, depcruise clean), canary staleness gate, CLI flag.
- `apps/api` — `buildIndexRefresher` service, promote-route trigger, `/api/health` staleness, `main.ts` wiring (new dep on `@qmd-team-intent-kb/git-exporter`, same cross-app-via-package pattern edge-daemon already uses).
- `apps/edge-daemon` — successful index update records `last_indexed_at` (optional `indexStateRepo` dep; legacy wiring unchanged).
- `.github/workflows/nightly.yml` — canary now passes `--max-staleness-seconds 86400`.

**Invariant note:** the promotion transaction (R9 atomicity) is untouched — the refresh runs strictly AFTER commit, never inside it.

## How it works

**Dirty marker — chose a DERIVED signal over an explicit `index_dirty_since` row because the promotion transaction already durably records `promoted_at`.** A tenant's index is dirty exactly when some `curated_memories.promoted_at` is newer than `index_state.last_indexed_at`. That means the marker is "set at promotion commit" atomically, for EVERY promotion path (API service, curator batch, plugin sweep, merge-gate), with no caller able to forget it and no dual-write to desync. The `index_state` row records only the CONSUME side: whoever completes the export→reindex chain calls `markIndexed` (that is the "clear").

- **Who clears it:** the edge-daemon cycle (the existing poll loop) on successful index update, and the API's post-promotion refresher on full chain success. The plugin's local govern pass does not yet write `last_indexed_at` (it composes ensure+update inline in the plugin repo, out of scope here) — on plugin-only brains staleness simply stays `null`/unmeasured until a chain owner records completion (fail-open; see below). Follow-up noted.
- **Staleness semantics** (documented on `IndexStateRepository.stalenessSeconds` and `QmdHealthStatus`): `null` = unmeasured (no `index_state` row — deliberately fail-open so first deploy over an existing brain does not false-alarm every pre-existing memory as un-indexed), `0` = measured fresh, `>0` = seconds since the **oldest** un-absorbed promotion (worst case, not most recent). Timestamps are ISO-8601 UTC on both sides so the SQL comparison is lexicographic-safe; the watermark is captured BEFORE the chain runs so a mid-chain promotion can only under-claim freshness, never over-claim it.
- **API refresh:** awaited (200 = promoted AND absorbed on the happy path) but best-effort — the memory is already durable, so a failed refresh logs a warning and leaves the staleness gauge honestly reporting stale; it never turns a successful promotion into an error. Tenant-guard: the adapter is bound to one tenant; a foreign-tenant promote skips the refresh (drift still observable via the gauge).
- **Canary/CLI:** `canary --max-staleness-seconds N` injects a read-only store probe (`TEAMKB_DB_PATH` / `<base>/teamkb.db`; never creates or migrates a DB). Unmeasured passes; an invalid flag value exits 2 (usage error) rather than silently disabling the gate.

## Verification & evidence

- Full `pnpm validate` (format:check + lint + typecheck + test): **178 files, 2,147 tests passed** (+22 new). The known source-trust bulk_import failure did not reproduce — suite fully green on this branch.
- `pnpm depcruise`: 0 errors (3 pre-existing orphan warnings, untouched).
- **Centerpiece D1 test** (`apps/api/src/__tests__/promote-then-search.qmd-integration.test.ts`, runs against the real pinned qmd binary; CI main test job has it on PATH):
  - promotes a candidate through the real route with the production refresher wiring, then `adapter.query()` finds it with **no manual reindex in the test body**;
  - asserts staleness reads **0 end-to-end** (repo → `adapter.health()` → `/api/health`) — proving the full qmd chain ran, not the native-FTS5 fusion half masking a broken qmd path;
  - a synthetically failing refresher leaves the promotion durable (200) and the gauge unmarked.
  - Local run: `✓ promote-then-search.qmd-integration.test.ts (2 tests) 7126ms — a memory promoted via the API is retrievable with no manual reindex 6830ms`.
- New unit coverage: `index-state-repository.test.ts` (11 tests — null/0/positive contract, tenant scoping, worst-case), health-check staleness threading (4), canary gate (5 + 2 format), CLI flag (4), daemon markIndexed on success / not on failure (2), `/api/health` staleness (3).

## Risk assessment

- **Latency on admin promote:** the awaited export+reindex adds seconds to `POST /promote` on large corpora. Accepted: the endpoint is low-frequency (admin/agent review), and 200-means-searchable is the point of D1. Escape hatch: deploy without wiring `indexRefresher` (behavior reverts to pre-PR, gauge still measures).
- **Migration v10:** additive `CREATE TABLE IF NOT EXISTS`; zero blast radius on existing rows; replay-safe on fresh DBs.
- **False alarms:** avoided by the fail-open `null` contract (unmeasured passes health and the canary gate). The gate only bites after the first successful chain records completion — which the daemon/API do automatically.
- **Deterministic-timestamp edge:** merge-gate promotions inject content-derived (possibly past) `promoted_at`; such a row can appear already-absorbed. Accepted — the merge gate has its own export path; noted for the follow-up.

## Operational impact

- No env/secret/deploy-order changes. First run of any writer (API/daemon) auto-applies migration v10 to `teamkb.db`.
- Rollback: revert the PR; the `index_state` table is inert if left behind.
- The live-brain nightly canary (runbook 027-OD-OPSM) picks up the staleness gate by adding `--max-staleness-seconds` to its invocation; CI nightly already does.

## Follow-up & deferred

- Plugin local-mode govern pass should record `last_indexed_at` after its step-4 index refresh so plugin-only brains get a measured (not just fail-open) gauge — plugin-repo change, out of this repo's scope.
- Optionally surface `stalenessSeconds` in `brain_status` (plugin) once the plugin pins a registrar release containing this change.

**Refs:** #286 (Wave-1 epic · bead qmd-team-intent-kb-m8u.7 + m8u.8)

---
## Review response (2026-07-19)
- **Test-count correction:** the "+22 new" headline was wrong; the per-file breakdown in the diff sums to **33 new tests** (31 unit + 2 integration). The suite totals are CI-evidenced by the checks on this PR.
- **qmd-on-PATH (adversarial NEEDS-OWNER-DECISION): resolved with evidence** — `.github/workflows/ci.yml` line 35 has a dedicated step "Put workspace bins on PATH (qmd for integration tests)" in the main test job, so `promote-then-search.qmd-integration.test.ts` runs (not skips) in CI.
- **Plugin govern-path claim, rephrased honestly:** asserted from a same-day read-only recon of `bobs-big-brain-plugin/src/govern.ts` on current main (runGovernLocked: ingest → curator sweep → runExport → ensureCollections+update → anchor, under the flock write lock). It is out-of-repo context, not diff-evidence; re-verify if the plugin moves before merge.
