### PR TITLE
Add the provenance-walk subcommand and the chain-boundary doctrine doc (Wave-2 F5/F6)

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -52,6 +52,7 @@
 - `043-OD-EVAL-onboarding-qbank-v1.md` — Outsider day-1 Q-bank + baseline scoring for retrieval productization
 - `044-AT-DECR-wave0-retrieval-reconciliation.md` — Wave-0 retrieval reconciliation: ship the reranker first (Apache/MIT), defer the dense arm to a measured P2 gate, EmbeddingGemma out. Supersedes only the retrieval-arm + embedder elements of `038-AT-DECR`; unblocks the retrieval beads in the umbrella blueprint (`019-PP-PLAN` A1/B1/B2).
 - `045-OD-RNBK-anchor-remote-divergence-recovery.md` — Anchor remote divergence recovery: the private anchor-witness remote (`bobs-big-brain-anchors`, force-push-blocked), the fetch/status divergence check, per-state recovery (ahead = plain push; behind/diverged = investigate with the HISTORY_REWRITTEN tooling before ANY reconciliation), honest trust framing (detectable, not impossible)
+- `046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md` — Substrate-boundary doctrine: the ICO trace chain proves COMPILE, the INTKB audit chain proves GOVERN admission; neither proves the other's claims (nor content truth); the spool manifest SHA-256 + UUID-v5 id lineage are the bridge; walked end-to-end by `curator-cli provenance-walk`
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
 - `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)

--- a/000-docs/046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md
+++ b/000-docs/046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md
@@ -1,0 +1,135 @@
+# What Each Chain Proves: the ICO Trace Chain Proves COMPILE, the INTKB Audit Chain Proves GOVERN Admission
+
+**Document:** 046-AT-ARCH
+**Date:** 2026-07-19
+**Status:** Active
+**Related:** 036-AT-THRT (spool boundary threat model) · 034-AT-NTRP (Compile, Then Govern thesis) · umbrella 013-OD-STND · the `provenance-walk` curator-cli subcommand
+
+---
+
+## 1. Why this document exists
+
+Bob's Big Brain carries **two independent hash chains**, one on each side of the
+compile/govern boundary. They are frequently described together ("the audit
+trail"), and that shorthand invites a specific, dangerous conflation: treating a
+verified chain on one side as evidence for a claim that only the _other_ side's
+chain can back. This document pins down exactly what each chain evidences, what
+neither evidences, and what bridges them — so that every future claim (README
+copy, PR body, runbook, sales sentence) can be checked against it.
+
+The one-line rule:
+
+> **The ICO trace chain proves that a COMPILE happened. The INTKB audit chain
+> proves that a GOVERN admission decision happened. Neither proves the other's
+> claims, and neither proves the content is true.**
+
+## 2. The compile-side chain (ICO / `bobs-big-brain-compiler`)
+
+**Artifacts** (all under the brain root, canonically `~/.teamkb/brain/`):
+
+| Artifact                                      | What it is                                                                                                                                                                                                                 |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brain/.ico/state.db`                         | The compiler's deterministic kernel state (SQLite): sources, tasks, outputs.                                                                                                                                               |
+| `brain/audit/traces/YYYY-MM-DD.jsonl`         | Daily trace files. Each event carries `event_type`, `event_id`, `timestamp`, `payload`, and a `prev_hash` linking it to the previous event — hash-chained within the day and now cross-day-chained across file boundaries. |
+| `brain/audit/provenance/<sourceId>.jsonl`     | Per-source provenance records: which compile operation (`compile.summarize`, …) emitted which `outputPath` from which source.                                                                                              |
+| `brain/spool/…jsonl` + `<file>.manifest.json` | The emitted spool candidates and the manifest sidecar pinning the file's SHA-256 and listing every emitted `candidateId` (ICO kernel `packages/kernel/src/spool.ts`).                                                      |
+
+**What this chain evidences:** that a compile pass ran over given inputs at a
+recorded time and emitted given artifacts — e.g. "on 2026-07-16 a
+`compile.summarize` pass over source `7efdf9cd…` emitted
+`wiki/sources/x.md`, and a spool file containing candidate `4a35532d…` was
+written whose bytes hash to the manifest's pinned SHA-256." The `prev_hash`
+chain makes after-the-fact edits and reordering of those trace events
+_detectable_ (tamper-evident, not tamper-proof).
+
+**What this chain does NOT evidence:**
+
+- that the compiled summary is _accurate_ or _true_ — the model proposed it;
+- that the candidate was ever ingested, evaluated, or admitted by INTKB;
+- anything at all about what sits in `curated_memories` today.
+
+## 3. The govern-side chain (INTKB / `bobs-big-brain-registrar`)
+
+**Artifacts** (in `teamkb.db`, schema in `packages/store/src/schema.ts`):
+
+| Artifact           | What it is                                                                                                                                                                                                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `audit_events`     | The receipt log — append-only by protocol, not by storage. Migration-added `entry_hash` / `prev_entry_hash` columns hash-chain each row (`packages/store/src/audit-chain.ts`, verified by `packages/store/src/audit-verify.ts` / `curator-cli verify-audit-chain`).                         |
+| `candidates`       | Every ingested candidate, with source metadata (`metadata_json.filePaths[0]` = the compile-side relPath for spool candidates).                                                                                                                                                              |
+| `curated_memories` | The governed corpus. Each row carries `candidate_id` — its claimed descent — and is minted exclusively by `promote()` (`apps/curator/src/promotion/promoter.ts`), which writes the row and its `'promoted'` receipt in one transaction (checked by `curator-cli verify-corpus-accounting`). |
+
+**What this chain evidences:** that a specific candidate was admitted (or
+rejected, superseded, demoted, …) by the **deterministic policy pipeline**
+(`packages/policy-engine`) at a recorded time, by a recorded actor, with a
+recorded reason — and that the sequence of those decisions has not been
+silently edited or reordered (again: detectable, not impossible — see the
+trust-model box in the umbrella README).
+
+**What this chain does NOT evidence:**
+
+- that the candidate's content was compiled correctly, or compiled at all —
+  an `mcp`-captured candidate never touched the compiler;
+- that the content is _true_ — policy admission is a governance decision
+  (dedupe, secret-scan, trust rules), not a fact-check;
+- anything about the state of the brain directory or the compiler's traces.
+
+## 4. The bridge between them
+
+Two deterministic mechanisms — and only these two — connect the chains:
+
+1. **The spool manifest SHA-256.** ICO emits each spool file with a
+   `<file>.manifest.json` sidecar pinning `spoolFileSha256` and listing
+   `candidateIds`. INTKB verifies that pin fail-closed at ingest
+   (`verifySpoolManifest`, enforced in `apps/curator/src/intake/spool-intake.ts`;
+   mismatches are refused and quarantined). The manifest is the compile side's
+   signed-off statement of _what crossed the boundary_.
+
+2. **The UUID-v5 content-addressed id lineage.** A spool candidate's id is
+   `uuidv5(workspaceId, relPath, bodySha256)` — a pure function of its content
+   and origin, derived identically on both sides
+   (`packages/common/src/uuid-v5.ts`, namespace vendored byte-identical from
+   the ICO kernel). Promotion then derives
+   `memoryId = uuidv5("memory", candidateId, contentHash)`. So a
+   `curated_memories` row names, verifiably, exactly which compile-side
+   artifact it descends from.
+
+The `provenance-walk` curator-cli subcommand walks this whole path for one
+memory (store row → id derivations → `'promoted'` receipt → candidate row →
+manifest entry → ICO trace event) and reports PASS / FAIL / UNVERIFIABLE per
+link — UNVERIFIABLE, not PASS, when a backing artifact is absent (e.g. no
+brain directory on CI).
+
+## 5. The conflation failure mode
+
+The failure mode this document exists to prevent is any sentence shaped like
+these — each one **wrong**, quoted here only to be forbidden:
+
+- ❌ "the audit chain proves the content is true / was compiled correctly"
+- ❌ "the trace chain proves the memory was admitted"
+
+More concrete wrong examples, with the reason each fails:
+
+- ❌ "The audit chain proves this summary is accurate." — No chain proves
+  accuracy; the audit chain proves only _admission by policy, and when_.
+- ❌ "The audit chain proves the content was compiled from that source." — That
+  is the trace chain's + manifest's claim; the audit chain only records what
+  the curator was _told_ via the candidate's id and metadata.
+- ❌ "The trace chain proves this page is in the governed corpus." — Compile
+  says nothing about admission; the candidate may have been rejected,
+  deduplicated, or never ingested.
+
+The honest composite claim is a **conjunction with the bridge stated**: "the
+trace chain evidences the compile, the manifest + UUID-v5 lineage evidence that
+this exact content crossed the boundary, and the audit chain evidences its
+admission." Drop any leg and the claim must shrink accordingly. The umbrella
+repo's `scripts/lint-forbidden-words.sh` now carries a CONFLATION check that
+flags the wrong forms on brand surfaces.
+
+## 6. Operator quick reference
+
+| Question                                             | Tool                                                                        | Chain consulted         |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------- |
+| "Was this memory admitted, when, by whom?"           | `curator-cli verify-audit-chain` + the `'promoted'` receipt                 | govern (`audit_events`) |
+| "Did every corpus row come through the promoter?"    | `curator-cli verify-corpus-accounting`                                      | govern                  |
+| "Did a compile pass emit this page?"                 | trace/provenance files under `brain/audit/`                                 | compile                 |
+| "Does this memory's whole lineage hold, end to end?" | `curator-cli provenance-walk --memory-id <id> --db <path> [--brain <path>]` | both, via the bridge    |

