### PR TITLE
fix(edge-daemon): hoist the freshness watermark before the export read (false-fresh staleness race)

### DIFF
--- a/apps/edge-daemon/src/__tests__/cycle.test.ts
+++ b/apps/edge-daemon/src/__tests__/cycle.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { makeMemory } from '@qmd-team-intent-kb/test-fixtures';
 import type Database from 'better-sqlite3';
 import { computeContentHash } from '@qmd-team-intent-kb/common';
 import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
@@ -249,6 +250,56 @@ describe('runCycle', () => {
     expect(deps.indexStateRepo!.get(TENANT)).toBeNull();
   });
 
+  it('watermark race (#293 review): a promotion landing after the export read measures STALE, never false-fresh', async () => {
+    // Ticking clock: every nowFn call advances 1s, so the step ordering is
+    // visible in the recorded timestamps — the seam that makes the race
+    // deterministic without physical interleaving.
+    let tMs = Date.parse('2026-07-01T00:00:00.000Z');
+    const tickingNow = (): string => new Date((tMs += 1000)).toISOString();
+
+    const mockAdapter = {
+      ensureCollections: async () => ({ ok: true as const, value: [] }),
+      update: async () => ({ ok: true as const, value: undefined }),
+    };
+    const raceConfig = makeConfig({
+      spoolDir,
+      exportOutputDir: exportDir,
+      enableExport: true, // the export step is where curated_memories is read
+      enableIndexUpdate: true,
+      nowFn: tickingNow,
+    });
+
+    const result = await runCycle(
+      raceConfig,
+      { ...deps, qmdAdapter: mockAdapter as never },
+      logger,
+    );
+    expect(result.export).not.toBeNull();
+    expect(result.indexUpdate!.ok).toBe(true);
+
+    const lastIndexedAt = deps.indexStateRepo!.get(TENANT)!.lastIndexedAt;
+    const lastExportedAt = deps.exportStateRepo.get('kb-export-default')!.lastExportedAt;
+
+    // The hoist itself: the freshness watermark must NOT post-date the export
+    // step — the export read is the moment the set of promotions this cycle
+    // can absorb was fixed. Pre-fix, the watermark was captured at
+    // indexUpdateStep start (AFTER the export), and this assertion fails.
+    expect(lastIndexedAt < lastExportedAt).toBe(true);
+
+    // The race: a promotion (e.g. the API promote path in another process)
+    // lands 1ms after the export recorded its clock — after the export read,
+    // before the pre-fix watermark instant one tick later. Its markdown was
+    // never exported or indexed this cycle, so it MUST measure stale.
+    const racePromotedAt = new Date(Date.parse(lastExportedAt) + 1).toISOString();
+    deps.memoryRepo.insert(makeMemory({ tenantId: TENANT, promotedAt: racePromotedAt }));
+
+    // Pre-fix: last_indexed_at (one tick AFTER lastExportedAt) covered the race
+    // promotion → stalenessSeconds 0, false-fresh, and the canary staleness
+    // gate passes over degraded retrieval. Post-fix: measured stale.
+    const nowMs = Date.parse(racePromotedAt) + 5_000;
+    expect(deps.indexStateRepo!.stalenessSeconds(TENANT, nowMs)).toBe(5);
+  });
+
   it('records timestamps correctly', async () => {
     let callCount = 0;
     const timedConfig = makeConfig({
@@ -263,7 +314,9 @@ describe('runCycle', () => {
 
     const result = await runCycle(timedConfig, deps, logger);
     expect(result.startedAt).toBe('2026-01-15T10:00:01.000Z');
-    expect(result.completedAt).toBe('2026-01-15T10:00:02.000Z');
+    // Tick 2 is consumed by the freshness watermark hoisted to before the
+    // export step (#293 review fix) — completedAt is the 3rd clock call.
+    expect(result.completedAt).toBe('2026-01-15T10:00:03.000Z');
   });
 
   it('staleness sweep deprecates stale memories when enabled', async () => {

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -264,12 +264,27 @@ async function exportStep(
 /**
  * Step 4: qmd index update — offline resilient, retried on transient qmd
  * errors. Mutates `result.indexUpdate`. No-op when disabled or no adapter.
+ *
+ * `indexedAt` is the freshness watermark to record on success. It MUST be
+ * captured before the EXPORT step's curated_memories read (runCycle hoists it
+ * to just before `exportStep`), not here at the start of the index update:
+ * this step only re-indexes what the export already wrote, so the data this
+ * cycle can possibly absorb was fixed at the export read. Capturing the
+ * watermark here (as this step originally did) post-dated that read — a
+ * promotion landing between the export's read and a here-captured watermark
+ * got `last_indexed_at > promoted_at` and measured FRESH while its markdown
+ * was never exported or indexed: a false-fresh on the dangerous side, letting
+ * the canary staleness gate pass over degraded retrieval (PR #293 review
+ * finding, MiniMax defect lane). With the pre-export watermark the same race
+ * measures stale and is re-absorbed next cycle — under-claiming freshness is
+ * the only allowed error direction. Mirrors the API path
+ * (`apps/api` index-refresher, watermark before `runExport`).
  */
 async function indexUpdateStep(
   config: DaemonConfig,
   deps: DaemonDependencies,
   logger: DaemonLogger,
-  nowFn: () => string,
+  indexedAt: string,
   result: CycleResult,
 ): Promise<void> {
   if (!config.enableIndexUpdate || !deps.qmdAdapter) return;
@@ -280,11 +295,6 @@ async function indexUpdateStep(
     maxJitterMs: config.retryMaxJitterMs,
     sleepFn: config.sleepFn,
   };
-  // Capture the freshness watermark BEFORE the index update runs: a promotion
-  // landing mid-update may or may not be absorbed, so marking with the
-  // pre-update instant can only UNDER-claim freshness (it stays "dirty" and is
-  // re-absorbed next cycle) — never over-claim it.
-  const indexedAt = nowFn();
   try {
     await withRetry(async () => {
       const ensureResult = await adapter.ensureCollections();
@@ -359,8 +369,15 @@ export async function runCycle(
   }
 
   stalenessStep(config, deps, logger, nowFn, result);
+  // Freshness watermark (D2) — hoisted to BEFORE the export step reads
+  // curated_memories (#293 review finding). The export read is the moment the
+  // set of promotions this cycle can absorb is fixed, so the watermark must
+  // not post-date it: a promotion landing after this instant measures stale
+  // (correct — its markdown was not exported this cycle) and is absorbed next
+  // cycle. See indexUpdateStep's doc for the false-fresh race this prevents.
+  const indexedAt = nowFn();
   await exportStep(config, deps, logger, nowFn, result);
-  await indexUpdateStep(config, deps, logger, nowFn, result);
+  await indexUpdateStep(config, deps, logger, indexedAt, result);
 
   result.completedAt = nowFn();
   return result;


### PR DESCRIPTION
## What

Fixes a watermark-timing bug in the edge-daemon freshness path shipped in #293 (found post-merge by the MiniMax defect lane's review): `indexUpdateStep` captured `indexedAt = nowFn()` at the **start of the index update**, which runs **after** `exportStep` had already read `curated_memories`. A promotion landing between the export's read and that watermark got `last_indexed_at > promoted_at` and measured **fresh** while its markdown was never exported or indexed.

The watermark is now captured in `runCycle` immediately **before** `exportStep` and passed into `indexUpdateStep(config, deps, logger, indexedAt, result)`. The in-code comment that claimed the old placement "can only UNDER-claim freshness" was inverted for this race and is rewritten to document it.

## Why

This was a false-fresh on the **dangerous side** of D2's contract: the staleness gauge exists so that un-absorbed promotions read stale, and the nightly canary gate (`--max-staleness-seconds`) fails loudly. With the race, the gauge could read 0 while retrieval was degraded — the canary passes over exactly the condition it guards. The only allowed error direction is under-claiming freshness (stale-but-actually-indexed self-heals next cycle; fresh-but-actually-missing never does).

**Decision rationale — chose hoisting into `runCycle` over capturing at the top of `exportStep`** because `indexUpdateStep` can run with export disabled and both steps must share one watermark; the hoist also mirrors the already-correct API path (`apps/api/src/services/index-refresher.ts` captures the watermark before `runExport` — verified unchanged and correct, not touched by this PR).

## Layer(s) touched

- `apps/edge-daemon/src/cycle.ts` only — `runCycle` (watermark hoist) + `indexUpdateStep` (signature `nowFn` → `indexedAt`, corrected doc comment). No store, adapter, API, or schema change. No invariant change: `markIndexed` still fires only on full index-update success.
- `apps/edge-daemon/src/__tests__/cycle.test.ts` — new race-locking test + one tick-count adjustment (the hoist adds one `nowFn` call, so `completedAt` in the frozen-clock test moves from tick 2 to tick 3; commented in-test).

## How it works

`runCycle` order is ingest → curate → staleness → **watermark** → export → index update. The export read is the moment the set of promotions this cycle can absorb is fixed; a watermark at or before that read guarantees any later promotion satisfies `promoted_at > last_indexed_at` → measures stale → absorbed next cycle. (The derived-dirty design from #293 is unchanged; only the consume-side watermark placement moves.)

## Verification & evidence

- **New race-locking test** (`watermark race (#293 review): a promotion landing after the export read measures STALE, never false-fresh`): runs the cycle with `enableExport: true` and a ticking injectable clock (the cycle suite's existing `nowFn` seam), then asserts:
  1. `last_indexed_at < last_exported_at` (the hoist itself — the watermark may not post-date the export step), and
  2. a promotion timestamped 1 ms after the export's recorded clock — inside the old race window, before the pre-fix watermark one tick later — measures `stalenessSeconds = 5` at now+5 s, not 0.
- **Race lock proven**: with the fix stashed (pre-fix `cycle.ts`, new test in place), the test **fails** — `last_indexed_at` post-dates `last_exported_at` and the race promotion reads false-fresh. Restored the fix: passes.
- Full `pnpm validate` (format:check + lint + typecheck + test): **181 files, 2,187 tests, all green**. `tsc -b` clean.

## Risk assessment

- Minimal blast radius: two files, one behavioral change (watermark instant moves earlier by one step). The earlier watermark can only cause a promotion absorbed mid-cycle to be re-absorbed next cycle (a redundant no-op reindex), never the reverse.
- The `completedAt` tick shift is test-only (frozen-clock counting); production timestamps are wall-clock.

## Operational impact

None: no env, migration, dependency, secret, or deploy-order change. Rollback = revert the commit. Live brains with a false-fresh `last_indexed_at` from the race window self-correct on the first post-deploy cycle (the next successful update rewrites the watermark correctly).

## Follow-up & deferred

- From #293, still open: the plugin's local govern pass recording `last_indexed_at` (plugin repo, out of scope here). Its future implementation must follow the same pre-export watermark rule this PR documents in `indexUpdateStep`'s comment.