--- a/apps/curator/src/__tests__/provenance-walk.test.ts
+++ b/apps/curator/src/__tests__/provenance-walk.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for the `provenance-walk` subcommand (Wave-2 F6): walk one curated
+ * memory's provenance chain across the govern/compile boundary and report
+ * PASS / FAIL / UNVERIFIABLE per link.
+ *
+ * Three scenarios matter:
+ *   1. End-to-end PASS — a spool-style candidate promoted via the REAL
+ *      promoter, with a fabricated spool-manifest sidecar and a fabricated
+ *      ICO brain dir (trace event), walks 7/7 PASS and exits 0.
+ *   2. Broken link — the manifest sidecars exist but none names the
+ *      candidate: the spool-manifest link FAILs and the exit code is 1.
+ *   3. Absent brain — the --brain path does not exist: the compile-trace
+ *      link is honestly UNVERIFIABLE (not FAIL) and the exit code is 3,
+ *      distinct from the broken-chain exit 1.
+ *
+ * @module __tests__/provenance-walk.test
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { computeContentHash, deriveCandidateId } from '@qmd-team-intent-kb/common';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import {
+  AuditRepository,
+  CandidateRepository,
+  MemoryRepository,
+  createTestDatabase,
+} from '@qmd-team-intent-kb/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatch, type CuratorCliDeps } from '../cli.js';
+import { promote } from '../promotion/promoter.js';
+
+import { makeCandidate } from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Scaffolding (same pattern as verify-corpus-accounting.test.ts)
+// ---------------------------------------------------------------------------
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+function stdoutText(): string {
+  const calls = stdoutSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+function stderrText(): string {
+  const calls = stderrSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+function makePipelineResult(candidateId: string): PipelineResult {
+  return { candidateId, outcome: 'approved', evaluations: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builder — one temp workspace holding brain/ + spool/ + a live
+// in-memory store seeded through the REAL candidate-insert + promoter path.
+// ---------------------------------------------------------------------------
+
+const REL_PATH = 'wiki/concepts/provenance-walk-fixture.md';
+// NOTE: no leading/trailing whitespace — the MemoryCandidate Zod schema trims
+// `content` on parse, and the candidate id must address the AS-STORED content.
+const BODY = '## Fixture\n\nA compiled page body used to content-address the candidate.';
+
+interface Fixture {
+  root: string;
+  brainDir: string;
+  spoolDir: string;
+  db: ReturnType<typeof createTestDatabase>;
+  deps: CuratorCliDeps;
+  candidate: MemoryCandidate;
+  memoryId: string;
+}
+
+/**
+ * Seed the store exactly the way production does: a spool-shaped candidate
+ * (content-addressed UUID-v5 id, source 'import', filePaths[0] = relPath)
+ * inserted via CandidateRepository, then promoted via promote(). The spool
+ * manifest sidecar and the ICO trace event are fabricated on disk.
+ */
+function buildFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), 'provenance-walk-'));
+  const brainDir = join(root, 'brain');
+  const spoolDir = join(root, 'spool');
+  mkdirSync(join(brainDir, 'audit', 'traces'), { recursive: true });
+  mkdirSync(spoolDir, { recursive: true });
+
+  // Candidate id derived exactly as ICO derives it: workspaceId is the
+  // basename of the brain root; body sha is the sha256 of the page body.
+  const bodySha256 = computeContentHash(BODY);
+  const candidateId = deriveCandidateId(basename(brainDir), REL_PATH, bodySha256);
+  const candidate = makeCandidate({
+    id: candidateId,
+    source: 'import',
+    content: BODY,
+    metadata: { filePaths: [REL_PATH], projectContext: 'ico', tags: [] },
+  });
+
+  const db = createTestDatabase();
+  const candidateRepo = new CandidateRepository(db);
+  const memoryRepo = new MemoryRepository(db);
+  const auditRepo = new AuditRepository(db);
+  const contentHash = computeContentHash(candidate.content);
+  candidateRepo.insert(candidate, contentHash);
+  const memory = promote(
+    { candidate, contentHash, pipelineResult: makePipelineResult(candidate.id) },
+    memoryRepo,
+    auditRepo,
+  );
+
+  // Spool file + manifest sidecar, shaped like ICO's emit (spoolFileSha256
+  // pins the file bytes; candidateIds lists the emitted ids).
+  const spoolFile = join(spoolDir, 'spool-2026-01-01T000000Z.jsonl');
+  const spoolBody = JSON.stringify({ id: candidateId }) + '\n';
+  writeFileSync(spoolFile, spoolBody);
+  writeFileSync(
+    `${spoolFile}.manifest.json`,
+    JSON.stringify({
+      schemaVersion: '1',
+      emittedCount: 1,
+      spoolFile: 'spool-2026-01-01T000000Z.jsonl',
+      spoolFileSha256: createHash('sha256').update(spoolBody, 'utf8').digest('hex'),
+      candidateIds: [candidateId],
+    }),
+  );
+
+  // One hash-chained ICO trace event referencing the compiled page.
+  writeFileSync(
+    join(brainDir, 'audit', 'traces', '2026-01-01.jsonl'),
+    JSON.stringify({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      event_type: 'compile.summarize',
+      event_id: 'fixture-event-1',
+      payload: { sourceId: 'fixture-source', outputPath: REL_PATH },
+      prev_hash: 'a'.repeat(64),
+    }) + '\n',
+  );
+
+  const deps: CuratorCliDeps = { createDb: () => db };
+  return { root, brainDir, spoolDir, db, deps, candidate, memoryId: memory.id };
+}
+
+function walkArgs(f: Fixture, overrides?: { brainDir?: string }): string[] {
+  return [
+    'provenance-walk',
+    '--memory-id',
+    f.memoryId,
+    '--db',
+    join(f.root, 'teamkb.db'), // presence-only: deps.createDb ignores the path
+    '--brain',
+    overrides?.brainDir ?? f.brainDir,
+    '--spool',
+    f.spoolDir,
+    '--json',
+  ];
+}
+
+interface WalkEnvelope {
+  memoryId: string;
+  links: Array<{ link: string; status: string; evidence: string }>;
+  passCount: number;
+  failCount: number;
+  unverifiableCount: number;
+  exitCode: number;
+}
+
+function parseEnvelope(): WalkEnvelope {
+  return JSON.parse(stdoutText()) as WalkEnvelope;
+}
+
+function linkStatus(env: WalkEnvelope, name: string): string | undefined {
+  return env.links.find((l) => l.link === name)?.status;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('curator-cli provenance-walk', () => {
+  let fixture: Fixture;
+
+  beforeEach(() => {
+    fixture = buildFixture();
+  });
+
+  afterEach(() => {
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  it('walks the full chain PASS end-to-end and exits 0', async () => {
+    const code = await dispatch(walkArgs(fixture), fixture.deps);
+
+    expect(code).toBe(0);
+    const env = parseEnvelope();
+    expect(env.memoryId).toBe(fixture.memoryId);
+    expect(env.failCount).toBe(0);
+    expect(env.unverifiableCount).toBe(0);
+    expect(env.passCount).toBe(7);
+    for (const name of [
+      'memory-row',
+      'memory-id-derivation',
+      'promotion-receipt',
+      'candidate-row',
+      'candidate-id-derivation',
+      'spool-manifest',
+      'compile-trace',
+    ]) {
+      expect(linkStatus(env, name)).toBe('PASS');
+    }
+  });
+
+  it('FAILs the spool-manifest link (exit 1) when no manifest names the candidate', async () => {
+    // Break exactly one link: manifests exist, but none lists this candidate.
+    const spoolFile = join(fixture.spoolDir, 'spool-2026-01-01T000000Z.jsonl');
+    writeFileSync(
+      `${spoolFile}.manifest.json`,
+      JSON.stringify({
+        schemaVersion: '1',
+        emittedCount: 1,
+        spoolFile: 'spool-2026-01-01T000000Z.jsonl',
+        spoolFileSha256: 'f'.repeat(64),
+        candidateIds: ['00000000-0000-5000-8000-000000000000'],
+      }),
+    );
+
+    const code = await dispatch(walkArgs(fixture), fixture.deps);
+
+    expect(code).toBe(1);
+    const env = parseEnvelope();
+    expect(linkStatus(env, 'spool-manifest')).toBe('FAIL');
+    expect(env.failCount).toBe(1);
+    // The govern-side links are unaffected by the broken bridge.
+    expect(linkStatus(env, 'memory-row')).toBe('PASS');
+    expect(linkStatus(env, 'promotion-receipt')).toBe('PASS');
+  });
+
+  it('reports compile-trace UNVERIFIABLE (exit 3, distinct from FAIL) when the brain dir is absent', async () => {
+    // The CI shape: the brain root path is well-formed (basename 'brain', so
+    // the workspaceId derivation still holds) but the directory does not
+    // exist on this host. That is absence of evidence, not contradiction.
+    const code = await dispatch(
+      walkArgs(fixture, { brainDir: join(fixture.root, 'nowhere', 'brain') }),
+      fixture.deps,
+    );
+
+    expect(code).toBe(3);
+    const env = parseEnvelope();
+    expect(linkStatus(env, 'compile-trace')).toBe('UNVERIFIABLE');
+    expect(env.failCount).toBe(0);
+    expect(env.unverifiableCount).toBe(1);
+    // Everything the store can still back stays PASS.
+    expect(linkStatus(env, 'memory-row')).toBe('PASS');
+    expect(linkStatus(env, 'candidate-id-derivation')).toBe('PASS');
+    expect(linkStatus(env, 'spool-manifest')).toBe('PASS');
+  });
+
+  it('FAILs the memory-row link (exit 1) for an unknown memory id', async () => {
+    const code = await dispatch(
+      [
+        'provenance-walk',
+        '--memory-id',
+        'does-not-exist',
+        '--db',
+        join(fixture.root, 'teamkb.db'),
+        '--brain',
+        fixture.brainDir,
+        '--spool',
+        fixture.spoolDir,
+        '--json',
+      ],
+      fixture.deps,
+    );
+
+    expect(code).toBe(1);
+    const env = parseEnvelope();
+    expect(linkStatus(env, 'memory-row')).toBe('FAIL');
+  });
+
+  it('refuses to run without --db (exit 2)', async () => {
+    const code = await dispatch(['provenance-walk', '--memory-id', fixture.memoryId], fixture.deps);
+    expect(code).toBe(2);
+    expect(stderrText()).toContain('missing required flag: --db');
+  });
+
+  it('refuses to run without --memory-id (exit 2)', async () => {
+    const code = await dispatch(
+      ['provenance-walk', '--db', join(fixture.root, 'teamkb.db')],
+      fixture.deps,
+    );
+    expect(code).toBe(2);
+    expect(stderrText()).toContain('missing required flag: --memory-id');
+  });
+});

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -22,6 +22,7 @@
  */
 
 import { existsSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 
 import {
   CandidateRepository,
@@ -41,6 +42,7 @@ import type {
 
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
+import { walkProvenance } from './provenance/provenance-walk.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -81,6 +83,15 @@ Subcommands:
     without one is an orphan — the signature of a raw SQL INSERT that bypassed
     the curator promoter. Opens the db READ-ONLY; exits 2 when orphans exist.
 
+  provenance-walk --memory-id <id> --db <path> [--brain <path>] [--spool <dir>]... [--json]
+    Walk one curated memory's provenance chain across the govern/compile
+    boundary: curated_memories row → id derivation → 'promoted' receipt →
+    candidates row → content-addressed candidate id → spool manifest entry
+    (the bridge) → ICO compile trace. Prints PASS / FAIL / UNVERIFIABLE per
+    link with the evidence backing it. Opens the db READ-ONLY.
+    Exit: 0 all PASS · 1 any FAIL (broken chain) · 3 no FAIL but >=1
+    UNVERIFIABLE (artifact absent, e.g. no brain dir on CI) · 2 usage error.
+
   help | --help | -h
     Print this message.
 
@@ -108,6 +119,17 @@ Options for 'verify-corpus-accounting':
   --db <path>     SQLite path to read READ-ONLY (required for any meaningful
                   run; an in-memory db is always empty). Never mutated.
   --json          Emit a structured JSON envelope in place of the summary.
+
+Options for 'provenance-walk':
+  --memory-id <id>  The curated_memories id to walk (required).
+  --db <path>       SQLite path to read READ-ONLY (required). Never mutated.
+  --brain <path>    ICO brain root holding audit/traces/. Its basename is the
+                    workspaceId used in the candidate-id derivation.
+                    Default: ~/.teamkb/brain.
+  --spool <dir>     Directory scanned recursively for spool *.manifest.json
+                    sidecars. Repeatable. Default: <db-dir>/spool and
+                    <db-dir>/brain/spool.
+  --json            Emit a structured JSON envelope in place of the summary.
 `;
 
 // ---------------------------------------------------------------------------
@@ -129,6 +151,8 @@ export async function dispatch(argv: string[], deps: CuratorCliDeps): Promise<nu
       return cmdGenerateExceptionManifest(argv.slice(1), deps);
     case 'verify-corpus-accounting':
       return cmdVerifyCorpusAccounting(argv.slice(1), deps);
+    case 'provenance-walk':
+      return cmdProvenanceWalk(argv.slice(1), deps);
     case 'help':
     case '--help':
     case '-h':
@@ -768,6 +792,139 @@ async function cmdVerifyCorpusAccounting(args: string[], deps: CuratorCliDeps): 
       process.stderr.write(`  ${o.id}  tenant=${o.tenantId}  promoted_at=${o.promotedAt}\n`);
     }
     return 2;
+  } finally {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// provenance-walk
+//
+// Walk one memory's full provenance chain across the govern/compile boundary
+// (046-AT-ARCH): the INTKB store rows + 'promoted' receipt (govern), the
+// UUID-v5 id lineage, the spool manifest bridge, and the ICO compile trace
+// (compile). Each link is verified against the artifact that actually backs
+// it; an absent artifact is honestly UNVERIFIABLE, never PASS.
+// ---------------------------------------------------------------------------
+
+interface ProvenanceWalkOpts {
+  memoryId: string;
+  dbPath: string;
+  brainDir?: string;
+  spoolDirs: string[];
+  json: boolean;
+}
+
+function parseProvenanceWalkArgs(
+  args: string[],
+): { ok: true; opts: ProvenanceWalkOpts } | { ok: false; message: string } {
+  let memoryId: string | undefined;
+  let dbPath: string | undefined;
+  let brainDir: string | undefined;
+  const spoolDirs: string[] = [];
+  let json = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+    switch (arg) {
+      case '--memory-id':
+        memoryId = args[i + 1];
+        i += 2;
+        break;
+      case '--db':
+        dbPath = args[i + 1];
+        i += 2;
+        break;
+      case '--brain':
+        brainDir = args[i + 1];
+        i += 2;
+        break;
+      case '--spool': {
+        const dir = args[i + 1];
+        if (dir !== undefined) spoolDirs.push(dir);
+        i += 2;
+        break;
+      }
+      case '--json':
+        json = true;
+        i += 1;
+        break;
+      default:
+        return { ok: false, message: `unknown flag: ${arg}` };
+    }
+  }
+
+  if (memoryId === undefined || memoryId.trim() === '') {
+    return { ok: false, message: 'missing required flag: --memory-id <id>' };
+  }
+  // --db is mandatory for the same reason as verify-corpus-accounting: an
+  // implicit in-memory store would make every link a verdict about nothing.
+  if (dbPath === undefined || dbPath.trim() === '') {
+    return {
+      ok: false,
+      message: 'missing required flag: --db <path> (refusing to walk an implicit in-memory store)',
+    };
+  }
+
+  return { ok: true, opts: { memoryId, dbPath, brainDir, spoolDirs, json } };
+}
+
+/** Directory containing a db path (mirror of defaultManifestPath's logic). */
+function dbDir(dbPath: string): string {
+  const idx = Math.max(dbPath.lastIndexOf('/'), dbPath.lastIndexOf('\\'));
+  return idx >= 0 ? dbPath.slice(0, idx) : '.';
+}
+
+async function cmdProvenanceWalk(args: string[], deps: CuratorCliDeps): Promise<number> {
+  const parsed = parseProvenanceWalkArgs(args);
+  if (!parsed.ok) {
+    process.stderr.write(`curator-cli provenance-walk: ${parsed.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const { memoryId, dbPath, json } = parsed.opts;
+  const brainDir = parsed.opts.brainDir ?? `${homedir()}/.teamkb/brain`;
+  const spoolDirs =
+    parsed.opts.spoolDirs.length > 0
+      ? parsed.opts.spoolDirs
+      : [`${dbDir(dbPath)}/spool`, `${dbDir(dbPath)}/brain/spool`];
+
+  // Open READ-ONLY — a verifier must never mutate a live brain.
+  const db = deps.createDb({ dbPath, readonly: true });
+  try {
+    const result = walkProvenance(db, memoryId, { spoolDirs, brainDir });
+
+    if (json) {
+      process.stdout.write(JSON.stringify(result) + '\n');
+      return result.exitCode;
+    }
+
+    process.stdout.write(`provenance walk: memory ${result.memoryId}\n`);
+    process.stdout.write(`brain root:  ${brainDir}\n`);
+    process.stdout.write(`spool dirs:  ${spoolDirs.join(', ')}\n\n`);
+    for (const link of result.links) {
+      process.stdout.write(`  [${link.status.padEnd(12)}] ${link.link}\n`);
+      process.stdout.write(`      ${link.evidence}\n`);
+    }
+    process.stdout.write(
+      `\nChain: ${result.passCount} PASS / ${result.failCount} FAIL / ` +
+        `${result.unverifiableCount} UNVERIFIABLE\n`,
+    );
+    if (result.failCount > 0) {
+      process.stderr.write(
+        `PROVENANCE_BROKEN: ${result.failCount} link(s) contradicted by the artifacts that back them.\n`,
+      );
+    } else if (result.unverifiableCount > 0) {
+      process.stdout.write(
+        `Some links are UNVERIFIABLE: their backing artifacts are absent on this host — ` +
+          `absence of evidence, not contradiction.\n`,
+      );
+    }
+    return result.exitCode;
   } finally {
     try {
       (db as unknown as { close?: () => void }).close?.();

--- a/apps/curator/src/provenance/provenance-walk.ts
+++ b/apps/curator/src/provenance/provenance-walk.ts
@@ -1,0 +1,441 @@
+/**
+ * provenance-walk — walk one curated memory's full provenance chain across the
+ * govern/compile boundary and report PASS / FAIL / UNVERIFIABLE per link.
+ *
+ * The two hash chains prove DIFFERENT things (046-AT-ARCH): the ICO trace
+ * chain (`<brain>/audit/traces/*.jsonl`) evidences that a compile pass ran;
+ * the INTKB `audit_events` chain evidences that a candidate was admitted by
+ * the deterministic policy pipeline. Neither proves the other's claims. The
+ * bridge between them is (a) the spool manifest sidecar's SHA-256 +
+ * candidateIds and (b) the shared UUID-v5 content-addressed id lineage
+ * (`packages/common/src/uuid-v5.ts`). This walker makes that bridge
+ * inspectable for a single memory:
+ *
+ *   memory_id
+ *     -> curated_memories row                              (govern store)
+ *     -> id == deriveMemoryId(candidate_id, content_hash)  (id lineage)
+ *     -> 'promoted' audit receipt                          (govern chain)
+ *     -> candidates row                                    (govern store)
+ *     -> candidate_id == deriveCandidateId(ws, relPath, sha256(content))
+ *     -> spool manifest entry (candidateIds + file SHA-256) (the bridge)
+ *     -> ICO compile trace event referencing relPath        (compile chain)
+ *
+ * Honesty discipline: a link whose backing artifact is ABSENT (no brain dir on
+ * CI, an mcp-captured candidate that never had a spool file, rotated traces)
+ * is reported UNVERIFIABLE — not PASS, not FAIL. FAIL is reserved for
+ * contradiction: an artifact that exists and disagrees.
+ *
+ * @module provenance/provenance-walk
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+
+import { computeContentHash, deriveCandidateId, deriveMemoryId } from '@qmd-team-intent-kb/common';
+import type { createDatabase as CreateDatabase } from '@qmd-team-intent-kb/store';
+
+type Db = ReturnType<typeof CreateDatabase>;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Verdict for one link of the chain. */
+export type LinkStatus = 'PASS' | 'FAIL' | 'UNVERIFIABLE';
+
+/** Stable link names, in walk order. */
+export type LinkName =
+  | 'memory-row'
+  | 'memory-id-derivation'
+  | 'promotion-receipt'
+  | 'candidate-row'
+  | 'candidate-id-derivation'
+  | 'spool-manifest'
+  | 'compile-trace';
+
+export interface WalkLink {
+  link: LinkName;
+  status: LinkStatus;
+  /** Human-readable statement of what evidence backs (or fails to back) the link. */
+  evidence: string;
+}
+
+export interface WalkResult {
+  memoryId: string;
+  links: WalkLink[];
+  passCount: number;
+  failCount: number;
+  unverifiableCount: number;
+  /** 0 = every link PASS · 1 = >=1 FAIL (broken chain) · 3 = no FAIL but >=1 UNVERIFIABLE. */
+  exitCode: 0 | 1 | 3;
+}
+
+export interface WalkOptions {
+  /** Directories scanned (recursively) for `*.manifest.json` spool sidecars. */
+  spoolDirs: string[];
+  /** ICO brain root (contains `audit/traces/`). Its basename is the workspaceId
+   *  ICO folded into the candidate's UUID-v5 derivation. */
+  brainDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes (raw SQL — the walker is read-only and repo-independent)
+// ---------------------------------------------------------------------------
+
+interface MemoryRow {
+  id: string;
+  candidate_id: string;
+  content: string;
+  content_hash: string;
+  tenant_id: string;
+  source: string;
+  promoted_at: string;
+}
+
+interface CandidateRow {
+  id: string;
+  source: string;
+  content: string;
+  content_hash: string;
+  metadata_json: string;
+}
+
+interface ReceiptRow {
+  id: string;
+  timestamp: string;
+}
+
+interface SpoolManifest {
+  spoolFile?: string;
+  spoolFileSha256?: string;
+  candidateIds?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively collect `*.manifest.json` files under a directory (best-effort:
+ *  unreadable entries are skipped, never fatal). */
+function collectManifestFiles(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      collectManifestFiles(full, out);
+    } else if (entry.endsWith('.manifest.json')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Parse one manifest sidecar; null on malformed JSON (skipped, not fatal). */
+function readManifest(path: string): SpoolManifest | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as SpoolManifest;
+  } catch {
+    return null;
+  }
+}
+
+/** Minimal shape of one ICO trace event (daily JSONL under audit/traces/). */
+interface TraceEvent {
+  event_type?: string;
+  event_id?: string;
+  timestamp?: string;
+  prev_hash?: string | null;
+  payload?: { outputPath?: string };
+}
+
+/** Scan every daily trace file for the first event whose payload.outputPath
+ *  matches `relPath`. Returns the match + its file, or null. */
+function findTraceEvent(
+  tracesDir: string,
+  relPath: string,
+): { file: string; event: TraceEvent } | null {
+  let files: string[];
+  try {
+    files = readdirSync(tracesDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .sort();
+  } catch {
+    return null;
+  }
+  for (const f of files) {
+    const full = join(tracesDir, f);
+    let body: string;
+    try {
+      body = readFileSync(full, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of body.split('\n')) {
+      if (line.trim() === '') continue;
+      // Cheap prefilter before JSON.parse — trace files can be large.
+      if (!line.includes(relPath)) continue;
+      let ev: TraceEvent;
+      try {
+        ev = JSON.parse(line) as TraceEvent;
+      } catch {
+        continue;
+      }
+      if (ev.payload?.outputPath === relPath) {
+        return { file: full, event: ev };
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// The walk
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the provenance chain for one memory id. Read-only over `db` and the
+ * filesystem; never throws for absent artifacts (that is what UNVERIFIABLE
+ * is for).
+ */
+export function walkProvenance(db: Db, memoryId: string, opts: WalkOptions): WalkResult {
+  const links: WalkLink[] = [];
+  const push = (link: LinkName, status: LinkStatus, evidence: string): void => {
+    links.push({ link, status, evidence });
+  };
+
+  // Link 1 — the curated_memories row itself.
+  const memory = db
+    .prepare(
+      `SELECT id, candidate_id, content, content_hash, tenant_id, source, promoted_at
+       FROM curated_memories WHERE id = ?`,
+    )
+    .get(memoryId) as MemoryRow | undefined;
+
+  if (memory === undefined) {
+    push('memory-row', 'FAIL', `no curated_memories row with id ${memoryId}`);
+    return finalize(memoryId, links);
+  }
+  push(
+    'memory-row',
+    'PASS',
+    `curated_memories row found (tenant=${memory.tenant_id}, source=${memory.source}, promoted_at=${memory.promoted_at})`,
+  );
+
+  // Link 2 — the memory id is content-derived from its candidate lineage
+  // (deriveMemoryId, packages/common/src/uuid-v5.ts), and the stored content
+  // still hashes to the stored content_hash.
+  const recomputedHash = computeContentHash(memory.content);
+  if (recomputedHash !== memory.content_hash) {
+    push(
+      'memory-id-derivation',
+      'FAIL',
+      `stored content no longer hashes to content_hash (expected ${memory.content_hash}, got ${recomputedHash}) — the durable row was modified after promotion`,
+    );
+  } else {
+    const derivedMemoryId = deriveMemoryId(memory.candidate_id, memory.content_hash);
+    if (derivedMemoryId === memory.id) {
+      push(
+        'memory-id-derivation',
+        'PASS',
+        `id == uuidv5("memory", candidate_id, content_hash) == ${derivedMemoryId}; content re-hashes to content_hash`,
+      );
+    } else {
+      push(
+        'memory-id-derivation',
+        'FAIL',
+        `id ${memory.id} != derived ${derivedMemoryId} — the id is not a pure function of this candidate lineage (pre-derivation legacy row, or the lineage was altered)`,
+      );
+    }
+  }
+
+  // Link 3 — the govern-side receipt: the audit_events chain must carry the
+  // row-creating 'promoted' event for this memory (the admission receipt).
+  const receipt = db
+    .prepare(
+      `SELECT id, timestamp FROM audit_events
+       WHERE memory_id = ? AND action = 'promoted'
+       ORDER BY timestamp LIMIT 1`,
+    )
+    .get(memoryId) as ReceiptRow | undefined;
+  if (receipt === undefined) {
+    push(
+      'promotion-receipt',
+      'FAIL',
+      `no 'promoted' audit_events receipt for this memory — the signature of an insert that bypassed the promoter (see verify-corpus-accounting)`,
+    );
+  } else {
+    push(
+      'promotion-receipt',
+      'PASS',
+      `'promoted' receipt ${receipt.id} at ${receipt.timestamp} on the audit_events hash chain (verify the whole chain with verify-audit-chain)`,
+    );
+  }
+
+  // Link 4 — the candidate row the memory claims descent from.
+  const candidate = db
+    .prepare(
+      `SELECT id, source, content, content_hash, metadata_json
+       FROM candidates WHERE id = ?`,
+    )
+    .get(memory.candidate_id) as CandidateRow | undefined;
+  if (candidate === undefined) {
+    push('candidate-row', 'FAIL', `no candidates row with id ${memory.candidate_id}`);
+    return finalize(memoryId, links);
+  }
+  push(
+    'candidate-row',
+    'PASS',
+    `candidates row found (id=${candidate.id}, source=${candidate.source})`,
+  );
+
+  // relPath: the compile-side source path ICO stamped into the candidate
+  // metadata (buildCandidate sets filePaths[0] = the wiki page's relPath).
+  let relPath: string | undefined;
+  try {
+    const meta = JSON.parse(candidate.metadata_json) as { filePaths?: string[] };
+    relPath = Array.isArray(meta.filePaths) ? meta.filePaths[0] : undefined;
+  } catch {
+    relPath = undefined;
+  }
+  const spoolDerived = candidate.source === 'import' && relPath !== undefined;
+
+  // Link 5 — the candidate id is content-addressed: ICO derives it as
+  // uuidv5(workspaceId, relPath, bodySha256) where bodySha256 is the SHA-256
+  // of the compiled page body — which is exactly the candidate content INTKB
+  // stored. workspaceId is the basename of the brain root (ICO kernel spool.ts).
+  if (!spoolDerived) {
+    push(
+      'candidate-id-derivation',
+      'UNVERIFIABLE',
+      `candidate source is '${candidate.source}' with no compile-side filePath — not a spool-derived candidate; its id is not content-addressed by design`,
+    );
+  } else {
+    const workspaceId = basename(resolve(opts.brainDir));
+    const bodySha256 = computeContentHash(candidate.content);
+    const derivedCandidateId = deriveCandidateId(workspaceId, relPath!, bodySha256);
+    if (derivedCandidateId === candidate.id) {
+      push(
+        'candidate-id-derivation',
+        'PASS',
+        `candidate_id == uuidv5(workspaceId="${workspaceId}", relPath="${relPath}", sha256(content)) == ${derivedCandidateId}`,
+      );
+    } else {
+      push(
+        'candidate-id-derivation',
+        'FAIL',
+        `candidate_id ${candidate.id} != derived ${derivedCandidateId} (workspaceId="${workspaceId}", relPath="${relPath}") — stored candidate content does not address to this id`,
+      );
+    }
+  }
+
+  // Link 6 — THE BRIDGE: the spool manifest sidecar ICO emitted alongside the
+  // spool file names this candidate id and pins the file's SHA-256.
+  if (!spoolDerived) {
+    push(
+      'spool-manifest',
+      'UNVERIFIABLE',
+      `not a spool-derived candidate — no spool manifest exists by design`,
+    );
+  } else {
+    const manifestFiles = opts.spoolDirs.flatMap((d) => collectManifestFiles(d));
+    if (manifestFiles.length === 0) {
+      push(
+        'spool-manifest',
+        'UNVERIFIABLE',
+        `no *.manifest.json sidecars found under: ${opts.spoolDirs.join(', ')} — spool artifacts absent (rotated, or not present on this host)`,
+      );
+    } else {
+      let found: { path: string; manifest: SpoolManifest } | null = null;
+      for (const mf of manifestFiles) {
+        const manifest = readManifest(mf);
+        if (manifest?.candidateIds?.includes(candidate.id) === true) {
+          found = { path: mf, manifest };
+          break;
+        }
+      }
+      if (found === null) {
+        push(
+          'spool-manifest',
+          'FAIL',
+          `scanned ${manifestFiles.length} manifest sidecar(s) under ${opts.spoolDirs.join(', ')} — none lists candidate ${candidate.id}; the spool bridge for this candidate is broken`,
+        );
+      } else {
+        // Extra integrity: if the sibling spool file still exists, its current
+        // bytes must hash to the manifest's pinned SHA-256.
+        const spoolPath = found.path.replace(/\.manifest\.json$/, '');
+        let fileNote = 'spool file no longer present (archived/rotated) — manifest entry stands';
+        let fileMismatch = false;
+        if (existsSync(spoolPath) && found.manifest.spoolFileSha256 !== undefined) {
+          const actual = computeContentHash(readFileSync(spoolPath, 'utf8'));
+          if (actual === found.manifest.spoolFileSha256) {
+            fileNote = `spool file present and hashes to the pinned SHA-256 (${actual.slice(0, 12)}…)`;
+          } else {
+            fileMismatch = true;
+            fileNote = `spool file present but hashes to ${actual}, manifest pins ${found.manifest.spoolFileSha256} — file modified after emit`;
+          }
+        }
+        push(
+          'spool-manifest',
+          fileMismatch ? 'FAIL' : 'PASS',
+          `manifest ${found.path} lists candidate ${candidate.id}; ${fileNote}`,
+        );
+      }
+    }
+  }
+
+  // Link 7 — the compile-side chain: an ICO trace event referencing this
+  // candidate's source relPath in <brain>/audit/traces/*.jsonl. This is the
+  // COMPILE claim only — it evidences a compile pass emitted this page; it
+  // says nothing about admission (that is link 3's chain).
+  if (!spoolDerived) {
+    push(
+      'compile-trace',
+      'UNVERIFIABLE',
+      `not a spool-derived candidate — there is no ICO compile trace to look for`,
+    );
+  } else if (!existsSync(opts.brainDir)) {
+    push(
+      'compile-trace',
+      'UNVERIFIABLE',
+      `brain root ${opts.brainDir} does not exist on this host — compile-side evidence unavailable (expected e.g. on CI)`,
+    );
+  } else {
+    const tracesDir = join(opts.brainDir, 'audit', 'traces');
+    const hit = findTraceEvent(tracesDir, relPath!);
+    if (hit === null) {
+      push(
+        'compile-trace',
+        'UNVERIFIABLE',
+        `no trace event with outputPath="${relPath}" under ${tracesDir} — traces absent or rotated past this compile (absence of evidence, not contradiction)`,
+      );
+    } else {
+      const chained = hit.event.prev_hash !== null && hit.event.prev_hash !== undefined;
+      push(
+        'compile-trace',
+        'PASS',
+        `trace event ${hit.event.event_id} (${hit.event.event_type}) at ${hit.event.timestamp} in ${hit.file}${chained ? ', hash-chained via prev_hash' : ' (chain head: prev_hash null)'}`,
+      );
+    }
+  }
+
+  return finalize(memoryId, links);
+}
+
+function finalize(memoryId: string, links: WalkLink[]): WalkResult {
+  const passCount = links.filter((l) => l.status === 'PASS').length;
+  const failCount = links.filter((l) => l.status === 'FAIL').length;
+  const unverifiableCount = links.filter((l) => l.status === 'UNVERIFIABLE').length;
+  const exitCode = failCount > 0 ? 1 : unverifiableCount > 0 ? 3 : 0;
+  return { memoryId, links, passCount, failCount, unverifiableCount, exitCode };
+}


### PR DESCRIPTION
## What

Two deliverables on the honesty track:

1. **`000-docs/046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md`** — the substrate-boundary doctrine: the ICO trace chain (`brain/audit/traces/*.jsonl`, hash-chained via `prev_hash`, cross-day-chained) evidences that a **COMPILE** ran over given inputs and emitted given artifacts; the INTKB `audit_events` chain evidences that a candidate was **admitted/rejected by the deterministic policy pipeline, and when**. Neither proves the other's claims, and neither proves the content is true. The spool manifest SHA-256 + the UUID-v5 content-addressed id lineage (`packages/common/src/uuid-v5.ts`) are the only bridge. Indexed in `000-docs/000-INDEX.md` as 046.
2. **`curator-cli provenance-walk --memory-id <id> --db <path> [--brain <path>] [--spool <dir>]`** — walks one memory's full lineage across that boundary and reports PASS / FAIL / UNVERIFIABLE per link, with the evidence backing each verdict. `--db` is mandatory (same refusal as `verify-corpus-accounting`); the db is opened READ-ONLY.

## Why + decision rationale

The two chains get shorthand-described as one "audit trail", which invites the conflation failure mode ("the audit chain proves the content was compiled correctly"). The doc names the boundary; the walker makes the honest composite claim mechanically checkable per memory. Chose a **three-state** verdict (PASS / FAIL / UNVERIFIABLE, exit 0 / 1 / 3) over binary pass-fail because an absent artifact — no brain dir on CI, an `mcp`-captured candidate that never had a spool file, rotated traces — is absence of evidence, not contradiction; reporting it as either PASS or FAIL would be dishonest in opposite directions.

## Layer(s) touched

`apps/curator` only: new `src/provenance/provenance-walk.ts` module, `cli.ts` subcommand wiring, new test file, plus the two docs files. No store/schema/policy-engine changes; no invariant changes. The walker uses raw read-only SELECTs and never mutates the db or the filesystem.

## How it works

memory_id → `curated_memories` row → `deriveMemoryId(candidate_id, content_hash)` recheck (plus content re-hash) → `'promoted'` receipt on `audit_events` → `candidates` row → `deriveCandidateId(workspaceId, relPath, sha256(content))` recheck (workspaceId = basename of the brain root, exactly as the ICO kernel derives it) → spool `*.manifest.json` scan for the candidate id, re-verifying the pinned `spoolFileSha256` when the file is still present → ICO trace-event scan for `payload.outputPath == relPath` under `<brain>/audit/traces/`.

## Verification & evidence

- Full suite green locally: **2192 tests / 182 files** (pnpm format + lint + typecheck + vitest), including 6 new tests: end-to-end PASS via the real `promote()` path with fabricated spool-manifest + brain-dir fixtures, broken-manifest-entry → `spool-manifest` FAIL exit 1, absent-brain → `compile-trace` UNVERIFIABLE exit 3 (distinct from FAIL), unknown-memory FAIL, and both usage-error refusals (exit 2).
- **Live run (read-only) against the real brain**, memory `66dfbae5-9f86-5c65-a47e-f720e2806c7b` (promoted 2026-07-16, spool-derived):

```
provenance walk: memory 66dfbae5-9f86-5c65-a47e-f720e2806c7b
brain root:  /home/jeremy/.teamkb/brain
spool dirs:  /home/jeremy/.teamkb/spool, /home/jeremy/.teamkb/brain/spool

  [PASS        ] memory-row
      curated_memories row found (tenant=intent-solutions, source=import, promoted_at=2026-07-16T23:10:59.537Z)
  [PASS        ] memory-id-derivation
      id == uuidv5("memory", candidate_id, content_hash) == 66dfbae5-9f86-5c65-a47e-f720e2806c7b; content re-hashes to content_hash
  [PASS        ] promotion-receipt
      'promoted' receipt 017f9bc5-7746-57f5-ab58-a539353c3059 at 2026-07-16T23:10:59.537Z on the audit_events hash chain (verify the whole chain with verify-audit-chain)
  [PASS        ] candidate-row
      candidates row found (id=4a35532d-0c17-5394-82ac-a799606a433a, source=import)
  [PASS        ] candidate-id-derivation
      candidate_id == uuidv5(workspaceId="brain", relPath="wiki/sources/x.md", sha256(content)) == 4a35532d-0c17-5394-82ac-a799606a433a
  [PASS        ] spool-manifest
      manifest /home/jeremy/.teamkb/spool/ingested/spool-2026-07-16T201548Z.jsonl.manifest.json lists candidate 4a35532d-0c17-5394-82ac-a799606a433a; spool file present and hashes to the pinned SHA-256 (f07a540da63a…)
  [PASS        ] compile-trace
      trace event 444ada78-c54c-4d7b-9d6f-9444ebbbb43a (provenance.record) at 2026-07-16T13:15:14.629Z in /home/jeremy/.teamkb/brain/audit/traces/2026-07-16.jsonl, hash-chained via prev_hash

Chain: 7 PASS / 0 FAIL / 0 UNVERIFIABLE
```

## Risk assessment

Low. Additive subcommand + docs; no existing code path altered beyond `cli.ts` dispatch/usage. Known heuristic limits, stated honestly in the evidence text: the trace scan matches `payload.outputPath` only; the workspaceId comes from the `--brain` basename (canonically `brain`), so a nonstandard brain-root name surfaces as a `candidate-id-derivation` FAIL rather than being silently accepted.

## Operational impact

None: no env vars, migrations, deps, secrets, or deploy-order changes. New CLI surface is documented in the curator USAGE text.

## Follow-up & deferred

- The companion umbrella PR extends `scripts/lint-forbidden-words.sh` with the chain-conflation check this doc defines (separate repo, same wave).
- 000-docs number 046 was the next free slot at branch time; parallel Wave-2 branches may collide on it — renumber on rebase if another 046 merges first.

## Governance links

Registrar 036-AT-THRT (spool boundary threat model) · 034-AT-NTRP (Compile, Then Govern) · umbrella 013-OD-STND (this PR's lane).

**Refs:** Wave-2 epic jeremylongshore/bobs-big-brain-registrar#287 (bead-5uq-F5/F6)
