### PR TITLE
feat(eval-surface): groundedness layer (C2), govern-decision dedup/contradiction/supersession classes (C3), grounding audit doc (C5)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,17 @@ jobs:
         # gap). Documented gaps are reported, not failed.
         run: pnpm --filter @qmd-team-intent-kb/eval-surface govern:ci
 
+      - name: Groundedness eval (deterministic scorer over the labeled fixture, fail-closed on regression)
+        # GSB Wave-2 C2: does an answer-like claim stay anchored to the memory
+        # it cites? Runs the DETERMINISTIC groundedness scorer (token/number/
+        # negation arithmetic — no LLM anywhere in this gate) over fixture v1
+        # (real promoted-memory excerpts + synthetic claims). Prints the
+        # segmented supported-precision / unsupported-catch-rate numbers and
+        # fails closed on any UNDOCUMENTED scorer error or a segment dropping
+        # below its measured-then-committed floor. Documented limitations
+        # (argument swaps, one distant negation) are reported, not failed.
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface groundedness:ci
+
       - name: Put workspace bins on PATH (qmd for the search-health canary)
         # qmd is a pinned root devDependency (@tobilu/qmd); the workspace bin
         # makes it discoverable so the reindex+canary CLI runs against a real

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -25,6 +25,7 @@
 
 - `005-TQ-TEST-testing-ci-strategy.md` — Testing philosophy, CI pipeline, quality gates
 - `006-TQ-SECU-security-governance.md` — Threat model and security controls
+- `046-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md` — Grounding audit: every improvement loop (retrieval ratchet, governed-brain anchor, provenance-integrity, govern-decision, groundedness, corpus accounting, staleness canary, mutation/coverage) with its anchor, its gate, and the DEFECT list for loops without one
 
 ### OD — Operations & Deployment
 
@@ -79,46 +80,47 @@
 
 ## Chronological Listing
 
-| #   | Code    | File                                | Description                      |
-| --- | ------- | ----------------------------------- | -------------------------------- |
-| 000 | PP-PLAN | mega-blueprint                      | Canonical project blueprint      |
-| 001 | AT-ARCH | repo-blueprint                      | Repository structure             |
-| 002 | AT-ARCH | architecture-overview               | System architecture              |
-| 003 | AT-DSGN | system-thesis                       | Design rationale                 |
-| 004 | PP-RMAP | phase-plan                          | Implementation roadmap           |
-| 005 | TQ-TEST | testing-ci-strategy                 | Testing and CI                   |
-| 006 | TQ-SECU | security-governance                 | Security and threats             |
-| 007 | AT-DSGN | data-model-draft                    | Domain model                     |
-| 008 | OD-RELS | release-versioning-policy           | Release policy                   |
-| 009 | DR-GUID | contribution-workflow               | Contributor guide                |
-| 010 | WA-WFLW | internal-claude-operations          | Claude workflows                 |
-| 011 | PM-RISK | risk-register                       | Risk tracking                    |
-| 012 | AA-AACR | initial-aar                         | Phase 0 AAR                      |
-| 013 | AA-AACR | phase1-schema                       | Phase 1 AAR                      |
-| 014 | AA-AACR | phase2-runtime                      | Phase 2 AAR                      |
-| 015 | AA-AACR | phase3-adapter                      | Phase 3 AAR                      |
-| 016 | OD-OPSM | branch-protection-checklist         | Branch protection setup          |
-| 017 | AA-AACR | phase4-api                          | Phase 4 AAR                      |
-| 018 | AA-AACR | phase5-curator                      | Phase 5 AAR                      |
-| 019 | AA-AACR | phase6-exporter                     | Phase 6 AAR                      |
-| 020 | OD-RELS | v1-release-checklist                | v1 release checklist             |
-| 021 | AA-AACR | phase7-reporting                    | Phase 7 AAR                      |
-| 022 | AA-AACR | phase8-security                     | Phase 8 AAR                      |
-| 023 | AA-AACR | phase9-release-readiness            | Phase 9 AAR                      |
-| 024 | PP-CLOS | v1-scope-closeout                   | v1 scope closeout                |
-| 025 | AA-AACR | v0.3.0-release-report               | v0.3.0 release report            |
-| 026 | AT-DSGN | repo-resolver-design                | repo-resolver package design     |
-| 027 | OD-OPSM | edge-daemon-runbook                 | edge-daemon operations runbook   |
-| 028 | OD-SECU | release-signing                     | Release supply-chain signing     |
-| 029 | OD-RELS | npm-publishing-strategy             | npm publishing strategy          |
-| 030 | DR-GUID | import-conversion-recipes           | Import from various sources      |
-| 031 | AA-AACR | v0.6.0-release-aar                  | v0.6.0 release report            |
-| 034 | AT-NTRP | ecosystem-thesis                    | Compile, Then Govern thesis      |
-| 035 | AT-DECR | post-thesis-build-direction         | Post-thesis council decision     |
-| 036 | AT-THRT | spool-boundary-threat-model         | Spool boundary threat model      |
-| 037 | AT-DSGN | qmd-adapter-source-index-separation | qmd-adapter source/index ADR     |
-| 038 | AT-DECR | retrieval-backend-decision          | Retrieval backend decision       |
-| 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0   | v0.7.0 release report            |
-| 040 | OD-OPSM | brain-api-tailnet-deploy            | Brain API tailnet deploy runbook |
+| #   | Code    | File                                                  | Description                      |
+| --- | ------- | ----------------------------------------------------- | -------------------------------- |
+| 000 | PP-PLAN | mega-blueprint                                        | Canonical project blueprint      |
+| 001 | AT-ARCH | repo-blueprint                                        | Repository structure             |
+| 002 | AT-ARCH | architecture-overview                                 | System architecture              |
+| 003 | AT-DSGN | system-thesis                                         | Design rationale                 |
+| 004 | PP-RMAP | phase-plan                                            | Implementation roadmap           |
+| 005 | TQ-TEST | testing-ci-strategy                                   | Testing and CI                   |
+| 006 | TQ-SECU | security-governance                                   | Security and threats             |
+| 007 | AT-DSGN | data-model-draft                                      | Domain model                     |
+| 008 | OD-RELS | release-versioning-policy                             | Release policy                   |
+| 009 | DR-GUID | contribution-workflow                                 | Contributor guide                |
+| 010 | WA-WFLW | internal-claude-operations                            | Claude workflows                 |
+| 011 | PM-RISK | risk-register                                         | Risk tracking                    |
+| 012 | AA-AACR | initial-aar                                           | Phase 0 AAR                      |
+| 013 | AA-AACR | phase1-schema                                         | Phase 1 AAR                      |
+| 014 | AA-AACR | phase2-runtime                                        | Phase 2 AAR                      |
+| 015 | AA-AACR | phase3-adapter                                        | Phase 3 AAR                      |
+| 016 | OD-OPSM | branch-protection-checklist                           | Branch protection setup          |
+| 017 | AA-AACR | phase4-api                                            | Phase 4 AAR                      |
+| 018 | AA-AACR | phase5-curator                                        | Phase 5 AAR                      |
+| 019 | AA-AACR | phase6-exporter                                       | Phase 6 AAR                      |
+| 020 | OD-RELS | v1-release-checklist                                  | v1 release checklist             |
+| 021 | AA-AACR | phase7-reporting                                      | Phase 7 AAR                      |
+| 022 | AA-AACR | phase8-security                                       | Phase 8 AAR                      |
+| 023 | AA-AACR | phase9-release-readiness                              | Phase 9 AAR                      |
+| 024 | PP-CLOS | v1-scope-closeout                                     | v1 scope closeout                |
+| 025 | AA-AACR | v0.3.0-release-report                                 | v0.3.0 release report            |
+| 026 | AT-DSGN | repo-resolver-design                                  | repo-resolver package design     |
+| 027 | OD-OPSM | edge-daemon-runbook                                   | edge-daemon operations runbook   |
+| 028 | OD-SECU | release-signing                                       | Release supply-chain signing     |
+| 029 | OD-RELS | npm-publishing-strategy                               | npm publishing strategy          |
+| 030 | DR-GUID | import-conversion-recipes                             | Import from various sources      |
+| 031 | AA-AACR | v0.6.0-release-aar                                    | v0.6.0 release report            |
+| 034 | AT-NTRP | ecosystem-thesis                                      | Compile, Then Govern thesis      |
+| 035 | AT-DECR | post-thesis-build-direction                           | Post-thesis council decision     |
+| 036 | AT-THRT | spool-boundary-threat-model                           | Spool boundary threat model      |
+| 037 | AT-DSGN | qmd-adapter-source-index-separation                   | qmd-adapter source/index ADR     |
+| 038 | AT-DECR | retrieval-backend-decision                            | Retrieval backend decision       |
+| 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0                     | v0.7.0 release report            |
+| 040 | OD-OPSM | brain-api-tailnet-deploy                              | Brain API tailnet deploy runbook |
+| 046 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
 
 ## Next Available Sequence: 048

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -25,7 +25,7 @@
 
 - `005-TQ-TEST-testing-ci-strategy.md` — Testing philosophy, CI pipeline, quality gates
 - `006-TQ-SECU-security-governance.md` — Threat model and security controls
-- `046-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md` — Grounding audit: every improvement loop (retrieval ratchet, governed-brain anchor, provenance-integrity, govern-decision, groundedness, corpus accounting, staleness canary, mutation/coverage) with its anchor, its gate, and the DEFECT list for loops without one
+- `047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md` — Grounding audit: every improvement loop (retrieval ratchet, governed-brain anchor, provenance-integrity, govern-decision, groundedness, corpus accounting, staleness canary, mutation/coverage) with its anchor, its gate, and the DEFECT list for loops without one
 
 ### OD — Operations & Deployment
 
@@ -121,6 +121,6 @@
 | 038 | AT-DECR | retrieval-backend-decision                            | Retrieval backend decision       |
 | 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0                     | v0.7.0 release report            |
 | 040 | OD-OPSM | brain-api-tailnet-deploy                              | Brain API tailnet deploy runbook |
-| 046 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
+| 047 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
 
 ## Next Available Sequence: 048

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -25,7 +25,7 @@
 
 - `005-TQ-TEST-testing-ci-strategy.md` — Testing philosophy, CI pipeline, quality gates
 - `006-TQ-SECU-security-governance.md` — Threat model and security controls
-- `047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md` — Grounding audit: every improvement loop (retrieval ratchet, governed-brain anchor, provenance-integrity, govern-decision, groundedness, corpus accounting, staleness canary, mutation/coverage) with its anchor, its gate, and the DEFECT list for loops without one
+- `048-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md` — Grounding audit: every improvement loop (retrieval ratchet, governed-brain anchor, provenance-integrity, govern-decision, groundedness, corpus accounting, staleness canary, mutation/coverage) with its anchor, its gate, and the DEFECT list for loops without one
 
 ### OD — Operations & Deployment
 
@@ -121,6 +121,6 @@
 | 038 | AT-DECR | retrieval-backend-decision                            | Retrieval backend decision       |
 | 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0                     | v0.7.0 release report            |
 | 040 | OD-OPSM | brain-api-tailnet-deploy                              | Brain API tailnet deploy runbook |
-| 047 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
+| 048 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
 
-## Next Available Sequence: 048
+## Next Available Sequence: 049

--- a/000-docs/046-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
+++ b/000-docs/046-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
@@ -1,0 +1,165 @@
+# Grounding audit: every improvement loop and its anchor
+
+**Doc:** 046-TQ-AUDT · **Date:** 2026-07-19 · **Scope:** qmd-team-intent-kb (the Bob's Big Brain Registrar)
+**Companion work:** Wave-2 C2 (groundedness eval) + C3 (govern-decision decision cases), shipped in the same PR as this doc.
+
+## Why this audit exists
+
+Every self-improvement loop in this repo claims to make something better: retrieval, governance,
+provenance, freshness, code quality. A loop is only trustworthy if it is **anchored** — pinned to a
+frozen dataset, a committed floor, or a labeled fixture that cannot drift with the thing being
+measured — and **gated** by a deterministic rule that fails closed. A loop without a real anchor is
+a vibe with a dashboard.
+
+This audit enumerates each loop and names, for every one: **what anchors it**, **what rule gates
+it**, and **where the anchor lives**. Loops that cannot name a real anchor are listed as DEFECTS at
+the end with a proposed bead title (beads not created here).
+
+Honesty note carried throughout: audit-chain claims in this repo are tamper-**evident** (with the
+external anchor cross-check), never tamper-proof; eval numbers are only as good as their fixtures,
+and every fixture's provenance and blind spots are stated where it is defined.
+
+## The loops
+
+### 1. Synthetic retrieval ratchet (PR-time)
+
+- **What it improves:** keyword/semantic/tokenization retrieval through the production
+  `adapter.query()` path.
+- **Anchor:** the committed synthetic corpus + query set
+  `packages/qmd-adapter/src/eval/datasets/synthetic-v1.ts`, with the measured, committed baseline
+  `SYNTHETIC_V1_BASELINE` (lexical Recall@10 = 1.0, semantic = 7/12, tokenization = 1.0 on the
+  fused path) and `RATCHET_EPSILON = 0.001`.
+- **Gate:** `ci-retrieval-ratchet.ts` exits non-zero if ANY stratum's Recall@10 drops below
+  `baseline − ε`; per-stratum, never a blended mean. It is a **regression ratchet**, deliberately
+  not an absolute-quality ship gate (the 0.85 sufficiency bar is a decision threshold, per
+  038-AT-DECR).
+- **Anchor lives:** in-repo (dataset + baseline are committed); run by the individually-named
+  `retrieval-eval` job in `.github/workflows/ci.yml`.
+
+### 2. Governed-brain-v1 anchor + floor (scheduled, real corpus)
+
+- **What it improves:** retrieval quality on the REAL brain, not a toy corpus.
+- **Anchor:** a FROZEN tar.zst snapshot of `~/.teamkb/kb-export`, pinned by SHA-256 in the
+  committed lock file `eval-results/governed-brain-v1-snapshot.lock.json`; hand-labeled queries
+  (`datasets/governed-brain-v1.ts`) whose gold ids are `qmd://` citations; the committed
+  per-stratum floor file `eval-results/governed-brain-v1-floor.json`.
+- **Gate:** `packages/qmd-adapter/src/eval/governed-eval-anchor.ts` — hash mismatch exits 2 (never
+  eval an unpinned corpus), stratum below floor exits 1, missing floor exits 3 with a proposed
+  floor (never an invented pass). Live-corpus runs are informational only, labeled unfrozen.
+- **Anchor lives:** hash + floor + queries in-repo; the snapshot tarball under
+  `~/.teamkb/eval-anchor/` on the brain host (private corpus never reaches a GitHub runner); runs
+  via the `bbb-eval-governed.timer` systemd user timer.
+
+### 3. Provenance-integrity eval (the receipts moat)
+
+- **What it improves:** per-memory content-hash consistency + audit-chain intactness + the
+  fork-classified external-anchor cross-check (Track F2).
+- **Anchor:** the eval builds a REAL on-disk brain fixture inside the run
+  (`packages/eval-surface/scripts/ci-provenance-integrity.ts`): a forked-but-untampered chain that
+  MUST pass with forks disclosed, and a genuinely tampered chain that MUST fail. The
+  anchored-truth reference is the hash-chain construction itself plus the external anchor log.
+- **Gate:** exit non-zero on genuine tampering passing or a clean/forked brain failing — both
+  directions asserted, so the metric can fail.
+- **Anchor lives:** in-repo (script + eval `packages/eval-surface/src/provenance-integrity.ts`);
+  required per-PR via the `moat-evals` job in `ci.yml`, re-run in `nightly.yml`. Divergence
+  recovery runbook: 045-OD-RNBK.
+
+### 4. Govern-decision eval (sensitive material + decision classes)
+
+- **What it improves:** the actual EFFICACY (not just determinism) of the govern decision.
+- **Anchor:** two versioned labeled sets, both in-repo and empirically labeled:
+  - `govern-decision/dataset/v1` (v1.2.0) — 33 adversarial secret/PII/path cases with
+    per-check `expectCaughtBy` / `knownFalseNegativeOf` ground truth;
+  - `govern-decision/decision-dataset/v1` (v1.0.0, new in Wave-2 C3) — 14 dedup /
+    contradiction / supersession / clean cases wired through the real store, the real
+    `PolicyPipeline` (`dedup_check` + `contradiction_check`), and the real
+    `detectSupersession`, reported per check AND per relationship class.
+- **Gate:** `ci-govern-decision.ts` fails closed on ANY undocumented false-negative in either
+  section. Documented gaps (split-key/boundary blind spots; re-cased dup, low-overlap and
+  cross-category contradictions, reworded-title supersession) are reported, never hidden.
+- **Anchor lives:** in-repo; required per-PR via `moat-evals` in `ci.yml`, re-run in `nightly.yml`.
+
+### 5. Groundedness eval (new — Wave-2 C2)
+
+- **What it improves:** whether an answer-like claim stays anchored to the memory it cites
+  (support-by-admitted-facts — explicitly NOT truth, NOT entailment).
+- **Anchor:** `groundedness/fixture/v1` — 60 labeled items (30 supported / 30 unsupported) built
+  from 30 real promoted-memory excerpts (kb-export UUIDs recorded per item) with synthetic
+  claims; semi-synthetic-from-real, stated in the fixture header. Committed floors measured on
+  the first real run (supported-precision 0.8824 → floor 0.88; unsupported-catch-rate 0.8667 →
+  floor 0.86); scorer blind spots (3 argument swaps, 1 distant negation) are fixture-documented.
+- **Gate:** `ci-groundedness.ts` fails closed on any undocumented scorer error or a segment
+  falling below its floor. The scorer is pure deterministic arithmetic — no LLM in the gate; the
+  env-gated MiniMax judge is an offline comparison arm only, off in CI by construction (tested).
+- **Anchor lives:** in-repo; run by the groundedness step in `nightly.yml`.
+- **Known caveat (also listed as DEFECT G2 below):** scorer thresholds were tuned on this same
+  fixture — the reported metrics are in-sample fit.
+
+### 6. Corpus accounting (substrate ↔ receipts agreement)
+
+- **What it improves:** the invariant that every `curated_memories` row carries its row-creating
+  `promoted` receipt written in the same transaction (no substrate bypass).
+- **Anchor:** the invariant itself is the anchor — `verify-corpus-accounting` re-derives it from
+  the store + audit log; the nightly job proves the MECHANISM on a synthetic store built by the
+  real curator CLI (≥1 accounted row required, so an empty store cannot pass trivially) and then
+  proves a planted raw-SQL bypass row is detected (non-zero exit).
+- **Gate:** the `Corpus-accounting guard` step in `nightly.yml` (jq assertion + bypass-detection
+  assertion, both fail-closed).
+- **Anchor lives:** verifier in `apps/curator` (`verify-corpus-accounting`); nightly step in-repo;
+  the run against the LIVE `~/.teamkb` store is an ops concern on the brain host (runbook
+  027-OD-OPSM).
+
+### 7. Staleness canary (search freshness)
+
+- **What it improves:** promoted memories becoming promptly searchable; a broken/misrouted index
+  failing loudly instead of returning silent empty results.
+- **Anchor:** known-positive control queries against a fixture brain built in the nightly run
+  (seeded from a committed markdown seed), plus `--max-staleness-seconds 86400` (D2) asserting no
+  promotion waits more than 24 h to become searchable.
+- **Gate:** the `Search-health canary` step in `nightly.yml` exits non-zero on 0 hits for any
+  known-positive control. On the ephemeral fixture the staleness leg reports "unmeasured" and
+  passes — the staleness assertion bites on the live-brain canary (runbook 027-OD-OPSM), the only
+  host with the real `~/.teamkb`.
+- **Anchor lives:** canary CLI in `packages/qmd-adapter` (in-repo); live-brain leg on the brain
+  host per the runbook.
+
+### 8. Mutation / coverage gates (test-suite quality)
+
+- **Coverage — anchored and gated:** Codecov required PR checks read `codecov.yml` — patch
+  coverage target 80% (threshold 0%), project target auto with 1% threshold. Anchor = the
+  committed `codecov.yml` targets; gate = the required Codecov checks in branch protection;
+  uploaded from the `validate` job in `ci.yml`.
+- **Mutation — configured but NOT anchored to any scheduled run:** `stryker.config.mjs` commits
+  real thresholds (`break: 70`) and `pnpm test:mutation` runs the suite locally, but **no CI or
+  nightly workflow executes Stryker** — the threshold is a rule with no loop attached. Listed as
+  DEFECT G1 below.
+
+## DEFECTS — loops that cannot name a real anchor
+
+Each defect gets a proposed bead title (plain-English imperative, per the bead naming convention).
+No beads are created by this doc.
+
+- **G1 — Mutation gate has a committed threshold but no scheduled run.** `stryker.config.mjs`
+  carries `break: 70`, yet no workflow (ci.yml, nightly.yml) runs Stryker, so mutation-score
+  regressions are invisible until someone runs it by hand. Proposed bead:
+  _"Run the Stryker mutation suite on a schedule and fail the run when the committed break
+  threshold is not met."_
+- **G2 — Groundedness metrics are in-sample.** Scorer v1's thresholds and window sizes were tuned
+  on the same fixture the floors were measured on; there is no independently authored held-out
+  set, so the reported precision/catch-rate overstate generalization by an unknown amount (the
+  fixture and module docs disclose this). Proposed bead:
+  _"Author a held-out groundedness validation set independently of scorer tuning and report both
+  in-sample and held-out numbers."_
+- **G3 — The live-host loops have no CI-visible dead-man's switch.** The governed-brain-v1 anchor
+  (timer), the live staleness canary, and the live corpus-accounting run all execute on the brain
+  host; if the host or a timer dies, CI stays green and nothing in THIS repo notices (the dev-box
+  liveness sweep is estate tooling outside this repo's audit surface). Proposed bead:
+  _"Publish a freshness heartbeat from the brain-host eval timers that a repo-side check can
+  verify and alert on."_
+
+## Reading rule for future loops
+
+A new improvement loop lands with: (1) a versioned, committed (or hash-pinned) anchor; (2) a
+deterministic fail-closed gate wired to a named CI job or timer; (3) an honest statement of what
+the metric cannot see. If any of the three is missing, it goes in this doc's DEFECT list before it
+ships, not after.

--- a/000-docs/047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
+++ b/000-docs/047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
@@ -1,6 +1,6 @@
 # Grounding audit: every improvement loop and its anchor
 
-**Doc:** 046-TQ-AUDT · **Date:** 2026-07-19 · **Scope:** qmd-team-intent-kb (the Bob's Big Brain Registrar)
+**Doc:** 047-TQ-AUDT · **Date:** 2026-07-19 · **Scope:** qmd-team-intent-kb (the Bob's Big Brain Registrar)
 **Companion work:** Wave-2 C2 (groundedness eval) + C3 (govern-decision decision cases), shipped in the same PR as this doc.
 
 ## Why this audit exists

--- a/000-docs/047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
+++ b/000-docs/047-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
@@ -70,13 +70,17 @@ and every fixture's provenance and blind spots are stated where it is defined.
 - **Anchor:** two versioned labeled sets, both in-repo and empirically labeled:
   - `govern-decision/dataset/v1` (v1.2.0) — 33 adversarial secret/PII/path cases with
     per-check `expectCaughtBy` / `knownFalseNegativeOf` ground truth;
-  - `govern-decision/decision-dataset/v1` (v1.0.0, new in Wave-2 C3) — 14 dedup /
+  - `govern-decision/decision-dataset/v1` (v1.1.0, new in Wave-2 C3) — 14 dedup /
     contradiction / supersession / clean cases wired through the real store, the real
     `PolicyPipeline` (`dedup_check` + `contradiction_check`), and the real
-    `detectSupersession`, reported per check AND per relationship class.
+    `detectSupersession` (at the single-sourced `DEFAULT_SUPERSESSION_THRESHOLD`),
+    reported per check AND per relationship class.
 - **Gate:** `ci-govern-decision.ts` fails closed on ANY undocumented false-negative in either
-  section. Documented gaps (split-key/boundary blind spots; re-cased dup, low-overlap and
-  cross-category contradictions, reworded-title supersession) are reported, never hidden.
+  section AND on any decision check dropping below its measured-then-committed precision
+  floor (`DECISION_PRECISION_FLOORS`). Documented gaps (split-key/boundary blind spots;
+  re-cased dup, low-overlap and cross-category contradictions, reworded-title supersession)
+  and the one KNOWN false positive (the contradiction heuristic firing on a compatible
+  restatement — a clean case, counted honestly against precision) are reported, never hidden.
 - **Anchor lives:** in-repo; required per-PR via `moat-evals` in `ci.yml`, re-run in `nightly.yml`.
 
 ### 5. Groundedness eval (new — Wave-2 C2)

--- a/000-docs/048-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
+++ b/000-docs/048-TQ-AUDT-grounding-audit-every-improvement-loop-and-its-anchor.md
@@ -1,6 +1,6 @@
 # Grounding audit: every improvement loop and its anchor
 
-**Doc:** 047-TQ-AUDT · **Date:** 2026-07-19 · **Scope:** qmd-team-intent-kb (the Bob's Big Brain Registrar)
+**Doc:** 048-TQ-AUDT · **Date:** 2026-07-19 · **Scope:** qmd-team-intent-kb (the Bob's Big Brain Registrar)
 **Companion work:** Wave-2 C2 (groundedness eval) + C3 (govern-decision decision cases), shipped in the same PR as this doc.
 
 ## Why this audit exists

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -5,7 +5,11 @@ import {
   DisclosureRejectedError,
 } from '@qmd-team-intent-kb/common';
 import { PolicyPipeline, type PipelineResult } from '@qmd-team-intent-kb/policy-engine';
-import { promote, detectSupersession } from '@qmd-team-intent-kb/curator';
+import {
+  promote,
+  detectSupersession,
+  DEFAULT_SUPERSESSION_THRESHOLD,
+} from '@qmd-team-intent-kb/curator';
 import { AuditEvent as AuditEventSchema } from '@qmd-team-intent-kb/schema';
 import type { CuratedMemory, Author } from '@qmd-team-intent-kb/schema';
 import type {
@@ -17,8 +21,12 @@ import type {
 } from '@qmd-team-intent-kb/store';
 import { badRequest, notFound, unprocessable } from '../errors.js';
 
-/** Title-similarity threshold for supersession, matching the curator default. */
-const SUPERSESSION_THRESHOLD = 0.6;
+/**
+ * Title-similarity threshold for supersession — the production default,
+ * consumed from the single source in policy-engine's supersession module (the
+ * same constant the curator and the govern-decision eval use).
+ */
+const SUPERSESSION_THRESHOLD = DEFAULT_SUPERSESSION_THRESHOLD;
 
 /**
  * Promotes an inbox candidate to a governed memory in one shot (bead `3iu.2`).

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -11,7 +11,10 @@ import type {
 } from '@qmd-team-intent-kb/store';
 import type { CuratorConfig, CurationResult, CurationBatchResult } from './types.js';
 import { checkDuplicate } from './dedup/dedup-checker.js';
-import { detectSupersession } from './supersession/supersession-detector.js';
+import {
+  detectSupersession,
+  DEFAULT_SUPERSESSION_THRESHOLD,
+} from './supersession/supersession-detector.js';
 import { promote } from './promotion/promoter.js';
 import { reject } from './rejection/rejector.js';
 
@@ -208,7 +211,7 @@ export class Curator {
     const supersession = detectSupersession(
       candidate,
       this.deps.memoryRepo,
-      this.config.supersessionThreshold ?? 0.6,
+      this.config.supersessionThreshold ?? DEFAULT_SUPERSESSION_THRESHOLD,
     );
 
     const memory = promote(

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -13,6 +13,7 @@ export type { DedupResult } from './dedup/dedup-checker.js';
 export {
   detectSupersession,
   computeTitleSimilarity,
+  DEFAULT_SUPERSESSION_THRESHOLD,
 } from './supersession/supersession-detector.js';
 export type { SupersessionMatch } from './supersession/supersession-detector.js';
 export { promote } from './promotion/promoter.js';

--- a/apps/curator/src/supersession/supersession-detector.ts
+++ b/apps/curator/src/supersession/supersession-detector.ts
@@ -7,7 +7,11 @@
  * implementation is byte-for-byte the same function, now owned by the govern
  * package layer.
  */
-export { detectSupersession, computeTitleSimilarity } from '@qmd-team-intent-kb/policy-engine';
+export {
+  detectSupersession,
+  computeTitleSimilarity,
+  DEFAULT_SUPERSESSION_THRESHOLD,
+} from '@qmd-team-intent-kb/policy-engine';
 export type {
   SupersessionMatch,
   SupersessionMemorySource,

--- a/apps/curator/src/supersession/supersession-detector.ts
+++ b/apps/curator/src/supersession/supersession-detector.ts
@@ -1,78 +1,14 @@
-import type { MemoryRepository } from '@qmd-team-intent-kb/store';
-import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
-
-/** A curated memory that may be superseded by the incoming candidate */
-export interface SupersessionMatch {
-  supersededMemoryId: string;
-  supersededTitle: string;
-  similarity: number;
-}
-
 /**
- * Detects whether an incoming candidate should supersede an existing active
- * curated memory, using Jaccard similarity on title word tokens within the
- * same category and tenant.
- *
- * Only active memories in the same category as the candidate are considered.
- * When multiple memories meet the threshold the one with the highest similarity
- * is returned; ties are broken by whichever was found first.
- *
- * @param threshold - Minimum Jaccard similarity (0.0–1.0) to consider a match.
- *                   Defaults to 0.6.
- * @returns The best-matching memory above the threshold, or null if none found.
+ * Re-export shim — the supersession detector moved to
+ * `@qmd-team-intent-kb/policy-engine` (Wave-2 C3) so the govern-decision eval
+ * (a package) can score the REAL detector without a package→app import
+ * (dependency-cruiser `no-package-depends-on-app`). Every curator call site and
+ * the public `@qmd-team-intent-kb/curator` surface keep working unchanged; the
+ * implementation is byte-for-byte the same function, now owned by the govern
+ * package layer.
  */
-export function detectSupersession(
-  candidate: MemoryCandidate,
-  memoryRepo: MemoryRepository,
-  threshold: number = 0.6,
-): SupersessionMatch | null {
-  const existingMemories = memoryRepo
-    .findByTenantAndLifecycle(candidate.tenantId, 'active')
-    .filter((m) => m.category === candidate.category);
-
-  let bestMatch: SupersessionMatch | null = null;
-
-  for (const memory of existingMemories) {
-    const similarity = computeTitleSimilarity(candidate.title, memory.title);
-    if (similarity >= threshold && (bestMatch === null || similarity > bestMatch.similarity)) {
-      bestMatch = {
-        supersededMemoryId: memory.id,
-        supersededTitle: memory.title,
-        similarity,
-      };
-    }
-  }
-
-  return bestMatch;
-}
-
-/**
- * Computes Jaccard similarity between two strings using word-level tokenization.
- *
- * Jaccard similarity = |intersection| / |union|
- *
- * Both strings are lower-cased and split on whitespace. Empty strings produce
- * 1.0 when both are empty (identical) and 0.0 when only one is empty.
- */
-export function computeTitleSimilarity(a: string, b: string): number {
-  const tokensA = new Set(tokenize(a));
-  const tokensB = new Set(tokenize(b));
-
-  if (tokensA.size === 0 && tokensB.size === 0) return 1.0;
-  if (tokensA.size === 0 || tokensB.size === 0) return 0.0;
-
-  let intersection = 0;
-  for (const token of tokensA) {
-    if (tokensB.has(token)) intersection++;
-  }
-
-  const union = tokensA.size + tokensB.size - intersection;
-  return union === 0 ? 0 : intersection / union;
-}
-
-function tokenize(text: string): string[] {
-  return text
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((t) => t.length > 0);
-}
+export { detectSupersession, computeTitleSimilarity } from '@qmd-team-intent-kb/policy-engine';
+export type {
+  SupersessionMatch,
+  SupersessionMemorySource,
+} from '@qmd-team-intent-kb/policy-engine';

--- a/packages/eval-surface/package.json
+++ b/packages/eval-surface/package.json
@@ -18,7 +18,9 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "provenance:ci": "tsx scripts/ci-provenance-integrity.ts",
-    "govern:ci": "tsx scripts/ci-govern-decision.ts"
+    "govern:ci": "tsx scripts/ci-govern-decision.ts",
+    "groundedness:ci": "tsx scripts/ci-groundedness.ts",
+    "groundedness:judge-compare": "tsx scripts/groundedness-judge-compare.ts"
   },
   "dependencies": {
     "@qmd-team-intent-kb/claude-runtime": "workspace:*",

--- a/packages/eval-surface/scripts/ci-govern-decision.ts
+++ b/packages/eval-surface/scripts/ci-govern-decision.ts
@@ -48,6 +48,38 @@ for (const m of report.perCheck) {
 }
 process.stdout.write(`\nmean F1 (reporting score): ${result.score}\n`);
 
+// Wave-2 C3: state-dependent decision section — dedup / contradiction /
+// supersession through the real store + pipeline + detector.
+const dec = report.decisionCases;
+process.stdout.write(
+  `\nDECISION cases — dataset v${dec.datasetVersion}: ` +
+    `${dec.totalCases} cases (${dec.positives} positive / ${dec.negatives} clean)\n`,
+);
+process.stdout.write('PER-CHECK precision / recall / F1:\n');
+for (const m of dec.perCheck) {
+  process.stdout.write(
+    `  ${m.check.padEnd(22)} P=${m.precision.toFixed(4)} R=${m.recall.toFixed(4)} ` +
+      `F1=${m.f1.toFixed(4)}  (TP=${m.truePositives} FP=${m.falsePositives} ` +
+      `FN=${m.falseNegatives} TN=${m.trueNegatives})\n`,
+  );
+}
+process.stdout.write('PER-CLASS catch-rate (the required class breakout):\n');
+for (const c of dec.perClass) {
+  process.stdout.write(
+    `  ${c.decisionClass.padEnd(14)} catch=${c.catchRate.toFixed(4)} ` +
+      `(${c.caught}/${c.scoredPairs} scored pairs, ${c.documentedMisses} documented miss(es))\n`,
+  );
+}
+if (dec.falseNegatives.length > 0) {
+  process.stdout.write('Decision false-negatives (documented = a known, tracked gap):\n');
+  for (const f of dec.falseNegatives) {
+    process.stdout.write(
+      `  ${f.caseId.padEnd(28)} ${f.check.padEnd(22)} ` +
+        `class=${f.decisionClass} documented=${f.documented}\n`,
+    );
+  }
+}
+
 if (report.falseNegatives.length > 0) {
   process.stdout.write('\nFalse-negatives (documented = a known, tracked gap):\n');
   for (const f of report.falseNegatives) {
@@ -58,20 +90,25 @@ if (report.falseNegatives.length > 0) {
   }
 }
 
-if (report.undocumentedFalseNegatives.length > 0) {
+const decisionSurprises = dec.undocumentedFalseNegatives;
+if (report.undocumentedFalseNegatives.length > 0 || decisionSurprises.length > 0) {
   process.stderr.write(
-    `\nci-govern-decision FAILED: ${report.undocumentedFalseNegatives.length} ` +
-      `UNDOCUMENTED false-negative(s) — a missed secret/PII the dataset did not ` +
-      `already flag as a known gap. Either the govern decision regressed, or a ` +
-      `new evasion needs a fix (not a relabel). Cases:\n`,
+    `\nci-govern-decision FAILED: ` +
+      `${report.undocumentedFalseNegatives.length + decisionSurprises.length} ` +
+      `UNDOCUMENTED false-negative(s) — a missed secret/PII/duplicate/contradiction/` +
+      `supersession the dataset did not already flag as a known gap. Either the ` +
+      `govern decision regressed, or a new evasion needs a fix (not a relabel). Cases:\n`,
   );
   for (const f of report.undocumentedFalseNegatives) {
     process.stderr.write(`  - ${f.caseId} (${f.check}, ${f.sensitiveClass}/${f.surface})\n`);
   }
+  for (const f of decisionSurprises) {
+    process.stderr.write(`  - ${f.caseId} (${f.check}, class=${f.decisionClass})\n`);
+  }
   process.exitCode = 1;
 } else {
   process.stdout.write(
-    '\nci-govern-decision OK — zero undocumented false-negatives ' +
-      '(all misses are documented, tracked gaps).\n',
+    '\nci-govern-decision OK — zero undocumented false-negatives across both ' +
+      'sections (all misses are documented, tracked gaps).\n',
   );
 }

--- a/packages/eval-surface/scripts/ci-govern-decision.ts
+++ b/packages/eval-surface/scripts/ci-govern-decision.ts
@@ -27,7 +27,7 @@
  * diagnostic) otherwise.
  */
 
-import { evaluateGovernDecision } from '../src/index.js';
+import { DECISION_PRECISION_FLOORS, evaluateGovernDecision } from '../src/index.js';
 import type { GovernDecisionReport } from '../src/index.js';
 
 const result = evaluateGovernDecision();
@@ -55,13 +55,25 @@ process.stdout.write(
   `\nDECISION cases — dataset v${dec.datasetVersion}: ` +
     `${dec.totalCases} cases (${dec.positives} positive / ${dec.negatives} clean)\n`,
 );
-process.stdout.write('PER-CHECK precision / recall / F1:\n');
+process.stdout.write('PER-CHECK precision / recall / F1 (precision floors in parentheses):\n');
 for (const m of dec.perCheck) {
   process.stdout.write(
-    `  ${m.check.padEnd(22)} P=${m.precision.toFixed(4)} R=${m.recall.toFixed(4)} ` +
-      `F1=${m.f1.toFixed(4)}  (TP=${m.truePositives} FP=${m.falsePositives} ` +
+    `  ${m.check.padEnd(22)} P=${m.precision.toFixed(4)} ` +
+      `(floor ${DECISION_PRECISION_FLOORS[m.check].toFixed(4)}) ` +
+      `R=${m.recall.toFixed(4)} F1=${m.f1.toFixed(4)}  ` +
+      `(TP=${m.truePositives} FP=${m.falsePositives} ` +
       `FN=${m.falseNegatives} TN=${m.trueNegatives})\n`,
   );
+}
+if (dec.falsePositives.length > 0) {
+  process.stdout.write(
+    'Decision false-positives (documented = a KNOWN FP, priced into the floor):\n',
+  );
+  for (const f of dec.falsePositives) {
+    process.stdout.write(
+      `  ${f.caseId.padEnd(28)} ${f.check.padEnd(22)} documented=${f.documented}\n`,
+    );
+  }
 }
 process.stdout.write('PER-CLASS catch-rate (the required class breakout):\n');
 for (const c of dec.perClass) {
@@ -91,24 +103,41 @@ if (report.falseNegatives.length > 0) {
 }
 
 const decisionSurprises = dec.undocumentedFalseNegatives;
-if (report.undocumentedFalseNegatives.length > 0 || decisionSurprises.length > 0) {
-  process.stderr.write(
-    `\nci-govern-decision FAILED: ` +
-      `${report.undocumentedFalseNegatives.length + decisionSurprises.length} ` +
-      `UNDOCUMENTED false-negative(s) — a missed secret/PII/duplicate/contradiction/` +
-      `supersession the dataset did not already flag as a known gap. Either the ` +
-      `govern decision regressed, or a new evasion needs a fix (not a relabel). Cases:\n`,
-  );
-  for (const f of report.undocumentedFalseNegatives) {
-    process.stderr.write(`  - ${f.caseId} (${f.check}, ${f.sensitiveClass}/${f.surface})\n`);
+const floorBreaches = dec.perCheck.filter((m) => m.precision < DECISION_PRECISION_FLOORS[m.check]);
+if (
+  report.undocumentedFalseNegatives.length > 0 ||
+  decisionSurprises.length > 0 ||
+  floorBreaches.length > 0
+) {
+  if (report.undocumentedFalseNegatives.length > 0 || decisionSurprises.length > 0) {
+    process.stderr.write(
+      `\nci-govern-decision FAILED: ` +
+        `${report.undocumentedFalseNegatives.length + decisionSurprises.length} ` +
+        `UNDOCUMENTED false-negative(s) — a missed secret/PII/duplicate/contradiction/` +
+        `supersession the dataset did not already flag as a known gap. Either the ` +
+        `govern decision regressed, or a new evasion needs a fix (not a relabel). Cases:\n`,
+    );
+    for (const f of report.undocumentedFalseNegatives) {
+      process.stderr.write(`  - ${f.caseId} (${f.check}, ${f.sensitiveClass}/${f.surface})\n`);
+    }
+    for (const f of decisionSurprises) {
+      process.stderr.write(`  - ${f.caseId} (${f.check}, class=${f.decisionClass})\n`);
+    }
   }
-  for (const f of decisionSurprises) {
-    process.stderr.write(`  - ${f.caseId} (${f.check}, class=${f.decisionClass})\n`);
+  for (const m of floorBreaches) {
+    process.stderr.write(
+      `\nci-govern-decision FAILED: ${m.check} precision ${m.precision.toFixed(4)} ` +
+        `is below its measured-then-committed floor ` +
+        `${DECISION_PRECISION_FLOORS[m.check].toFixed(4)} — a NEW firing on a clean ` +
+        `case. Fix the rule or document the FP in the dataset (with a version bump ` +
+        `and a re-measured floor), never by relabeling a clean case positive.\n`,
+    );
   }
   process.exitCode = 1;
 } else {
   process.stdout.write(
     '\nci-govern-decision OK — zero undocumented false-negatives across both ' +
-      'sections (all misses are documented, tracked gaps).\n',
+      'sections and every decision precision floor held (documented misses and ' +
+      'known FPs reported above, tracked, not hidden).\n',
   );
 }

--- a/packages/eval-surface/scripts/ci-groundedness.ts
+++ b/packages/eval-surface/scripts/ci-groundedness.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+/**
+ * CI groundedness gate (Wave-2 C2) — runs the DETERMINISTIC groundedness
+ * scorer (scorer v1) over the labeled fixture (fixture/v1: real promoted-memory
+ * excerpts + synthetic claims) and FAILS CLOSED when:
+ *
+ *   - any scorer error is UNDOCUMENTED (a wrong prediction the fixture does
+ *     not already carry as a known limitation), or
+ *   - a segmented metric falls below its committed floor
+ *     (supported-precision / unsupported-catch-rate — floors were MEASURED on
+ *     the first real run, then committed; see GROUNDEDNESS_FLOORS).
+ *
+ * No LLM runs here or anywhere in CI: scorer v1 is pure token/number/negation
+ * arithmetic. The optional MiniMax judge is an offline comparison arm only
+ * (scripts/groundedness-judge-compare.ts, run by hand with explicit env).
+ *
+ * Mirrors ci-govern-decision.ts (the moat-eval gate pattern): prints the
+ * segmented numbers so CI logs carry real measurements, exits non-zero on a
+ * genuine regression, and treats documented limitations as reported data.
+ */
+
+import { evaluateGroundedness, GROUNDEDNESS_FLOORS } from '../src/index.js';
+import type { GroundednessReport } from '../src/index.js';
+
+const result = evaluateGroundedness();
+const report = JSON.parse(String(result.details.report_json)) as GroundednessReport;
+
+process.stdout.write(
+  `groundedness eval — fixture v${report.fixtureVersion}: ${report.totalItems} items ` +
+    `(${report.supportedItems} supported / ${report.unsupportedItems} unsupported)\n\n`,
+);
+process.stdout.write('SEGMENTED metrics (floors in parentheses):\n');
+process.stdout.write(
+  `  supported-precision    ${report.supportedPrecision.toFixed(4)} ` +
+    `(floor ${GROUNDEDNESS_FLOORS.supportedPrecision.toFixed(4)})\n`,
+);
+process.stdout.write(`  supported-recall       ${report.supportedRecall.toFixed(4)}\n`);
+process.stdout.write(
+  `  unsupported-catch-rate ${report.unsupportedCatchRate.toFixed(4)} ` +
+    `(floor ${GROUNDEDNESS_FLOORS.unsupportedCatchRate.toFixed(4)})\n`,
+);
+process.stdout.write(`  balanced accuracy      ${report.balancedAccuracy.toFixed(4)}\n`);
+
+process.stdout.write('\nUnsupported catch by perturbation:\n');
+for (const p of report.perPerturbation) {
+  if (p.items === 0) continue;
+  process.stdout.write(`  ${p.perturbation.padEnd(18)} ${p.caught}/${p.items}\n`);
+}
+
+if (report.errors.length > 0) {
+  process.stdout.write('\nScorer errors (documented = a known v1 limitation):\n');
+  for (const e of report.errors) {
+    process.stdout.write(
+      `  ${e.itemId.padEnd(32)} label=${e.label} predicted=${e.predicted} ` +
+        `${e.perturbation !== undefined ? `perturbation=${e.perturbation} ` : ''}` +
+        `documented=${e.documented}\n`,
+    );
+  }
+}
+
+if (!result.passed) {
+  process.stderr.write(
+    `\nci-groundedness FAILED: ` +
+      `${report.undocumentedErrors.length} undocumented scorer error(s), ` +
+      `supported-precision=${report.supportedPrecision} ` +
+      `(floor ${GROUNDEDNESS_FLOORS.supportedPrecision}), ` +
+      `unsupported-catch-rate=${report.unsupportedCatchRate} ` +
+      `(floor ${GROUNDEDNESS_FLOORS.unsupportedCatchRate}). ` +
+      `Fix the scorer or the fixture — never relabel to hide a regression.\n`,
+  );
+  process.exitCode = 1;
+} else {
+  process.stdout.write(
+    '\nci-groundedness OK — zero undocumented scorer errors and both segment ' +
+      'floors held (documented limitations reported above, tracked, not hidden).\n',
+  );
+}

--- a/packages/eval-surface/scripts/groundedness-judge-compare.ts
+++ b/packages/eval-surface/scripts/groundedness-judge-compare.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+/**
+ * OFFLINE groundedness judge comparison — run BY HAND, never in CI, never a
+ * gate (Wave-2 C2 comparison arm).
+ *
+ *   GROUNDEDNESS_LLM_JUDGE=minimax MINIMAX_API_KEY=… \
+ *     pnpm --filter @qmd-team-intent-kb/eval-surface groundedness:judge-compare
+ *
+ * Prints scorer v1's deterministic verdict next to the LLM judge's for every
+ * fixture item plus an agreement summary. Disagreement is INFORMATION about
+ * the deterministic scorer's blind spots (e.g. argument swaps) — it changes
+ * nothing automatically; a human decides whether a scorer-v2 heuristic or a
+ * fixture annotation is warranted. Exits 0 unless the judge is unconfigured
+ * or errors (so a broken comparison is loud, per "a metric that cannot fail
+ * is worthless").
+ */
+
+import { GROUNDEDNESS_ITEMS, judgeFromEnv, scoreGroundedness } from '../src/index.js';
+
+const judge = judgeFromEnv();
+if (judge === null) {
+  process.stderr.write(
+    'groundedness-judge-compare: not configured. Set GROUNDEDNESS_LLM_JUDGE=minimax ' +
+      'and MINIMAX_API_KEY to run the offline comparison arm. (CI never sets these.)\n',
+  );
+  process.exit(1);
+}
+
+let agree = 0;
+let disagree = 0;
+for (const item of GROUNDEDNESS_ITEMS) {
+  const deterministic = scoreGroundedness(item.claim, item.memoryExcerpt).predicted;
+  const llm = await judge.judge(item);
+  const match = deterministic === llm ? 'agree   ' : 'DISAGREE';
+  if (deterministic === llm) agree++;
+  else disagree++;
+  process.stdout.write(
+    `${match} ${item.id.padEnd(32)} label=${item.label.padEnd(11)} ` +
+      `scorer=${deterministic.padEnd(11)} ${judge.name}=${llm}\n`,
+  );
+}
+process.stdout.write(
+  `\nAgreement: ${agree}/${agree + disagree} ` +
+    `(comparison only — the deterministic scorer remains the sole CI arbiter)\n`,
+);

--- a/packages/eval-surface/src/__tests__/decision-eval.test.ts
+++ b/packages/eval-surface/src/__tests__/decision-eval.test.ts
@@ -9,7 +9,9 @@
  *  - The shipped set has ZERO undocumented false-negatives (CI gate green)
  *    while the documented gaps (re-cased dup, low-overlap + cross-category
  *    contradiction, reworded-title supersession) ARE reported.
- *  - Precision is 1.0 on every decision check (no firings on clean cases).
+ *  - Every check holds its measured-then-committed precision floor; the
+ *    compatible-restatement firing is a KNOWN false positive (documented,
+ *    counted against precision, never a TP).
  *  - The report breaks out the duplicate / contradiction / supersession
  *    classes separately (the C3 requirement).
  *  - Fed a synthetic regression (an expected catch that cannot fire) the eval
@@ -22,6 +24,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DECISION_CASES,
   DECISION_DATASET_VERSION,
+  DECISION_PRECISION_FLOORS,
   evaluateDecisionCases,
   evaluateGovernDecision,
 } from '../index.js';
@@ -53,8 +56,29 @@ describe('evaluateDecisionCases — shipped decision set', () => {
     expect(byId.has('sup-reworded-title-01:supersession-detector')).toBe(true);
   });
 
-  it('has precision 1.0 on every decision check (clean cases never fire)', () => {
+  it('holds every measured-then-committed precision floor', () => {
     for (const m of report.perCheck) {
+      expect(m.precision).toBeGreaterThanOrEqual(DECISION_PRECISION_FLOORS[m.check]);
+    }
+  });
+
+  it('reports the compatible restatement as a KNOWN false positive — not a TP, not a surprise', () => {
+    // contra-restated-01 is ground-truth NON-contradiction (dataset v1.1.0):
+    // the token heuristic's firing counts against precision as a DOCUMENTED FP.
+    expect(report.knownFalsePositives).toEqual([
+      { caseId: 'contra-restated-01', check: 'contradiction-rule', documented: true },
+    ]);
+    // No undocumented firing on any clean case.
+    expect(report.falsePositives.filter((f) => !f.documented)).toHaveLength(0);
+    // The FP is priced into the matrix: contradiction precision is honestly <1.
+    const contradiction = report.perCheck.find((m) => m.check === 'contradiction-rule')!;
+    expect(contradiction.falsePositives).toBe(1);
+    expect(contradiction.precision).toBeLessThan(1);
+    // ...and it no longer inflates recall: only genuine contradictions count.
+    expect(contradiction.truePositives).toBe(3);
+    // The other checks stay FP-free.
+    for (const check of ['dedup-rule', 'supersession-detector'] as const) {
+      const m = report.perCheck.find((x) => x.check === check)!;
       expect(m.falsePositives).toBe(0);
       expect(m.precision).toBe(1);
     }
@@ -144,6 +168,14 @@ describe('evaluateDecisionCases — synthetic regressions', () => {
     const dedup = rep.perCheck.find((m) => m.check === 'dedup-rule');
     expect(dedup!.falsePositives).toBe(1);
     expect(dedup!.precision).toBeLessThan(1);
+    // An UNDOCUMENTED firing on a clean case is a surprise, not a known FP...
+    expect(rep.falsePositives).toEqual([
+      { caseId: 'syn-clean-fires-01', check: 'dedup-rule', documented: false },
+    ]);
+    expect(rep.knownFalsePositives).toHaveLength(0);
+    // ...and it breaches the dedup precision floor, flipping the whole eval red.
+    const result = evaluateGovernDecision({ decisionCases: [firingClean] });
+    expect(result.passed).toBe(false);
   });
 });
 
@@ -153,6 +185,9 @@ describe('evaluateGovernDecision — integrated decision section', () => {
     expect(r.details.decision_dataset_version).toBe(DECISION_DATASET_VERSION);
     expect(Number(r.details.decision_total_cases)).toBe(DECISION_CASES.length);
     expect(r.details.decision_undocumented_false_negatives).toBe(0);
+    expect(r.details.decision_known_false_positives).toBe(1);
+    expect(r.details.decision_undocumented_false_positives).toBe(0);
+    expect(r.details.decision_precision_floors_held).toBe(true);
     expect(r.details['decision.catchrate.duplicate']).toBeGreaterThan(0);
     expect(r.details['decision.catchrate.contradiction']).toBeGreaterThan(0);
     expect(r.details['decision.catchrate.supersession']).toBeGreaterThan(0);

--- a/packages/eval-surface/src/__tests__/decision-eval.test.ts
+++ b/packages/eval-surface/src/__tests__/decision-eval.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Decision-case eval unit tests (Wave-2 C3).
+ *
+ * Asserts the structural guarantees of the state-dependent govern-decision
+ * section on the shipped decision set:
+ *  - Real-machinery wiring: catches ride the production dedup_check /
+ *    contradiction_check rules and the real detectSupersession, over a real
+ *    in-memory store.
+ *  - The shipped set has ZERO undocumented false-negatives (CI gate green)
+ *    while the documented gaps (re-cased dup, low-overlap + cross-category
+ *    contradiction, reworded-title supersession) ARE reported.
+ *  - Precision is 1.0 on every decision check (no firings on clean cases).
+ *  - The report breaks out the duplicate / contradiction / supersession
+ *    classes separately (the C3 requirement).
+ *  - Fed a synthetic regression (an expected catch that cannot fire) the eval
+ *    reports an UNDOCUMENTED false-negative and evaluateGovernDecision flips
+ *    passed:false; fed a firing clean case it counts a false positive.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DECISION_CASES,
+  DECISION_DATASET_VERSION,
+  evaluateDecisionCases,
+  evaluateGovernDecision,
+} from '../index.js';
+import type { DecisionCase } from '../index.js';
+
+describe('evaluateDecisionCases — shipped decision set', () => {
+  const report = evaluateDecisionCases();
+
+  it('scores the shipped set with a version stamp and all three classes', () => {
+    expect(report.datasetVersion).toBe(DECISION_DATASET_VERSION);
+    expect(report.totalCases).toBe(DECISION_CASES.length);
+    expect(report.totalCases).toBeGreaterThanOrEqual(14);
+    const classes = report.perClass.map((c) => c.decisionClass);
+    expect(classes).toEqual(['duplicate', 'contradiction', 'supersession']);
+  });
+
+  it('has ZERO undocumented false-negatives (the CI gate is green)', () => {
+    expect(report.undocumentedFalseNegatives).toHaveLength(0);
+  });
+
+  it('reports the documented gaps instead of hiding them', () => {
+    const documented = report.falseNegatives.filter((f) => f.documented);
+    expect(documented.length).toBeGreaterThanOrEqual(4);
+    const byId = new Set(documented.map((f) => `${f.caseId}:${f.check}`));
+    // The four gaps this set proves out — each a real, tracked blind spot.
+    expect(byId.has('dup-recased-01:dedup-rule')).toBe(true);
+    expect(byId.has('contra-low-overlap-01:contradiction-rule')).toBe(true);
+    expect(byId.has('contra-cross-category-01:contradiction-rule')).toBe(true);
+    expect(byId.has('sup-reworded-title-01:supersession-detector')).toBe(true);
+  });
+
+  it('has precision 1.0 on every decision check (clean cases never fire)', () => {
+    for (const m of report.perCheck) {
+      expect(m.falsePositives).toBe(0);
+      expect(m.precision).toBe(1);
+    }
+  });
+
+  it('catches the exact duplicate through the real dedup rule', () => {
+    const dupMisses = report.falseNegatives.filter(
+      (f) => f.caseId === 'dup-exact-01' || f.caseId === 'dup-exact-02',
+    );
+    expect(dupMisses).toHaveLength(0);
+  });
+
+  it('per-class breakout carries scored pairs and a catch rate in [0,1]', () => {
+    for (const c of report.perClass) {
+      expect(c.scoredPairs).toBeGreaterThan(0);
+      expect(c.catchRate).toBeGreaterThanOrEqual(0);
+      expect(c.catchRate).toBeLessThanOrEqual(1);
+      expect(c.caught + c.documentedMisses).toBeLessThanOrEqual(c.scoredPairs);
+    }
+  });
+});
+
+describe('evaluateDecisionCases — synthetic regressions', () => {
+  const cleanBase: DecisionCase = {
+    id: 'syn-clean-01',
+    description: 'synthetic clean case',
+    decisionClass: 'clean',
+    candidate: {
+      title: 'Totally unrelated topic',
+      content: 'The build cache is keyed on the lockfile hash.',
+      category: 'reference',
+    },
+    existingActives: [
+      {
+        title: 'Another topic entirely',
+        content: 'Weekly reports render as static HTML from the reporting app.',
+        category: 'reference',
+      },
+    ],
+    expectFiredBy: [],
+  };
+
+  it('flags an UNDOCUMENTED false-negative when an expected catch cannot fire', () => {
+    const regression: DecisionCase = {
+      id: 'syn-regression-01',
+      description: 'expects dedup to fire on non-duplicate content (cannot happen)',
+      decisionClass: 'duplicate',
+      candidate: {
+        title: 'Not a duplicate',
+        content: 'This content shares nothing with the existing memory.',
+        category: 'reference',
+      },
+      existingActives: [
+        {
+          title: 'Existing memory',
+          content: 'A completely different sentence about the audit log.',
+          category: 'reference',
+        },
+      ],
+      expectFiredBy: ['dedup-rule'],
+    };
+    const rep = evaluateDecisionCases([regression, cleanBase]);
+    expect(rep.undocumentedFalseNegatives).toHaveLength(1);
+    expect(rep.undocumentedFalseNegatives[0]).toMatchObject({
+      caseId: 'syn-regression-01',
+      check: 'dedup-rule',
+      documented: false,
+    });
+
+    // ...and the surprise flips the WHOLE govern-decision eval red.
+    const result = evaluateGovernDecision({ decisionCases: [regression, cleanBase] });
+    expect(result.passed).toBe(false);
+  });
+
+  it('counts a false positive when a clean case fires a check', () => {
+    const firingClean: DecisionCase = {
+      ...cleanBase,
+      id: 'syn-clean-fires-01',
+      description: 'labeled clean but content duplicates the existing active',
+      candidate: {
+        title: 'Same content as existing',
+        content: 'Weekly reports render as static HTML from the reporting app.',
+        category: 'reference',
+      },
+    };
+    const rep = evaluateDecisionCases([firingClean]);
+    const dedup = rep.perCheck.find((m) => m.check === 'dedup-rule');
+    expect(dedup!.falsePositives).toBe(1);
+    expect(dedup!.precision).toBeLessThan(1);
+  });
+});
+
+describe('evaluateGovernDecision — integrated decision section', () => {
+  it('exposes the decision breakout in details and report_json', () => {
+    const r = evaluateGovernDecision();
+    expect(r.details.decision_dataset_version).toBe(DECISION_DATASET_VERSION);
+    expect(Number(r.details.decision_total_cases)).toBe(DECISION_CASES.length);
+    expect(r.details.decision_undocumented_false_negatives).toBe(0);
+    expect(r.details['decision.catchrate.duplicate']).toBeGreaterThan(0);
+    expect(r.details['decision.catchrate.contradiction']).toBeGreaterThan(0);
+    expect(r.details['decision.catchrate.supersession']).toBeGreaterThan(0);
+    const report = JSON.parse(String(r.details.report_json)) as {
+      decisionCases: { perClass: unknown[] };
+    };
+    expect(report.decisionCases.perClass).toHaveLength(3);
+  });
+});

--- a/packages/eval-surface/src/__tests__/groundedness.test.ts
+++ b/packages/eval-surface/src/__tests__/groundedness.test.ts
@@ -1,0 +1,185 @@
+/**
+ * groundedness eval unit tests (Wave-2 C2).
+ *
+ * Asserts the structural guarantees of the groundedness layer:
+ *  - fixture v1 shape: ≥50 items, unique ids, both labels, real-export UUIDs;
+ *  - the shipped set PASSES: zero undocumented scorer errors, both committed
+ *    floors held, supported recall intact;
+ *  - the documented limitations (argument swaps, one distant negation) are
+ *    REPORTED, not hidden — and the test pins them so a silent scorer change
+ *    that "fixes" or worsens them is visible;
+ *  - scorer v1 behavior: number inversion / negation flip / wrong component
+ *    each flip the verdict; a paraphrase with admitted vocabulary passes;
+ *  - a synthetic regression (undocumented wrong prediction) flips passed:false;
+ *  - the LLM judge is OFF by default (null without explicit env opt-in) — the
+ *    no-LLM-in-CI property as a test.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateGroundedness,
+  GROUNDEDNESS_FIXTURE_VERSION,
+  GROUNDEDNESS_FLOORS,
+  GROUNDEDNESS_ITEMS,
+  judgeFromEnv,
+  scoreGroundedness,
+} from '../index.js';
+import type { GroundednessItem, GroundednessReport } from '../index.js';
+
+function report(result: ReturnType<typeof evaluateGroundedness>): GroundednessReport {
+  return JSON.parse(String(result.details.report_json)) as GroundednessReport;
+}
+
+describe('groundedness fixture v1 — shape', () => {
+  it('has ≥50 items with unique ids and both labels represented', () => {
+    expect(GROUNDEDNESS_ITEMS.length).toBeGreaterThanOrEqual(50);
+    const ids = new Set(GROUNDEDNESS_ITEMS.map((i) => i.id));
+    expect(ids.size).toBe(GROUNDEDNESS_ITEMS.length);
+    expect(GROUNDEDNESS_ITEMS.some((i) => i.label === 'supported')).toBe(true);
+    expect(GROUNDEDNESS_ITEMS.some((i) => i.label === 'unsupported')).toBe(true);
+  });
+
+  it('every item carries a kb-export UUID and a non-empty excerpt + claim', () => {
+    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    for (const item of GROUNDEDNESS_ITEMS) {
+      expect(item.sourceMemoryId).toMatch(uuid);
+      expect(item.memoryExcerpt.length).toBeGreaterThan(40);
+      expect(item.claim.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('every unsupported item names its perturbation', () => {
+    for (const item of GROUNDEDNESS_ITEMS.filter((i) => i.label === 'unsupported')) {
+      expect(item.perturbation).toBeDefined();
+    }
+  });
+});
+
+describe('evaluateGroundedness — shipped fixture', () => {
+  const result = evaluateGroundedness();
+  const rep = report(result);
+
+  it('PASSES: zero undocumented errors and both committed floors held', () => {
+    expect(result.name).toBe('groundedness');
+    expect(rep.fixtureVersion).toBe(GROUNDEDNESS_FIXTURE_VERSION);
+    expect(rep.undocumentedErrors).toHaveLength(0);
+    expect(rep.supportedPrecision).toBeGreaterThanOrEqual(GROUNDEDNESS_FLOORS.supportedPrecision);
+    expect(rep.unsupportedCatchRate).toBeGreaterThanOrEqual(
+      GROUNDEDNESS_FLOORS.unsupportedCatchRate,
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it('holds full supported recall (no supported paraphrase falsely flagged)', () => {
+    expect(rep.supportedRecall).toBe(1);
+  });
+
+  it('reports the documented limitations rather than hiding them', () => {
+    const documented = rep.errors.filter((e) => e.documented);
+    expect(documented.length).toBeGreaterThanOrEqual(4);
+    // Pin the known blind spots: 3 argument swaps + 1 distant negation. A
+    // scorer change that silently alters this set must surface here.
+    const swapMisses = documented.filter((e) => e.perturbation === 'argument-swap');
+    expect(swapMisses.length).toBe(3);
+  });
+
+  it('catches every inverted-number and wrong-component perturbation', () => {
+    const byPerturbation = new Map(rep.perPerturbation.map((p) => [p.perturbation, p]));
+    expect(byPerturbation.get('inverted-number')!.caught).toBe(
+      byPerturbation.get('inverted-number')!.items,
+    );
+    expect(byPerturbation.get('wrong-component')!.caught).toBe(
+      byPerturbation.get('wrong-component')!.items,
+    );
+  });
+});
+
+describe('scoreGroundedness — scorer v1 behavior', () => {
+  const memory =
+    'The pipeline runs 8 deterministic rules and short-circuits on first failure. Manifest data is never passed to policy evaluation.';
+
+  it('accepts a paraphrase whose vocabulary the memory admits', () => {
+    const p = scoreGroundedness(
+      'The pipeline runs 8 deterministic rules and short-circuits on the first failure.',
+      memory,
+    );
+    expect(p.predicted).toBe('supported');
+  });
+
+  it('flags an inverted number', () => {
+    const p = scoreGroundedness('The pipeline runs 12 deterministic rules.', memory);
+    expect(p.predicted).toBe('unsupported');
+    expect(p.numberMismatches).toContain('12');
+  });
+
+  it('flags a negation flip (claim asserts what the memory negates)', () => {
+    const p = scoreGroundedness(
+      'Manifest data is passed to policy evaluation by the pipeline rules.',
+      memory,
+    );
+    expect(p.predicted).toBe('unsupported');
+    expect(p.negationMismatches.length).toBeGreaterThan(0);
+  });
+
+  it('flags a wrong-component claim via the token-support floor', () => {
+    const p = scoreGroundedness(
+      'The pipeline delegates verdicts to a gradient-boosted classifier ensemble.',
+      memory,
+    );
+    expect(p.predicted).toBe('unsupported');
+    expect(p.tokenSupport).toBeLessThan(0.7);
+  });
+
+  it('flags an affix antonym (sufficient vs insufficient)', () => {
+    const p = scoreGroundedness(
+      'A direct bump alone is sufficient to clear the finding.',
+      'A direct bump alone is insufficient to clear the finding.',
+    );
+    expect(p.predicted).toBe('unsupported');
+    expect(p.negationMismatches).toContain('sufficient');
+  });
+
+  it('CANNOT see an argument swap — the documented v1 limitation, pinned', () => {
+    const p = scoreGroundedness(
+      'Local servers use confidential clients and remote servers use public clients.',
+      'Local servers use public clients and remote servers use confidential clients.',
+    );
+    // If a future scorer version learns to catch swaps, this test flips and
+    // the fixture's knownScorerMiss annotations must be re-measured.
+    expect(p.predicted).toBe('supported');
+  });
+});
+
+describe('evaluateGroundedness — synthetic regression', () => {
+  it('flips passed:false on an undocumented wrong prediction', () => {
+    const regression: GroundednessItem = {
+      id: 'syn-supported-but-ungrounded-01',
+      sourceMemoryId: '00000000-0000-4000-8000-000000000001',
+      memoryExcerpt: 'The deploy pipeline restarts the service after the health check passes.',
+      claim: 'Quarterly revenue grew 40 percent across seventeen regional markets.',
+      label: 'supported', // mislabeled on purpose: the scorer will say unsupported
+    };
+    const result = evaluateGroundedness({ items: [regression] });
+    const rep = report(result);
+    expect(rep.undocumentedErrors).toHaveLength(1);
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('LLM judge — OFF in CI by construction', () => {
+  it('returns null without the explicit double env opt-in', () => {
+    expect(judgeFromEnv({})).toBeNull();
+    expect(judgeFromEnv({ GROUNDEDNESS_LLM_JUDGE: 'minimax' })).toBeNull();
+    expect(judgeFromEnv({ MINIMAX_API_KEY: 'x' })).toBeNull();
+  });
+
+  it('builds a named judge only when fully opted in (no network touched)', () => {
+    const judge = judgeFromEnv({
+      GROUNDEDNESS_LLM_JUDGE: 'minimax',
+      MINIMAX_API_KEY: 'test-key-not-real',
+    });
+    expect(judge).not.toBeNull();
+    expect(judge!.name).toContain('minimax');
+  });
+});

--- a/packages/eval-surface/src/govern-decision.ts
+++ b/packages/eval-surface/src/govern-decision.ts
@@ -49,7 +49,10 @@ import type {
   GovernDecisionReport,
 } from './govern-decision/types.js';
 import type { DecisionCase } from './govern-decision/decision-types.js';
-import { evaluateDecisionCases } from './govern-decision/decision-eval.js';
+import {
+  DECISION_PRECISION_FLOORS,
+  evaluateDecisionCases,
+} from './govern-decision/decision-eval.js';
 import { DATASET_VERSION } from './govern-decision/dataset/v1/index.js';
 import { loadDataset, type LoadedCase } from './govern-decision/dataset/v1/load.js';
 
@@ -260,11 +263,17 @@ export function evaluateGovernDecision(options: GovernDecisionOptions = {}): Eva
   const meanF1 =
     perCheck.length === 0 ? 1 : perCheck.reduce((s, m) => s + m.f1, 0) / perCheck.length;
 
-  // GATING property: zero undocumented (surprise / regression) false-negatives —
-  // across BOTH sections (sensitive-material checks AND the C3 decision checks).
+  // GATING properties: zero undocumented (surprise / regression) false-
+  // negatives across BOTH sections, AND every decision check holding its
+  // measured-then-committed precision floor (known FPs are documented and
+  // priced into the floors; a NEW firing on a clean case breaches them).
+  const decisionPrecisionFloorsHeld = decisionCases.perCheck.every(
+    (m) => m.precision >= DECISION_PRECISION_FLOORS[m.check],
+  );
   const passed =
     undocumentedFalseNegatives.length === 0 &&
-    decisionCases.undocumentedFalseNegatives.length === 0;
+    decisionCases.undocumentedFalseNegatives.length === 0 &&
+    decisionPrecisionFloorsHeld;
   const threshold = options.threshold ?? 0;
 
   return {
@@ -286,6 +295,10 @@ export function evaluateGovernDecision(options: GovernDecisionOptions = {}): Eva
       decision_undocumented_false_negatives: decisionCases.undocumentedFalseNegatives.length,
       decision_documented_false_negatives:
         decisionCases.falseNegatives.length - decisionCases.undocumentedFalseNegatives.length,
+      decision_known_false_positives: decisionCases.knownFalsePositives.length,
+      decision_undocumented_false_positives:
+        decisionCases.falsePositives.length - decisionCases.knownFalsePositives.length,
+      decision_precision_floors_held: decisionPrecisionFloorsHeld,
       ...Object.fromEntries(
         decisionCases.perCheck.flatMap((m) => [
           [`decision.precision.${m.check}`, m.precision],

--- a/packages/eval-surface/src/govern-decision.ts
+++ b/packages/eval-surface/src/govern-decision.ts
@@ -48,6 +48,8 @@ import type {
   GovernCheck,
   GovernDecisionReport,
 } from './govern-decision/types.js';
+import type { DecisionCase } from './govern-decision/decision-types.js';
+import { evaluateDecisionCases } from './govern-decision/decision-eval.js';
 import { DATASET_VERSION } from './govern-decision/dataset/v1/index.js';
 import { loadDataset, type LoadedCase } from './govern-decision/dataset/v1/load.js';
 
@@ -158,6 +160,8 @@ function isDocumentedMiss(def: GovernCase, check: GovernCheck): boolean {
 export interface GovernDecisionOptions {
   /** Override the labeled set (defaults to dataset/v1). Used by tests. */
   readonly cases?: readonly GovernCase[];
+  /** Override the decision-case set (defaults to decision-dataset/v1). Used by tests. */
+  readonly decisionCases?: readonly DecisionCase[];
   /**
    * Pass threshold for the aggregate score. The GATING property, however, is
    * not the score — it is "zero UNDOCUMENTED false-negatives" (see below).
@@ -239,6 +243,10 @@ export function evaluateGovernDecision(options: GovernDecisionOptions = {}): Eva
 
   const undocumentedFalseNegatives = falseNegatives.filter((f) => !f.documented);
 
+  // Wave-2 C3: the state-dependent decision section (dedup / contradiction /
+  // supersession over real store + real pipeline + real detector).
+  const decisionCases = evaluateDecisionCases(options.decisionCases);
+
   const report: GovernDecisionReport = {
     totalCases: loaded.length,
     positives: positives.length,
@@ -246,13 +254,17 @@ export function evaluateGovernDecision(options: GovernDecisionOptions = {}): Eva
     perCheck,
     falseNegatives,
     undocumentedFalseNegatives,
+    decisionCases,
   };
 
   const meanF1 =
     perCheck.length === 0 ? 1 : perCheck.reduce((s, m) => s + m.f1, 0) / perCheck.length;
 
-  // GATING property: zero undocumented (surprise / regression) false-negatives.
-  const passed = undocumentedFalseNegatives.length === 0;
+  // GATING property: zero undocumented (surprise / regression) false-negatives —
+  // across BOTH sections (sensitive-material checks AND the C3 decision checks).
+  const passed =
+    undocumentedFalseNegatives.length === 0 &&
+    decisionCases.undocumentedFalseNegatives.length === 0;
   const threshold = options.threshold ?? 0;
 
   return {
@@ -268,6 +280,21 @@ export function evaluateGovernDecision(options: GovernDecisionOptions = {}): Eva
       undocumented_false_negatives: undocumentedFalseNegatives.length,
       documented_false_negatives: falseNegatives.length - undocumentedFalseNegatives.length,
       mean_f1: Number(meanF1.toFixed(4)),
+      // C3 decision section — flat summary fields (full breakout in report_json).
+      decision_dataset_version: decisionCases.datasetVersion,
+      decision_total_cases: decisionCases.totalCases,
+      decision_undocumented_false_negatives: decisionCases.undocumentedFalseNegatives.length,
+      decision_documented_false_negatives:
+        decisionCases.falseNegatives.length - decisionCases.undocumentedFalseNegatives.length,
+      ...Object.fromEntries(
+        decisionCases.perCheck.flatMap((m) => [
+          [`decision.precision.${m.check}`, m.precision],
+          [`decision.recall.${m.check}`, m.recall],
+        ]),
+      ),
+      ...Object.fromEntries(
+        decisionCases.perClass.map((c) => [`decision.catchrate.${c.decisionClass}`, c.catchRate]),
+      ),
       // Per-check precision/recall as flat, JSON-serialisable fields (the
       // EvaluatorResult.details value type is number|string|boolean).
       ...flattenPerCheck(perCheck),

--- a/packages/eval-surface/src/govern-decision/decision-dataset/v1/index.ts
+++ b/packages/eval-surface/src/govern-decision/decision-dataset/v1/index.ts
@@ -1,0 +1,317 @@
+/**
+ * govern-decision DECISION-CASE labeled dataset — v1 (Wave-2 C3).
+ *
+ * Labeled cases for the three STATE-DEPENDENT govern decisions: does the
+ * pipeline catch a candidate that duplicates, contradicts, or supersedes an
+ * existing ACTIVE memory? Each case seeds real active memories into a real
+ * in-memory store and runs the real `PolicyPipeline` (`dedup_check` +
+ * `contradiction_check`) and the real `detectSupersession` — no mocks of the
+ * decision under test (see ../decision-eval.ts).
+ *
+ * ## Provenance of the labels
+ *
+ * Every `expectFiredBy` / `knownFalseNegativeOf` label was set from an
+ * EMPIRICAL run of the real detectors on this exact material. The eval
+ * re-derives the outcomes and fails closed on any UNDOCUMENTED false-negative,
+ * so labels and code cannot silently disagree (same contract as dataset/v1).
+ *
+ * The documented gaps this set proves out — honest output, not hidden:
+ *   - exact-hash dedup misses trivially-reworded/re-cased duplicates
+ *     (`dup-recased-01`) — caught instead by the contradiction flag;
+ *   - the token-overlap contradiction heuristic misses a genuine semantic
+ *     contradiction phrased with different vocabulary (`contra-low-overlap-01`)
+ *     and is blind across categories (`contra-cross-category-01`);
+ *   - title-Jaccard supersession misses a fully reworded title
+ *     (`sup-reworded-title-01`).
+ *
+ * DECISION_DATASET_VERSION is bumped on any case add/remove/relabel.
+ */
+
+import type { DecisionCase } from '../../decision-types.js';
+
+/** Semantic version of THIS decision-case set. Bump on any change. */
+export const DECISION_DATASET_VERSION = '1.0.0';
+
+/** Tenant every decision case runs under (the store is per-case and ephemeral). */
+export const DECISION_TENANT = 'govern-eval-tenant';
+
+export const DECISION_CASES: readonly DecisionCase[] = [
+  /* ------------------------------ DUPLICATES ------------------------------ */
+  {
+    id: 'dup-exact-01',
+    description: 'Byte-identical content under a different title — exact-hash dedup must catch',
+    decisionClass: 'duplicate',
+    candidate: {
+      title: 'Input validation rule (restated)',
+      content: 'All API endpoints must validate input with Zod schemas before any handler runs.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'API input validation convention',
+        content: 'All API endpoints must validate input with Zod schemas before any handler runs.',
+        category: 'convention',
+      },
+    ],
+    // contradiction_check deliberately SKIPS byte-identical content (dedup's
+    // job) and the titles share too little for supersession — both out of scope.
+    expectFiredBy: ['dedup-rule'],
+  },
+  {
+    id: 'dup-exact-02',
+    description: 'Identical content AND identical title — dedup and supersession both catch',
+    decisionClass: 'duplicate',
+    candidate: {
+      title: 'Retry budget convention',
+      content: 'Every outbound HTTP call gets at most two retries with exponential backoff.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'Retry budget convention',
+        content: 'Every outbound HTTP call gets at most two retries with exponential backoff.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: ['dedup-rule', 'supersession-detector'],
+  },
+  {
+    id: 'dup-recased-01',
+    description:
+      'Re-cased duplicate (same words, different casing) — exact-hash dedup MISSES; the contradiction flag is the safety net',
+    decisionClass: 'duplicate',
+    candidate: {
+      title: 'Result types note',
+      content: 'use result types for all fallible operations in the parser core.',
+      category: 'pattern',
+    },
+    existingActives: [
+      {
+        title: 'Fallible-operation convention',
+        content: 'Use Result types for all fallible operations in the parser core.',
+        category: 'pattern',
+      },
+    ],
+    // SHA-256 over exact bytes: one changed letter defeats it — the documented
+    // dedup blind spot. The token-overlap contradiction rule (case-insensitive)
+    // sees an identical token set and flags it for review instead.
+    expectFiredBy: ['contradiction-rule'],
+    knownFalseNegativeOf: ['dedup-rule'],
+  },
+
+  /* ----------------------------- CONTRADICTIONS --------------------------- */
+  {
+    id: 'contra-inverted-policy-01',
+    description: 'Direct negation of an existing convention (allowed → never allowed)',
+    decisionClass: 'contradiction',
+    candidate: {
+      title: 'Deploy window update',
+      content:
+        'Production deploys are never allowed on Tuesdays and Thursdays even after the smoke suite passes.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'Production deploy window',
+        content:
+          'Production deploys are allowed only on Tuesdays and Thursdays after the smoke suite passes.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: ['contradiction-rule'],
+  },
+  {
+    id: 'contra-number-flip-01',
+    description: 'Same sentence with the two retention numbers swapped (token set identical)',
+    decisionClass: 'contradiction',
+    candidate: {
+      title: 'Backup retention note',
+      content:
+        'The backup retention window is 7 days for the audit log and 30 days for derived indexes.',
+      category: 'reference',
+    },
+    existingActives: [
+      {
+        title: 'Retention windows',
+        content:
+          'The backup retention window is 30 days for the audit log and 7 days for derived indexes.',
+        category: 'reference',
+      },
+    ],
+    expectFiredBy: ['contradiction-rule'],
+  },
+  {
+    id: 'contra-restated-01',
+    description:
+      'Compatible restatement of the same convention — the v1 token heuristic fires (same-topic surface, not semantic contradiction; the flag routes it to review, honestly documented in the rule)',
+    decisionClass: 'contradiction',
+    candidate: {
+      title: 'Commit message rule restated',
+      content:
+        'Commit messages must explain what changed and why the change was needed in every commit.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'Commit message convention',
+        content: 'Every commit message must explain what changed and why the change was needed.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: ['contradiction-rule'],
+  },
+  {
+    id: 'contra-low-overlap-01',
+    description:
+      'Genuine semantic contradiction phrased with different vocabulary — the token-overlap heuristic MISSES (documented v1 gap; semantic detection is deferred by design)',
+    decisionClass: 'contradiction',
+    candidate: {
+      title: 'Where credentials belong',
+      content: 'Credentials belong in the platform vault service and never inside a repository.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'Secrets storage convention',
+        content: 'Secrets are stored in SOPS-encrypted files committed to git.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: [],
+    knownFalseNegativeOf: ['contradiction-rule'],
+  },
+  {
+    id: 'contra-cross-category-01',
+    description:
+      'Contradicting text filed under a DIFFERENT category — the category-scoped lookup never sees it (documented blind spot)',
+    decisionClass: 'contradiction',
+    candidate: {
+      title: 'Deploy window pattern',
+      content:
+        'Production deploys are never allowed on Tuesdays and Thursdays even after the smoke suite passes.',
+      category: 'pattern',
+    },
+    existingActives: [
+      {
+        title: 'Production deploy window',
+        content:
+          'Production deploys are allowed only on Tuesdays and Thursdays after the smoke suite passes.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: [],
+    knownFalseNegativeOf: ['contradiction-rule'],
+  },
+
+  /* ------------------------------ SUPERSESSIONS --------------------------- */
+  {
+    id: 'sup-title-refresh-01',
+    description: 'Revision of an existing memory keeping the title stem (title Jaccard 0.78)',
+    decisionClass: 'supersession',
+    candidate: {
+      title: 'Error handling convention for the API layer 2026 revision',
+      content:
+        'API-layer errors are wrapped in a typed envelope with a machine-readable code and retry hint.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'Error handling convention for the API layer',
+        content: 'API-layer errors bubble up as plain thrown exceptions logged at the boundary.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: ['supersession-detector'],
+  },
+  {
+    id: 'sup-close-title-01',
+    description: 'Near-identical title with one extra word (title Jaccard 0.83)',
+    decisionClass: 'supersession',
+    candidate: {
+      title: 'Deploy runbook for the VPS host',
+      content: 'Deploys go through the Actions workflow with an OIDC-authenticated forced command.',
+      category: 'reference',
+    },
+    existingActives: [
+      {
+        title: 'Deploy runbook for the VPS',
+        content: 'Deploys are performed by hand over SSH from the operator laptop.',
+        category: 'reference',
+      },
+    ],
+    expectFiredBy: ['supersession-detector'],
+  },
+  {
+    id: 'sup-reworded-title-01',
+    description:
+      'Same subject with a fully reworded title — title-Jaccard supersession MISSES (documented v1 gap)',
+    decisionClass: 'supersession',
+    candidate: {
+      title: 'Rollback procedure for failed deploys',
+      content:
+        'When a deploy fails its smoke check the previous release is restored automatically.',
+      category: 'reference',
+    },
+    existingActives: [
+      {
+        title: 'How we roll back a bad deploy',
+        content: 'A failed deploy is rolled back by re-running the workflow against the prior tag.',
+        category: 'reference',
+      },
+    ],
+    expectFiredBy: [],
+    knownFalseNegativeOf: ['supersession-detector'],
+  },
+
+  /* -------------------------------- CLEAN --------------------------------- */
+  {
+    id: 'clean-same-category-01',
+    description: 'Unrelated memory in the same category — nothing may fire',
+    decisionClass: 'clean',
+    candidate: {
+      title: 'Timezone handling convention',
+      content: 'Store timestamps as UTC ISO-8601 strings and convert at the presentation edge.',
+      category: 'convention',
+    },
+    existingActives: [
+      {
+        title: 'API input validation convention',
+        content: 'All API endpoints must validate input with Zod schemas before any handler runs.',
+        category: 'convention',
+      },
+    ],
+    expectFiredBy: [],
+  },
+  {
+    id: 'clean-shared-vocab-01',
+    description:
+      'Same domain vocabulary (deploy/CI words) but a genuinely different topic — precision probe, nothing may fire',
+    decisionClass: 'clean',
+    candidate: {
+      title: 'Grafana dashboard generation',
+      content:
+        'Grafana dashboards for the deploy fleet are generated from a shared metrics package.',
+      category: 'reference',
+    },
+    existingActives: [
+      {
+        title: 'CI gate ordering',
+        content: 'The CI pipeline must run the full unit suite before any deploy job starts.',
+        category: 'reference',
+      },
+    ],
+    expectFiredBy: [],
+  },
+  {
+    id: 'clean-empty-store-01',
+    description: 'No existing actives at all — every state-dependent check must stay silent',
+    decisionClass: 'clean',
+    candidate: {
+      title: 'First memory of a fresh tenant',
+      content: 'The governed brain of a brand-new tenant starts with an empty curated set.',
+      category: 'reference',
+    },
+    existingActives: [],
+    expectFiredBy: [],
+  },
+];

--- a/packages/eval-surface/src/govern-decision/decision-dataset/v1/index.ts
+++ b/packages/eval-surface/src/govern-decision/decision-dataset/v1/index.ts
@@ -22,15 +22,28 @@
  *     contradiction phrased with different vocabulary (`contra-low-overlap-01`)
  *     and is blind across categories (`contra-cross-category-01`);
  *   - title-Jaccard supersession misses a fully reworded title
- *     (`sup-reworded-title-01`).
+ *     (`sup-reworded-title-01`);
+ *   - the token-overlap contradiction heuristic FIRES on a compatible
+ *     restatement (`contra-restated-01`) — a KNOWN false positive on a clean
+ *     case, counted against precision and held by the committed floors.
  *
  * DECISION_DATASET_VERSION is bumped on any case add/remove/relabel.
  */
 
 import type { DecisionCase } from '../../decision-types.js';
 
-/** Semantic version of THIS decision-case set. Bump on any change. */
-export const DECISION_DATASET_VERSION = '1.0.0';
+/**
+ * Semantic version of THIS decision-case set. Bump on any change.
+ *
+ * 1.1.0 (PR #301 review, finding 1) — `contra-restated-01` relabeled
+ * contradiction→clean with `knownFalsePositiveOf: ['contradiction-rule']`:
+ * a compatible restatement is ground-truth NON-contradiction, so the rule's
+ * firing is a documented false positive (counted against precision, gated by
+ * the measured precision floors), not a true positive inflating the
+ * contradiction catch-rate.
+ * 1.0.0 — initial decision set.
+ */
+export const DECISION_DATASET_VERSION = '1.1.0';
 
 /** Tenant every decision case runs under (the store is per-case and ephemeral). */
 export const DECISION_TENANT = 'govern-eval-tenant';
@@ -143,8 +156,15 @@ export const DECISION_CASES: readonly DecisionCase[] = [
   {
     id: 'contra-restated-01',
     description:
-      'Compatible restatement of the same convention — the v1 token heuristic fires (same-topic surface, not semantic contradiction; the flag routes it to review, honestly documented in the rule)',
-    decisionClass: 'contradiction',
+      'Compatible restatement of the same convention — NOT a contradiction. The v1 token heuristic still fires on it (same-topic surface, not semantics): a KNOWN false positive, kept as a clean case so the firing counts against precision instead of inflating contradiction recall',
+    // Relabeled contradiction→clean under DECISION_DATASET_VERSION 1.1.0
+    // (PR #301 review, finding 1): a restatement is ground-truth NON-
+    // contradiction, so treating the rule's firing as a TP both inflated the
+    // contradiction-class catch-rate and set a trap where FIXING the heuristic
+    // would look like a regression. The firing is now a documented false
+    // positive; the review-routing value of the flag is unchanged in
+    // production, but the eval scores it honestly.
+    decisionClass: 'clean',
     candidate: {
       title: 'Commit message rule restated',
       content:
@@ -158,7 +178,8 @@ export const DECISION_CASES: readonly DecisionCase[] = [
         category: 'convention',
       },
     ],
-    expectFiredBy: ['contradiction-rule'],
+    expectFiredBy: [],
+    knownFalsePositiveOf: ['contradiction-rule'],
   },
   {
     id: 'contra-low-overlap-01',

--- a/packages/eval-surface/src/govern-decision/decision-eval.ts
+++ b/packages/eval-surface/src/govern-decision/decision-eval.ts
@@ -20,8 +20,11 @@
  * Scoring semantics mirror the main govern-decision eval: a positive case is
  * in scope for a check only when it names it in `expectFiredBy` or
  * `knownFalseNegativeOf`; every `clean` case is in scope for every check
- * (a firing check there is a false positive). The gating property is ZERO
- * UNDOCUMENTED false-negatives; documented gaps are reported, never hidden.
+ * (a firing check there is a false positive — counted against precision even
+ * when `knownFalsePositiveOf` documents it, so the numbers stay honest).
+ * The gating properties are ZERO UNDOCUMENTED false-negatives AND the
+ * per-check precision floors ({@link DECISION_PRECISION_FLOORS}, measured
+ * then committed); documented gaps and known FPs are reported, never hidden.
  */
 
 import { computeContentHash } from '@qmd-team-intent-kb/common';
@@ -47,6 +50,7 @@ import type {
   DecisionClass,
   DecisionClassMetrics,
   DecisionFalseNegative,
+  DecisionFalsePositive,
 } from './decision-types.js';
 import {
   DECISION_CASES,
@@ -69,6 +73,21 @@ const POSITIVE_CLASSES: ReadonlyArray<Exclude<DecisionClass, 'clean'>> = [
 // Supersession threshold: consumed from the policy-engine single source
 // (DEFAULT_SUPERSESSION_THRESHOLD) — the exact constant curator + api use, so
 // the eval can never measure a different threshold than production runs.
+
+/**
+ * Measured-then-committed per-check PRECISION floors (PR #301 review,
+ * finding 1). Known false positives (a clean case a check is documented to
+ * fire on, e.g. the contradiction heuristic on a compatible restatement)
+ * count honestly against precision; these floors — taken from the real run
+ * over decision-dataset v1.1.0, never invented — are what the gate holds.
+ * A NEW (undocumented) firing on a clean case drops the check below its
+ * floor and fails the eval closed.
+ */
+export const DECISION_PRECISION_FLOORS: Record<DecisionCheck, number> = {
+  'dedup-rule': 1.0,
+  'contradiction-rule': 0.75,
+  'supersession-detector': 1.0,
+};
 
 /**
  * The policy the decision cases run under: the two state-dependent rules with
@@ -233,6 +252,7 @@ export function evaluateDecisionCases(
 
   const perCheck: DecisionCheckMetrics[] = [];
   const falseNegatives: DecisionFalseNegative[] = [];
+  const falsePositives: DecisionFalsePositive[] = [];
 
   for (const check of ALL_DECISION_CHECKS) {
     let tp = 0;
@@ -259,8 +279,20 @@ export function evaluateDecisionCases(
     }
 
     for (const def of negatives) {
-      if (fired.get(def.id)!.has(check)) fp += 1;
-      else tn += 1;
+      if (fired.get(def.id)!.has(check)) {
+        // Every firing on a clean case is a FALSE POSITIVE and counts against
+        // precision — including KNOWN FPs (documented via knownFalsePositiveOf).
+        // "Known" only means it is reported as documented rather than as a
+        // surprise; the committed precision floors are what hold the line.
+        fp += 1;
+        falsePositives.push({
+          caseId: def.id,
+          check,
+          documented: (def.knownFalsePositiveOf ?? []).includes(check),
+        });
+      } else {
+        tn += 1;
+      }
     }
 
     perCheck.push(metricsFor(check, tp, fp, fn, tn));
@@ -305,5 +337,7 @@ export function evaluateDecisionCases(
     perClass,
     falseNegatives,
     undocumentedFalseNegatives: falseNegatives.filter((f) => !f.documented),
+    falsePositives,
+    knownFalsePositives: falsePositives.filter((f) => f.documented),
   };
 }

--- a/packages/eval-surface/src/govern-decision/decision-eval.ts
+++ b/packages/eval-surface/src/govern-decision/decision-eval.ts
@@ -1,0 +1,304 @@
+/**
+ * govern-decision DECISION-CASE runner (Wave-2 C3) — scores the three
+ * STATE-DEPENDENT govern decisions over the labeled decision set:
+ *
+ *   - `dedup-rule`             — the production `dedup_check` rule inside the
+ *                                real `PolicyPipeline` (exact SHA-256 hash)
+ *   - `contradiction-rule`     — the production Phase-1 `contradiction_check`
+ *                                rule inside the same pipeline (token overlap)
+ *   - `supersession-detector`  — the real `detectSupersession` (policy-engine)
+ *
+ * Wired through the REAL machinery end to end: each case seeds its existing
+ * actives into a real in-memory store (`createTestDatabase` +
+ * `MemoryRepository.insert`, so the write-side enum guards run too), builds
+ * the pipeline context EXACTLY the way the curator does (`existingHashes`
+ * from content hashes, `getActiveMemoriesInCategory` from a live repository
+ * query), and evaluates the candidate through `PolicyPipeline.evaluate`. A
+ * false-negative measured here is therefore a real production miss, not a
+ * harness artifact. The store is ephemeral (`:memory:`) — no durable state.
+ *
+ * Scoring semantics mirror the main govern-decision eval: a positive case is
+ * in scope for a check only when it names it in `expectFiredBy` or
+ * `knownFalseNegativeOf`; every `clean` case is in scope for every check
+ * (a firing check there is a false positive). The gating property is ZERO
+ * UNDOCUMENTED false-negatives; documented gaps are reported, never hidden.
+ */
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { detectSupersession, PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import {
+  CuratedMemory,
+  GovernancePolicy,
+  MemoryCandidate,
+  type MemoryCategory,
+} from '@qmd-team-intent-kb/schema';
+import { createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import { randomUUID } from 'node:crypto';
+
+import type {
+  DecisionCase,
+  DecisionCasesReport,
+  DecisionCheck,
+  DecisionCheckMetrics,
+  DecisionClass,
+  DecisionClassMetrics,
+  DecisionFalseNegative,
+} from './decision-types.js';
+import {
+  DECISION_CASES,
+  DECISION_DATASET_VERSION,
+  DECISION_TENANT,
+} from './decision-dataset/v1/index.js';
+
+const ALL_DECISION_CHECKS: readonly DecisionCheck[] = [
+  'dedup-rule',
+  'contradiction-rule',
+  'supersession-detector',
+];
+
+const POSITIVE_CLASSES: ReadonlyArray<Exclude<DecisionClass, 'clean'>> = [
+  'duplicate',
+  'contradiction',
+  'supersession',
+];
+
+/** Title-similarity threshold — the production default used by curator + api. */
+const SUPERSESSION_THRESHOLD = 0.6;
+
+/**
+ * The policy the decision cases run under: the two state-dependent rules with
+ * their production semantics — `dedup_check` rejects (as in the recommended
+ * policy), `contradiction_check` is Phase-1 flag-only by construction.
+ */
+function buildDecisionPolicy(): GovernancePolicy {
+  return GovernancePolicy.parse({
+    id: '00000000-0000-4000-8000-00000000c301',
+    name: 'govern-decision eval policy (dedup + contradiction)',
+    tenantId: DECISION_TENANT,
+    rules: [
+      {
+        id: 'rule-contradiction-check',
+        type: 'contradiction_check',
+        action: 'flag',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+      {
+        id: 'rule-dedup-check',
+        type: 'dedup_check',
+        action: 'reject',
+        enabled: true,
+        priority: 1,
+        parameters: {},
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: '2026-07-19T00:00:00.000Z',
+    updatedAt: '2026-07-19T00:00:00.000Z',
+  });
+}
+
+/** Build a Zod-valid candidate for a decision case. */
+function buildCandidate(def: DecisionCase): MemoryCandidate {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: def.candidate.content,
+    title: def.candidate.title,
+    category: def.candidate.category,
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'govern-eval' },
+    tenantId: DECISION_TENANT,
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-07-19T00:00:00.000Z',
+  });
+}
+
+/** Build a Zod-valid ACTIVE curated memory to seed the store with. */
+function buildActiveMemory(
+  title: string,
+  content: string,
+  category: MemoryCategory,
+): CuratedMemory {
+  return CuratedMemory.parse({
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content,
+    title,
+    category,
+    trustLevel: 'medium',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'govern-eval' },
+    tenantId: DECISION_TENANT,
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: '2026-07-19T00:00:00.000Z',
+    promotedBy: { type: 'human', id: 'govern-eval' },
+    updatedAt: '2026-07-19T00:00:00.000Z',
+    version: 1,
+  });
+}
+
+/** Which decision checks fired for this case, measured through the real machinery. */
+function firedChecks(def: DecisionCase): ReadonlySet<DecisionCheck> {
+  const db = createTestDatabase();
+  try {
+    const repo = new MemoryRepository(db);
+    for (const active of def.existingActives) {
+      repo.insert(buildActiveMemory(active.title, active.content, active.category));
+    }
+
+    const candidate = buildCandidate(def);
+    const pipeline = new PolicyPipeline(buildDecisionPolicy());
+
+    // EXACTLY the curator's context wiring (apps/curator/src/curator.ts):
+    // hashes of every existing content, and a live category-scoped repo query.
+    const result = pipeline.evaluate(candidate, {
+      existingHashes: new Set(def.existingActives.map((a) => computeContentHash(a.content))),
+      tenantId: DECISION_TENANT,
+      getActiveMemoriesInCategory: (category) =>
+        repo
+          .findByTenantAndLifecycle(DECISION_TENANT, 'active')
+          .filter((m) => m.category === category)
+          .map((m) => ({ id: m.id, content: m.content })),
+    });
+
+    const fired = new Set<DecisionCheck>();
+    if (result.evaluations.some((e) => e.ruleType === 'dedup_check' && e.outcome === 'fail')) {
+      fired.add('dedup-rule');
+    }
+    if (
+      result.evaluations.some((e) => e.ruleType === 'contradiction_check' && e.outcome === 'flag')
+    ) {
+      fired.add('contradiction-rule');
+    }
+    if (detectSupersession(candidate, repo, SUPERSESSION_THRESHOLD) !== null) {
+      fired.add('supersession-detector');
+    }
+    return fired;
+  } finally {
+    db.close();
+  }
+}
+
+function metricsFor(
+  check: DecisionCheck,
+  tp: number,
+  fp: number,
+  fn: number,
+  tn: number,
+): DecisionCheckMetrics {
+  const precision = tp + fp === 0 ? 1 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 1 : tp / (tp + fn);
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+  return {
+    check,
+    truePositives: tp,
+    falsePositives: fp,
+    falseNegatives: fn,
+    trueNegatives: tn,
+    precision: Number(precision.toFixed(4)),
+    recall: Number(recall.toFixed(4)),
+    f1: Number(f1.toFixed(4)),
+  };
+}
+
+/**
+ * Run the decision-case eval. Pure w.r.t. durable state (ephemeral in-memory
+ * stores only). Returns the full per-check + per-class report; the caller
+ * (evaluateGovernDecision) folds the undocumented-FN count into the gate.
+ */
+export function evaluateDecisionCases(
+  cases: readonly DecisionCase[] = DECISION_CASES,
+): DecisionCasesReport {
+  const fired = new Map<string, ReadonlySet<DecisionCheck>>();
+  for (const def of cases) {
+    fired.set(def.id, firedChecks(def));
+  }
+
+  const positives = cases.filter((c) => c.decisionClass !== 'clean');
+  const negatives = cases.filter((c) => c.decisionClass === 'clean');
+
+  const perCheck: DecisionCheckMetrics[] = [];
+  const falseNegatives: DecisionFalseNegative[] = [];
+
+  for (const check of ALL_DECISION_CHECKS) {
+    let tp = 0;
+    let fp = 0;
+    let fn = 0;
+    let tn = 0;
+
+    for (const def of positives) {
+      const expected = def.expectFiredBy.includes(check);
+      const documentedMiss = (def.knownFalseNegativeOf ?? []).includes(check);
+      if (!expected && !documentedMiss) continue; // out of scope for this case
+
+      if (fired.get(def.id)!.has(check)) {
+        tp += 1;
+      } else {
+        fn += 1;
+        falseNegatives.push({
+          caseId: def.id,
+          check,
+          decisionClass: def.decisionClass,
+          documented: documentedMiss,
+        });
+      }
+    }
+
+    for (const def of negatives) {
+      if (fired.get(def.id)!.has(check)) fp += 1;
+      else tn += 1;
+    }
+
+    perCheck.push(metricsFor(check, tp, fp, fn, tn));
+  }
+
+  // Per-class breakout: catch-rate over every scored (case, check) pair of the
+  // class — the number the report must surface so a dedup regression is not
+  // averaged away by contradiction/supersession health (and vice versa).
+  const perClass: DecisionClassMetrics[] = POSITIVE_CLASSES.map((decisionClass) => {
+    let scoredPairs = 0;
+    let caught = 0;
+    let documentedMisses = 0;
+    for (const def of positives.filter((c) => c.decisionClass === decisionClass)) {
+      const scoredChecks = new Set<DecisionCheck>([
+        ...def.expectFiredBy,
+        ...(def.knownFalseNegativeOf ?? []),
+      ]);
+      for (const check of scoredChecks) {
+        scoredPairs += 1;
+        if (fired.get(def.id)!.has(check)) {
+          caught += 1;
+        } else if ((def.knownFalseNegativeOf ?? []).includes(check)) {
+          documentedMisses += 1;
+        }
+      }
+    }
+    return {
+      decisionClass,
+      scoredPairs,
+      caught,
+      catchRate: scoredPairs === 0 ? 1 : Number((caught / scoredPairs).toFixed(4)),
+      documentedMisses,
+    };
+  });
+
+  return {
+    datasetVersion: DECISION_DATASET_VERSION,
+    totalCases: cases.length,
+    positives: positives.length,
+    negatives: negatives.length,
+    perCheck,
+    perClass,
+    falseNegatives,
+    undocumentedFalseNegatives: falseNegatives.filter((f) => !f.documented),
+  };
+}

--- a/packages/eval-surface/src/govern-decision/decision-eval.ts
+++ b/packages/eval-surface/src/govern-decision/decision-eval.ts
@@ -25,7 +25,11 @@
  */
 
 import { computeContentHash } from '@qmd-team-intent-kb/common';
-import { detectSupersession, PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import {
+  DEFAULT_SUPERSESSION_THRESHOLD,
+  detectSupersession,
+  PolicyPipeline,
+} from '@qmd-team-intent-kb/policy-engine';
 import {
   CuratedMemory,
   GovernancePolicy,
@@ -62,8 +66,9 @@ const POSITIVE_CLASSES: ReadonlyArray<Exclude<DecisionClass, 'clean'>> = [
   'supersession',
 ];
 
-/** Title-similarity threshold — the production default used by curator + api. */
-const SUPERSESSION_THRESHOLD = 0.6;
+// Supersession threshold: consumed from the policy-engine single source
+// (DEFAULT_SUPERSESSION_THRESHOLD) — the exact constant curator + api use, so
+// the eval can never measure a different threshold than production runs.
 
 /**
  * The policy the decision cases run under: the two state-dependent rules with
@@ -179,7 +184,7 @@ function firedChecks(def: DecisionCase): ReadonlySet<DecisionCheck> {
     ) {
       fired.add('contradiction-rule');
     }
-    if (detectSupersession(candidate, repo, SUPERSESSION_THRESHOLD) !== null) {
+    if (detectSupersession(candidate, repo, DEFAULT_SUPERSESSION_THRESHOLD) !== null) {
       fired.add('supersession-detector');
     }
     return fired;

--- a/packages/eval-surface/src/govern-decision/decision-types.ts
+++ b/packages/eval-surface/src/govern-decision/decision-types.ts
@@ -1,0 +1,124 @@
+/**
+ * govern-decision DECISION-CASE types — the labeled schema for the Wave-2 C3
+ * extension: does the govern decision catch candidates that DUPLICATE,
+ * CONTRADICT, or SUPERSEDE existing active memories?
+ *
+ * ## Why (GSB blueprint Wave-2 C3 · umbrella epic)
+ *
+ * The original adversarial set (dataset/v1) measures the SENSITIVE-MATERIAL
+ * surfaces (secrets / PII / paths). It never exercises the three decisions
+ * that need EXISTING STATE to fire: `dedup_check` (exact content-hash),
+ * `contradiction_check` (the Phase-1 flag-only rule), and the supersession
+ * detector. Those are the govern decisions most likely to rot silently —
+ * they pass vacuously whenever the context wiring breaks (no hashes, no
+ * active-memory lookup), which is exactly the failure this labeled set makes
+ * measurable.
+ *
+ * Cases are wired through the REAL machinery: a real in-memory store
+ * (`createTestDatabase` + `MemoryRepository`), the real `PolicyPipeline` with
+ * the production `dedup_check` + `contradiction_check` rules, and the real
+ * `detectSupersession` (now exported from policy-engine). No mocks of the
+ * decision under test.
+ *
+ * Labels follow the same honesty contract as the main set: `expectFiredBy` is
+ * empirical ground truth; `knownFalseNegativeOf` documents measured gaps
+ * (reworded duplicates beat exact-hash dedup; low-overlap or cross-category
+ * contradictions beat the token-overlap heuristic; reworded titles beat
+ * title-Jaccard supersession). Documented gaps are reported, never hidden;
+ * an UNDOCUMENTED miss fails the eval closed.
+ */
+
+import type { MemoryCategory } from '@qmd-team-intent-kb/schema';
+
+/** The three state-dependent decision surfaces this extension scores. */
+export type DecisionCheck =
+  /** The production `dedup_check` rule (exact SHA-256 content hash) inside the pipeline. */
+  | 'dedup-rule'
+  /** The production Phase-1 `contradiction_check` rule (token-overlap flag) inside the pipeline. */
+  | 'contradiction-rule'
+  /** `detectSupersession` (policy-engine) — title-Jaccard supersession detection. */
+  | 'supersession-detector';
+
+/** The relationship class a decision case exercises (or `clean` for a negative). */
+export type DecisionClass =
+  | 'duplicate' // candidate duplicates an existing active memory
+  | 'contradiction' // candidate contradicts an existing active memory
+  | 'supersession' // candidate supersedes an existing active memory
+  | 'clean'; // benign — no meaningful relationship to existing actives
+
+/** A minimal existing ACTIVE memory the case seeds into the real store. */
+export interface ExistingActive {
+  readonly title: string;
+  readonly content: string;
+  readonly category: MemoryCategory;
+}
+
+/** One labeled decision case. */
+export interface DecisionCase {
+  /** Stable, human-readable id, e.g. `dup-exact-01`. Unique in the set. */
+  readonly id: string;
+  /** One-line description of the relationship and how it is (or isn't) caught. */
+  readonly description: string;
+  /** The relationship class (or `clean` for a known-negative). */
+  readonly decisionClass: DecisionClass;
+  /** The incoming candidate's distinguishing fields. */
+  readonly candidate: {
+    readonly title: string;
+    readonly content: string;
+    readonly category: MemoryCategory;
+  };
+  /** Active memories seeded into the store BEFORE the candidate is evaluated. */
+  readonly existingActives: readonly ExistingActive[];
+  /**
+   * For a positive case: the checks that SHOULD fire. Empty for `clean` cases
+   * and for positives that are wholly documented gaps.
+   */
+  readonly expectFiredBy: readonly DecisionCheck[];
+  /** Checks EMPIRICALLY CONFIRMED to miss this case today (documented gaps). */
+  readonly knownFalseNegativeOf?: readonly DecisionCheck[];
+}
+
+/** Per-check confusion-matrix counts for the decision checks. */
+export interface DecisionCheckMetrics {
+  readonly check: DecisionCheck;
+  readonly truePositives: number;
+  readonly falsePositives: number;
+  readonly falseNegatives: number;
+  readonly trueNegatives: number;
+  readonly precision: number;
+  readonly recall: number;
+  readonly f1: number;
+}
+
+/** Per-class recall breakout: how much of each relationship class is caught. */
+export interface DecisionClassMetrics {
+  readonly decisionClass: Exclude<DecisionClass, 'clean'>;
+  /** Number of (case, expected-or-documented check) pairs in this class. */
+  readonly scoredPairs: number;
+  /** Pairs where the check fired. */
+  readonly caught: number;
+  /** caught / scoredPairs (1 when there is nothing to catch). */
+  readonly catchRate: number;
+  /** Pairs whose miss is already documented in `knownFalseNegativeOf`. */
+  readonly documentedMisses: number;
+}
+
+/** One decision-case false negative. */
+export interface DecisionFalseNegative {
+  readonly caseId: string;
+  readonly check: DecisionCheck;
+  readonly decisionClass: DecisionClass;
+  readonly documented: boolean;
+}
+
+/** The decision-case section of the govern-decision report. */
+export interface DecisionCasesReport {
+  readonly datasetVersion: string;
+  readonly totalCases: number;
+  readonly positives: number;
+  readonly negatives: number;
+  readonly perCheck: readonly DecisionCheckMetrics[];
+  readonly perClass: readonly DecisionClassMetrics[];
+  readonly falseNegatives: readonly DecisionFalseNegative[];
+  readonly undocumentedFalseNegatives: readonly DecisionFalseNegative[];
+}

--- a/packages/eval-surface/src/govern-decision/decision-types.ts
+++ b/packages/eval-surface/src/govern-decision/decision-types.ts
@@ -76,6 +76,15 @@ export interface DecisionCase {
   readonly expectFiredBy: readonly DecisionCheck[];
   /** Checks EMPIRICALLY CONFIRMED to miss this case today (documented gaps). */
   readonly knownFalseNegativeOf?: readonly DecisionCheck[];
+  /**
+   * For a `clean` case: checks EMPIRICALLY CONFIRMED to FIRE on it today — a
+   * KNOWN false positive (e.g. the token-overlap contradiction heuristic
+   * firing on a compatible restatement). Known FPs still count as false
+   * positives in the confusion matrix (precision honestly drops), but they
+   * are reported as documented, never as a surprise; the gate holds them via
+   * the measured-then-committed per-check precision floors.
+   */
+  readonly knownFalsePositiveOf?: readonly DecisionCheck[];
 }
 
 /** Per-check confusion-matrix counts for the decision checks. */
@@ -111,6 +120,14 @@ export interface DecisionFalseNegative {
   readonly documented: boolean;
 }
 
+/** One decision-case false positive: a check that fired on a `clean` case. */
+export interface DecisionFalsePositive {
+  readonly caseId: string;
+  readonly check: DecisionCheck;
+  /** True when the case's `knownFalsePositiveOf` already documents this firing. */
+  readonly documented: boolean;
+}
+
 /** The decision-case section of the govern-decision report. */
 export interface DecisionCasesReport {
   readonly datasetVersion: string;
@@ -121,4 +138,8 @@ export interface DecisionCasesReport {
   readonly perClass: readonly DecisionClassMetrics[];
   readonly falseNegatives: readonly DecisionFalseNegative[];
   readonly undocumentedFalseNegatives: readonly DecisionFalseNegative[];
+  /** Every firing on a clean case — documented (known FP) or a surprise. */
+  readonly falsePositives: readonly DecisionFalsePositive[];
+  /** Subset of `falsePositives` covered by a case's `knownFalsePositiveOf`. */
+  readonly knownFalsePositives: readonly DecisionFalsePositive[];
 }

--- a/packages/eval-surface/src/govern-decision/types.ts
+++ b/packages/eval-surface/src/govern-decision/types.ts
@@ -21,6 +21,8 @@
 
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 
+import type { DecisionCasesReport } from './decision-types.js';
+
 /**
  * The independent "checks" whose efficacy we score. Each is one detection
  * surface in the govern decision, scored separately so a gap in one (e.g. the
@@ -131,4 +133,10 @@ export interface GovernDecisionReport {
   readonly falseNegatives: readonly FalseNegative[];
   /** Subset of `falseNegatives` NOT covered by a case's `knownFalseNegativeOf`. */
   readonly undocumentedFalseNegatives: readonly FalseNegative[];
+  /**
+   * Wave-2 C3: the state-dependent decision section — dedup / contradiction /
+   * supersession over the labeled decision set, broken out per check AND per
+   * relationship class. Its undocumented false-negatives join the gate.
+   */
+  readonly decisionCases: DecisionCasesReport;
 }

--- a/packages/eval-surface/src/groundedness.ts
+++ b/packages/eval-surface/src/groundedness.ts
@@ -1,0 +1,186 @@
+/**
+ * groundedness evaluator — does an answer-like claim stay ANCHORED to the
+ * memory it cites? (Wave-2 C2 · GSB blueprint groundedness layer)
+ *
+ * ## Why
+ *
+ * The retrieval evals measure whether the right memory comes BACK; nothing
+ * measured whether what gets SAID on top of a retrieved memory is actually
+ * supported by it. This evaluator scores the deterministic groundedness
+ * scorer (scorer v1) against a labeled fixture of (claim, real-memory-excerpt)
+ * pairs and reports SEGMENTED metrics — supported-precision and
+ * unsupported-catch-rate — so over-flagging and under-catching are visible
+ * separately, never averaged into one number.
+ *
+ * ## Honesty box (read before trusting the numbers)
+ *
+ *   - Scorer v1 attests SUPPORT-BY-ADMITTED-FACTS (terms/numbers/polarity
+ *     present in the cited text), not truth and not entailment. It is an eval
+ *     of the eval surface, not an oracle.
+ *   - The fixture is SEMI-SYNTHETIC-FROM-REAL: real promoted-memory excerpts,
+ *     synthetically authored claims (see fixture/v1). Scorer thresholds were
+ *     tuned on this same fixture — metrics are in-sample fit.
+ *   - Known limitations (argument swaps etc.) are carried as documented
+ *     scorer misses in the fixture and REPORTED; an undocumented wrong
+ *     prediction fails the eval closed (same contract as govern-decision).
+ *   - The optional LLM judge (./groundedness/llm-judge.ts) is an OFFLINE
+ *     COMPARISON ARM only: env-gated, never invoked here, never in CI, never
+ *     a gate. No LLM runs in any gating path.
+ *
+ * Pure w.r.t. durable state: no I/O, no model calls, in-memory scoring only.
+ */
+
+import type { EvaluatorResult } from './types.js';
+import type {
+  GroundednessError,
+  GroundednessItem,
+  GroundednessReport,
+  Perturbation,
+} from './groundedness/types.js';
+import { FIXTURE_VERSION, GROUNDEDNESS_ITEMS } from './groundedness/fixture/v1/index.js';
+import { scoreGroundedness } from './groundedness/scorer.js';
+
+/**
+ * Committed metric floors — DERIVED FROM THE FIRST REAL RUN of scorer v1 over
+ * fixture v1 (measure, then commit; never invented). The run is deterministic
+ * (fixed fixture, pure scorer), so equality holds until either changes; the
+ * floors exist so a scorer or fixture change that degrades a segment fails
+ * loudly instead of silently shifting the balance.
+ */
+export const GROUNDEDNESS_FLOORS = {
+  // Measured 2026-07-19 on fixture v1.0.0 with scorer v1: supported-precision
+  // 0.8824 (30 true supported / 34 predicted supported — the 4 documented
+  // scorer misses predict "supported" on unsupported items), unsupported
+  // catch-rate 0.8667 (26/30; misses = 3 argument swaps + 1 distant negation,
+  // all fixture-documented). Floors sit a hair under the measured values so
+  // an equal re-run passes; ONE additional error in either segment lands
+  // below the floor and fails the gate.
+  supportedPrecision: 0.88,
+  unsupportedCatchRate: 0.86,
+} as const;
+
+const PERTURBATIONS: readonly Perturbation[] = [
+  'inverted-number',
+  'wrong-component',
+  'negation-flip',
+  'argument-swap',
+  'overreach',
+];
+
+export interface GroundednessOptions {
+  /** Override the labeled fixture (defaults to fixture/v1). Used by tests. */
+  readonly items?: readonly GroundednessItem[];
+}
+
+/**
+ * Run the groundedness eval.
+ *
+ * Verdict (`passed`) is fail-closed on BOTH properties:
+ *   1. zero UNDOCUMENTED scorer errors (every wrong prediction is either a
+ *      fixture-documented limitation or a regression that flips the gate);
+ *   2. the segmented metrics hold their committed floors.
+ *
+ * The continuous `score` is balanced accuracy — a reporting number, never the
+ * pass/fail decision (the platform refuses gradient scores AS the verdict).
+ */
+export function evaluateGroundedness(options: GroundednessOptions = {}): EvaluatorResult {
+  const items = options.items ?? GROUNDEDNESS_ITEMS;
+
+  let predictedSupported = 0;
+  let supportedCorrect = 0; // predicted supported AND labeled supported
+  let supportedTotal = 0;
+  let supportedCaught = 0; // labeled supported, predicted supported
+  let unsupportedTotal = 0;
+  let unsupportedCaught = 0; // labeled unsupported, predicted unsupported
+
+  const errors: GroundednessError[] = [];
+  const perPerturbation = new Map<Perturbation, { items: number; caught: number }>(
+    PERTURBATIONS.map((p) => [p, { items: 0, caught: 0 }]),
+  );
+
+  for (const item of items) {
+    const prediction = scoreGroundedness(item.claim, item.memoryExcerpt);
+    const predicted = prediction.predicted;
+
+    if (predicted === 'supported') {
+      predictedSupported += 1;
+      if (item.label === 'supported') supportedCorrect += 1;
+    }
+    if (item.label === 'supported') {
+      supportedTotal += 1;
+      if (predicted === 'supported') supportedCaught += 1;
+    } else {
+      unsupportedTotal += 1;
+      if (predicted === 'unsupported') unsupportedCaught += 1;
+      if (item.perturbation !== undefined) {
+        const bucket = perPerturbation.get(item.perturbation)!;
+        bucket.items += 1;
+        if (predicted === 'unsupported') bucket.caught += 1;
+      }
+    }
+
+    if (predicted !== item.label) {
+      errors.push({
+        itemId: item.id,
+        label: item.label,
+        predicted,
+        ...(item.perturbation !== undefined ? { perturbation: item.perturbation } : {}),
+        documented: item.knownScorerMiss === true,
+      });
+    }
+  }
+
+  const supportedPrecision =
+    predictedSupported === 0 ? 1 : Number((supportedCorrect / predictedSupported).toFixed(4));
+  const supportedRecall =
+    supportedTotal === 0 ? 1 : Number((supportedCaught / supportedTotal).toFixed(4));
+  const unsupportedCatchRate =
+    unsupportedTotal === 0 ? 1 : Number((unsupportedCaught / unsupportedTotal).toFixed(4));
+  const balancedAccuracy = Number(((supportedRecall + unsupportedCatchRate) / 2).toFixed(4));
+
+  const undocumentedErrors = errors.filter((e) => !e.documented);
+
+  const report: GroundednessReport = {
+    fixtureVersion: FIXTURE_VERSION,
+    totalItems: items.length,
+    supportedItems: supportedTotal,
+    unsupportedItems: unsupportedTotal,
+    supportedPrecision,
+    supportedRecall,
+    unsupportedCatchRate,
+    balancedAccuracy,
+    perPerturbation: PERTURBATIONS.map((p) => ({
+      perturbation: p,
+      ...perPerturbation.get(p)!,
+    })),
+    errors,
+    undocumentedErrors,
+  };
+
+  const passed =
+    undocumentedErrors.length === 0 &&
+    supportedPrecision >= GROUNDEDNESS_FLOORS.supportedPrecision &&
+    unsupportedCatchRate >= GROUNDEDNESS_FLOORS.unsupportedCatchRate;
+
+  return {
+    name: 'groundedness',
+    passed,
+    score: balancedAccuracy,
+    threshold: GROUNDEDNESS_FLOORS.unsupportedCatchRate,
+    details: {
+      fixture_version: FIXTURE_VERSION,
+      total_items: report.totalItems,
+      supported_items: report.supportedItems,
+      unsupported_items: report.unsupportedItems,
+      supported_precision: supportedPrecision,
+      supported_recall: supportedRecall,
+      unsupported_catch_rate: unsupportedCatchRate,
+      balanced_accuracy: balancedAccuracy,
+      undocumented_errors: undocumentedErrors.length,
+      documented_errors: errors.length - undocumentedErrors.length,
+      floor_supported_precision: GROUNDEDNESS_FLOORS.supportedPrecision,
+      floor_unsupported_catch_rate: GROUNDEDNESS_FLOORS.unsupportedCatchRate,
+      report_json: JSON.stringify(report),
+    },
+  };
+}

--- a/packages/eval-surface/src/groundedness/fixture/v1/index.ts
+++ b/packages/eval-surface/src/groundedness/fixture/v1/index.ts
@@ -1,0 +1,668 @@
+/**
+ * groundedness labeled fixture — v1 (Wave-2 C2).
+ *
+ * 60 labeled (claim, memory-excerpt) pairs derived from 30 REAL promoted
+ * memories in the live brain's kb-export (innocuous technical/architectural
+ * memories only — anything credential- or person-shaped was excluded at
+ * selection time). Each memory yields:
+ *   - one SUPPORTED claim   — a paraphrase of what the excerpt says;
+ *   - one UNSUPPORTED claim — plausible but NOT in the excerpt (an inverted
+ *     number, a wrong component, a flipped negation, a swapped argument, or
+ *     an overreach), each tagged with its `perturbation`.
+ *
+ * ## Provenance — semi-synthetic-from-real, stated honestly
+ *
+ * Excerpts are verbatim memory text (`sourceMemoryId` = the export UUID);
+ * claims are authored synthetically for this fixture, so labels are
+ * by-construction ground truth. Because the same author wrote the claims and
+ * tuned scorer v1's thresholds on this set, the reported metrics are
+ * IN-SAMPLE fit — a held-out set is future work (see the module doc).
+ *
+ * `knownScorerMiss: true` marks items scorer v1 is EMPIRICALLY CONFIRMED to
+ * get wrong today (chiefly argument swaps, which preserve the token set) —
+ * documented limitations, reported not hidden. An UNDOCUMENTED wrong
+ * prediction fails the eval closed.
+ *
+ * FIXTURE_VERSION is bumped on any item add/remove/relabel.
+ */
+
+import type { GroundednessItem } from '../../types.js';
+
+/** Semantic version of THIS fixture. Bump on any change to the item set. */
+export const FIXTURE_VERSION = '1.0.0';
+
+export const GROUNDEDNESS_ITEMS: readonly GroundednessItem[] = [
+  /* ---------------- 00c95f4e — Confused Deputy Problem -------------------- */
+  {
+    id: 'grd-confused-deputy-sup',
+    sourceMemoryId: '00c95f4e-e1ee-51ad-9331-3aefd68a1629',
+    memoryExcerpt:
+      'The confused deputy problem in MCP occurs when servers act as authentication proxies between clients and third-party services. Prevention of confused deputy attacks requires OAuth 2.1 with PKCE (Proof Key for Code Exchange) for all authorization requests, state parameter validation, and strict redirect URI validation.',
+    claim:
+      'Preventing confused deputy attacks in MCP requires OAuth 2.1 with PKCE, state parameter validation, and strict redirect URI validation.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-confused-deputy-unsup',
+    sourceMemoryId: '00c95f4e-e1ee-51ad-9331-3aefd68a1629',
+    memoryExcerpt:
+      'The confused deputy problem in MCP occurs when servers act as authentication proxies between clients and third-party services. Prevention of confused deputy attacks requires OAuth 2.1 with PKCE (Proof Key for Code Exchange) for all authorization requests, state parameter validation, and strict redirect URI validation.',
+    claim:
+      'Preventing confused deputy attacks in MCP requires SAML assertions and mutual TLS between the client and the proxy gateway.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 010e0d4e — mutable global registry -------------------- */
+  {
+    id: 'grd-mutable-registry-sup',
+    sourceMemoryId: '010e0d4e-7ac7-52a8-8f2b-b257999ac689',
+    memoryExcerpt:
+      'A mutable global registry is a software design anti-pattern where module-level constants or maps are mutated at runtime, causing shared state corruption across tenants in multi-tenant systems. This pattern causes three failure modes: multi-tenant pollution, test isolation failure, and race conditions. The fix is to make data instance-owned rather than module-owned.',
+    claim:
+      'The mutable global registry anti-pattern causes three failure modes — including multi-tenant pollution and race conditions — and the fix is making data instance-owned.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-mutable-registry-unsup',
+    sourceMemoryId: '010e0d4e-7ac7-52a8-8f2b-b257999ac689',
+    memoryExcerpt:
+      'A mutable global registry is a software design anti-pattern where module-level constants or maps are mutated at runtime, causing shared state corruption across tenants in multi-tenant systems. This pattern causes three failure modes: multi-tenant pollution, test isolation failure, and race conditions. The fix is to make data instance-owned rather than module-owned.',
+    claim:
+      'The mutable global registry anti-pattern causes five failure modes and is fixed by freezing the module-level maps at startup.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 0532995b — Multi-Tenancy (RLS) ------------------------ */
+  {
+    id: 'grd-multitenancy-sup',
+    sourceMemoryId: '0532995b-5f7b-52f4-9742-a52ddd7988d5',
+    memoryExcerpt:
+      'Multi-tenancy in MCP server architecture uses a shared database, shared schema model where data isolation is enforced through Row Level Security (RLS). The schema includes a stores table as a master tenant registry, with all tenant tables enforcing RLS by store_id.',
+    claim:
+      'Tenants share one database and schema, with data isolation enforced through Row Level Security keyed by store_id.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-multitenancy-unsup',
+    sourceMemoryId: '0532995b-5f7b-52f4-9742-a52ddd7988d5',
+    memoryExcerpt:
+      'Multi-tenancy in MCP server architecture uses a shared database, shared schema model where data isolation is enforced through Row Level Security (RLS). The schema includes a stores table as a master tenant registry, with all tenant tables enforcing RLS by store_id.',
+    claim:
+      'Each tenant gets its own dedicated database, with isolation enforced at the connection pool layer.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 05e16ec4 — Self-eval metrics must be able to fail ----- */
+  {
+    id: 'grd-selfeval-sup',
+    sourceMemoryId: '05e16ec4-cc15-5afe-8c7b-caee7d25c98c',
+    memoryExcerpt:
+      'recall@k and citation-coverage were tautological because k >= corpus size, so everything retrieved scored 1.0 (fix: golden cases carry topical distractors with the relevant doc placed LAST, past position k, so the score is earned by ranking); a groundedness metric used skip-on-error, turning a fully-broken pipeline into a PASS (fix: exceptions score 0.0, only a truly-empty applicable set passes).',
+    claim:
+      'recall@k was tautological because k was at least the corpus size, and the fix was golden cases carrying topical distractors with the relevant doc placed last.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-selfeval-unsup',
+    sourceMemoryId: '05e16ec4-cc15-5afe-8c7b-caee7d25c98c',
+    memoryExcerpt:
+      'recall@k and citation-coverage were tautological because k >= corpus size, so everything retrieved scored 1.0 (fix: golden cases carry topical distractors with the relevant doc placed LAST, past position k, so the score is earned by ranking); a groundedness metric used skip-on-error, turning a fully-broken pipeline into a PASS (fix: exceptions score 0.0, only a truly-empty applicable set passes).',
+    claim:
+      'A groundedness metric that skips on error is safe because a fully-broken pipeline can never reach a PASS.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+    // The flipped term ("PASS") sits three tokens after the negation marker,
+    // beyond scorer v1's window-1 scope, and the claim's vocabulary stays
+    // inside the memory's — a documented distant-negation limitation.
+    knownScorerMiss: true,
+  },
+
+  /* ---------------- 081bce4f — Compile-Then-Govern Architecture ----------- */
+  {
+    id: 'grd-compile-govern-sup',
+    sourceMemoryId: '081bce4f-1801-539d-a852-add50f441e50',
+    memoryExcerpt:
+      'The compilation layer (ICO) transforms raw corpus into durable, human-readable, frontmatter-typed knowledge files through six deterministic passes: summarise, extract, synthesise, contradict, gap, and link. The two layers communicate through a file system spool boundary, which provides crash safety, inspectability, independent release cadence, and an auditable hand-off.',
+    claim:
+      'The compilation layer runs six deterministic passes and hands off to governance through a file system spool boundary.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-compile-govern-unsup',
+    sourceMemoryId: '081bce4f-1801-539d-a852-add50f441e50',
+    memoryExcerpt:
+      'The compilation layer (ICO) transforms raw corpus into durable, human-readable, frontmatter-typed knowledge files through six deterministic passes: summarise, extract, synthesise, contradict, gap, and link. The two layers communicate through a file system spool boundary, which provides crash safety, inspectability, independent release cadence, and an auditable hand-off.',
+    claim:
+      'The compilation layer runs four deterministic passes and hands off to governance through a message queue.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 08909f28 — Consecutive-Failure Escalation ------------- */
+  {
+    id: 'grd-failure-escalation-sup',
+    sourceMemoryId: '08909f28-291a-5d1b-a867-030f09f6fc03',
+    memoryExcerpt:
+      'Consecutive-failure escalation is a monitoring pattern that increases the priority of alerts as a streak of failures continues. It walks per-run logs and raises alert priority once a failure streak forms, ensuring that persistent failures become increasingly visible and are not ignored.',
+    claim:
+      'Consecutive-failure escalation raises alert priority as a failure streak continues, walking per-run logs so persistent failures stay visible.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-failure-escalation-unsup',
+    sourceMemoryId: '08909f28-291a-5d1b-a867-030f09f6fc03',
+    memoryExcerpt:
+      'Consecutive-failure escalation is a monitoring pattern that increases the priority of alerts as a streak of failures continues. It walks per-run logs and raises alert priority once a failure streak forms, ensuring that persistent failures become increasingly visible and are not ignored.',
+    claim:
+      'Consecutive-failure escalation lowers alert priority during a long failure streak to reduce paging fatigue for the on-call.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 098b3789 — Shared Prometheus Metrics Package ---------- */
+  {
+    id: 'grd-metrics-package-sup',
+    sourceMemoryId: '098b3789-37d7-5566-9047-85deeaab471a',
+    memoryExcerpt:
+      'A shared Prometheus metrics package that standardizes label names, histogram buckets, and counter naming conventions across all services, eliminating inconsistencies that required per-service Grafana dashboard overrides. The package standardizes the /metrics endpoint configuration to port 9090 and path /metrics across all IRSB services.',
+    claim:
+      'The shared Prometheus metrics package standardizes label names and histogram buckets, and pins the metrics endpoint to port 9090.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-metrics-package-unsup',
+    sourceMemoryId: '098b3789-37d7-5566-9047-85deeaab471a',
+    memoryExcerpt:
+      'A shared Prometheus metrics package that standardizes label names, histogram buckets, and counter naming conventions across all services, eliminating inconsistencies that required per-service Grafana dashboard overrides. The package standardizes the /metrics endpoint configuration to port 9090 and path /metrics across all IRSB services.',
+    claim:
+      'The shared Prometheus metrics package pins the metrics endpoint to port 8080 across all services.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 0adb8484 — OAuth 2.0 ---------------------------------- */
+  {
+    id: 'grd-oauth-sup',
+    sourceMemoryId: '0adb8484-ae02-5294-bf21-bc769d139e79',
+    memoryExcerpt:
+      'The Authorization Server issues JWT access tokens via the client_credentials flow, and the Resource Server secures endpoints. The choice between public and confidential client depends on deployment: local servers use public clients with brokers; remote servers use confidential clients with the Authorization Code Flow.',
+    claim:
+      'Local servers use public clients with brokers, while remote servers use confidential clients with the Authorization Code Flow.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-oauth-unsup',
+    sourceMemoryId: '0adb8484-ae02-5294-bf21-bc769d139e79',
+    memoryExcerpt:
+      'The Authorization Server issues JWT access tokens via the client_credentials flow, and the Resource Server secures endpoints. The choice between public and confidential client depends on deployment: local servers use public clients with brokers; remote servers use confidential clients with the Authorization Code Flow.',
+    claim:
+      'Local servers use confidential clients with the Authorization Code Flow, while remote servers use public clients with brokers.',
+    label: 'unsupported',
+    perturbation: 'argument-swap',
+    knownScorerMiss: true, // token set identical to the supported claim — v1's admitted blind spot
+  },
+
+  /* ---------------- 0b25a9fc — Govern path stays LLM-free ----------------- */
+  {
+    id: 'grd-llm-free-sup',
+    sourceMemoryId: '0b25a9fc-2802-5984-8256-d84d9fe7c8c9',
+    memoryExcerpt:
+      'Deterministic govern (promote, policy) must not import from packages named or framed as model runtime (e.g. claude-runtime), even when today’s classifyContent is pure sync regex. Prefer re-exporting pure classifiers through policy-engine (which already owns sensitivity-gate) and have the promoter depend on that re-export.',
+    claim:
+      'The deterministic govern path avoids importing model-runtime packages and instead re-exports pure classifiers through policy-engine.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-llm-free-unsup',
+    sourceMemoryId: '0b25a9fc-2802-5984-8256-d84d9fe7c8c9',
+    memoryExcerpt:
+      'Deterministic govern (promote, policy) must not import from packages named or framed as model runtime (e.g. claude-runtime), even when today’s classifyContent is pure sync regex. Prefer re-exporting pure classifiers through policy-engine (which already owns sensitivity-gate) and have the promoter depend on that re-export.',
+    claim:
+      'Because classifyContent is pure sync regex today, the govern path may import model-runtime packages directly.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 0d4a6119 — Search Adapter Pattern --------------------- */
+  {
+    id: 'grd-search-adapter-sup',
+    sourceMemoryId: '0d4a6119-10c7-5c4c-838a-010951be2e36',
+    memoryExcerpt:
+      'FTS5 ships as default (zero dependencies). qmd is the upgrade path (proven at 18.2K stars). The interface is the contract, not the implementation. This pattern ensures that the search layer can be swapped or upgraded without modifying the core system.',
+    claim:
+      'FTS5 is the default search backend with zero dependencies, and qmd is the upgrade path; the interface is the contract.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-search-adapter-unsup',
+    sourceMemoryId: '0d4a6119-10c7-5c4c-838a-010951be2e36',
+    memoryExcerpt:
+      'FTS5 ships as default (zero dependencies). qmd is the upgrade path (proven at 18.2K stars). The interface is the contract, not the implementation. This pattern ensures that the search layer can be swapped or upgraded without modifying the core system.',
+    claim: 'qmd is the upgrade path for the search layer, proven at 44K stars.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 0f6b344c — Dual-Layer CVE Clearance ------------------- */
+  {
+    id: 'grd-cve-clearance-sup',
+    sourceMemoryId: '0f6b344c-66d4-50b3-9ce3-65fe11d0e91b',
+    memoryExcerpt:
+      'Bumping a direct dependency alone is insufficient to permanently clear transitive CVEs because package managers use semantic versioning ranges that can resolve to older, vulnerable versions on future clean installs. A top-level overrides block forces every transitive reference to resolve through pinned versions. Both moves are mandatory; neither alone is complete for permanent CVE clearance.',
+    claim:
+      'Permanently clearing a transitive CVE takes both the direct dependency bump and a top-level overrides block; neither alone is complete.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-cve-clearance-unsup',
+    sourceMemoryId: '0f6b344c-66d4-50b3-9ce3-65fe11d0e91b',
+    memoryExcerpt:
+      'Bumping a direct dependency alone is insufficient to permanently clear transitive CVEs because package managers use semantic versioning ranges that can resolve to older, vulnerable versions on future clean installs. A top-level overrides block forces every transitive reference to resolve through pinned versions. Both moves are mandatory; neither alone is complete for permanent CVE clearance.',
+    claim:
+      'Bumping the direct dependency alone is sufficient to permanently clear transitive CVEs, so an overrides block is redundant.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 104123f1 — An eval metric that cannot fail ------------ */
+  {
+    id: 'grd-metric-fail-sup',
+    sourceMemoryId: '104123f1-bec3-5c82-a0ea-683e1f2ade1d',
+    memoryExcerpt:
+      'A groundedness metric that skips-on-error turns a broken pipeline into a PASS; it must score 0 on error instead. Also ensure the harness cannot vacuously pass with zero metrics and that provider-parity can actually fail.',
+    claim:
+      'A groundedness metric must score 0 on error, because skipping on error turns a broken pipeline into a PASS.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-metric-fail-unsup',
+    sourceMemoryId: '104123f1-bec3-5c82-a0ea-683e1f2ade1d',
+    memoryExcerpt:
+      'A groundedness metric that skips-on-error turns a broken pipeline into a PASS; it must score 0 on error instead. Also ensure the harness cannot vacuously pass with zero metrics and that provider-parity can actually fail.',
+    claim:
+      'recall@k becomes tautological when the corpus contains duplicate documents, and the fix is deduplicating before indexing.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 10876443 — Strict-Then-Broad Fallback ----------------- */
+  {
+    id: 'grd-strict-broad-sup',
+    sourceMemoryId: '10876443-b467-592d-933d-e8cf3f93ae40',
+    memoryExcerpt:
+      'The system first attempts a strict AND query where all tokens must co-occur on a single page. If this returns no results, it falls back to a broad OR query with BM25 ranking, which naturally ranks pages with more token matches higher. After implementing the strict-then-broad fallback, the system achieved 5/5 question engagement with 28 citations.',
+    claim:
+      'Retrieval first tries a strict AND query and falls back to a broad OR query with BM25 ranking when the strict query returns no results.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-strict-broad-unsup',
+    sourceMemoryId: '10876443-b467-592d-933d-e8cf3f93ae40',
+    memoryExcerpt:
+      'The system first attempts a strict AND query where all tokens must co-occur on a single page. If this returns no results, it falls back to a broad OR query with BM25 ranking, which naturally ranks pages with more token matches higher. After implementing the strict-then-broad fallback, the system achieved 5/5 question engagement with 28 citations.',
+    claim:
+      'After the strict-then-broad fallback landed, the system achieved 3/5 question engagement with 12 citations.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 14ab3268 — Structured Output Over Model Choice -------- */
+  {
+    id: 'grd-structured-output-sup',
+    sourceMemoryId: '14ab3268-3a72-54a2-a0ad-b6ca692018b3',
+    memoryExcerpt:
+      'Structured output (schema in, schema out) is more important than the specific LLM model choice for deterministic rendering. The prompt provides a fully-populated example schema, and the LLM returns schema-compliant JSON reliably on the first try, making the output deterministic enough to render.',
+    claim:
+      'For deterministic rendering, structured schema-in/schema-out output matters more than which LLM model is chosen.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-structured-output-unsup',
+    sourceMemoryId: '14ab3268-3a72-54a2-a0ad-b6ca692018b3',
+    memoryExcerpt:
+      'Structured output (schema in, schema out) is more important than the specific LLM model choice for deterministic rendering. The prompt provides a fully-populated example schema, and the LLM returns schema-compliant JSON reliably on the first try, making the output deterministic enough to render.',
+    claim:
+      'For deterministic rendering, the specific LLM model choice is more important than structured schema output.',
+    label: 'unsupported',
+    perturbation: 'argument-swap',
+    knownScorerMiss: true, // swap preserves the token set — v1's admitted blind spot
+  },
+
+  /* ---------------- 15ec30ac — REFUSE/CHALLENGE/FLAG grading -------------- */
+  {
+    id: 'grd-scanner-grades-sup',
+    sourceMemoryId: '15ec30ac-a3b1-5c52-ae8d-28c44c5168a3',
+    memoryExcerpt:
+      'The supply-chain scanner separates findings into three grades so a false-positive storm never pressures anyone to disable the gate: REFUSE (exit 2, always fails, NEVER waivable) is reserved for genuinely-malicious executable content; CHALLENGE (exit 1 unless waived) is dual-use, cleared only by a reviewed scan-allowlist.txt entry, never by weakening a pattern; FLAG (exit 0, report-only) is ubiquitous/noisy signal.',
+    claim:
+      'The scanner separates findings into three grades — REFUSE always fails and is never waivable, CHALLENGE clears only via a reviewed allowlist entry, and FLAG is report-only.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-scanner-grades-unsup',
+    sourceMemoryId: '15ec30ac-a3b1-5c52-ae8d-28c44c5168a3',
+    memoryExcerpt:
+      'The supply-chain scanner separates findings into three grades so a false-positive storm never pressures anyone to disable the gate: REFUSE (exit 2, always fails, NEVER waivable) is reserved for genuinely-malicious executable content; CHALLENGE (exit 1 unless waived) is dual-use, cleared only by a reviewed scan-allowlist.txt entry, never by weakening a pattern; FLAG (exit 0, report-only) is ubiquitous/noisy signal.',
+    claim:
+      'A REFUSE finding is waivable through a reviewed scan-allowlist.txt entry, just like a CHALLENGE.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 160333ca — A gate that can't evaluate must BLOCK ------ */
+  {
+    id: 'grd-gate-block-sup',
+    sourceMemoryId: '160333ca-7623-50b6-ae36-725364c2ebe5',
+    memoryExcerpt:
+      'When a pattern was malformed grep exited 2, the error was invisible to set -e/the ERR trap, and the token silently never matched — a fail-OPEN where real leaks passed. The fix: if grep exits >= 2 (cannot evaluate), the gate BLOCKs with a gate-bug reason instead of reporting PASS.',
+    claim:
+      'If grep exits 2 or higher and the gate cannot evaluate its rule, the gate BLOCKs with a gate-bug reason instead of reporting PASS.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-gate-block-unsup',
+    sourceMemoryId: '160333ca-7623-50b6-ae36-725364c2ebe5',
+    memoryExcerpt:
+      'When a pattern was malformed grep exited 2, the error was invisible to set -e/the ERR trap, and the token silently never matched — a fail-OPEN where real leaks passed. The fix: if grep exits >= 2 (cannot evaluate), the gate BLOCKs with a gate-bug reason instead of reporting PASS.',
+    claim:
+      'If grep exits 2 or higher the gate reports PASS with a warning annotation so a malformed pattern is triaged asynchronously.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 16f60762 — Deterministic-First Architecture ----------- */
+  {
+    id: 'grd-deterministic-first-sup',
+    sourceMemoryId: '16f60762-211a-5347-90c9-863e300de6f4',
+    memoryExcerpt:
+      'The PolicyPipeline composes 8 deterministic rules: secret-detection, content-length, source-trust, relevance-score, dedup-check, tenant-match, sensitivity-gate, and content-sanitization. The pipeline short-circuits on first failure, ensuring that only vetted content becomes part of the curated knowledge base.',
+    claim:
+      'The PolicyPipeline composes 8 deterministic rules — including secret-detection and dedup-check — and short-circuits on first failure.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-deterministic-first-unsup',
+    sourceMemoryId: '16f60762-211a-5347-90c9-863e300de6f4',
+    memoryExcerpt:
+      'The PolicyPipeline composes 8 deterministic rules: secret-detection, content-length, source-trust, relevance-score, dedup-check, tenant-match, sensitivity-gate, and content-sanitization. The pipeline short-circuits on first failure, ensuring that only vetted content becomes part of the curated knowledge base.',
+    claim:
+      'The PolicyPipeline composes 12 deterministic rules and always evaluates every rule before deciding.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 17242c90 — Keyless SHA-256 audit chain ---------------- */
+  {
+    id: 'grd-audit-chain-sup',
+    sourceMemoryId: '17242c90-5922-51d8-b9bc-12b4f2cb558c',
+    memoryExcerpt:
+      'A bare hash-chained (keyless SHA-256) audit log gives NO tamper-evidence against an attacker with file-write access: they can shear events off the head, renumber survivors, and recompute every hash with no secret, and the file verifies clean. Real defenses: Ed25519-signed events, and out-of-band anchors that live OUTSIDE the file.',
+    claim:
+      'A keyless SHA-256 hash chain gives no tamper-evidence against an attacker with file-write access; real defenses are Ed25519-signed events and out-of-band anchors.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-audit-chain-unsup',
+    sourceMemoryId: '17242c90-5922-51d8-b9bc-12b4f2cb558c',
+    memoryExcerpt:
+      'A bare hash-chained (keyless SHA-256) audit log gives NO tamper-evidence against an attacker with file-write access: they can shear events off the head, renumber survivors, and recompute every hash with no secret, and the file verifies clean. Real defenses: Ed25519-signed events, and out-of-band anchors that live OUTSIDE the file.',
+    claim:
+      'A keyless SHA-256 hash chain by itself provides tamper-evidence against an attacker with file-write access.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 175fae90 — Structured Logging ------------------------- */
+  {
+    id: 'grd-structured-logging-sup',
+    sourceMemoryId: '175fae90-9df8-51f4-b4b6-0785e3671a95',
+    memoryExcerpt:
+      'Structured logging is a method of logging that formats log records as structured data, such as JSON. This approach includes fields like timestamp, level, logger, message, module, function, line number, exception info, custom attributes, correlation ID, and user context. Structured logging with correlation IDs and user context enables effective troubleshooting.',
+    claim:
+      'Structured logging formats log records as structured data such as JSON, with fields like timestamp and correlation ID, enabling effective troubleshooting.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-structured-logging-unsup',
+    sourceMemoryId: '175fae90-9df8-51f4-b4b6-0785e3671a95',
+    memoryExcerpt:
+      'Structured logging is a method of logging that formats log records as structured data, such as JSON. This approach includes fields like timestamp, level, logger, message, module, function, line number, exception info, custom attributes, correlation ID, and user context. Structured logging with correlation IDs and user context enables effective troubleshooting.',
+    claim:
+      'Structured logging writes records as XML documents indexed by syslog facility codes for retention.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 17c1f4fb — Fail-Closed Compliance --------------------- */
+  {
+    id: 'grd-fail-closed-sup',
+    sourceMemoryId: '17c1f4fb-938f-5ca1-85ca-d5b65d1aaf3c',
+    memoryExcerpt:
+      'DNC scrubbing is enforced on every outbound SMS with no exceptions or manual overrides, and the zip gate rejects out-of-area leads before enrichment spends money. This design ensures that any failure in the compliance system results in a blocked action.',
+    claim:
+      'DNC scrubbing runs on every outbound SMS with no manual overrides, and the zip gate rejects out-of-area leads before enrichment spends money.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-fail-closed-unsup',
+    sourceMemoryId: '17c1f4fb-938f-5ca1-85ca-d5b65d1aaf3c',
+    memoryExcerpt:
+      'DNC scrubbing is enforced on every outbound SMS with no exceptions or manual overrides, and the zip gate rejects out-of-area leads before enrichment spends money. This design ensures that any failure in the compliance system results in a blocked action.',
+    claim: 'Manual overrides of DNC scrubbing are allowed for individual outbound SMS exceptions.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 19a6d21a — Multi-Provider Router ---------------------- */
+  {
+    id: 'grd-provider-router-sup',
+    sourceMemoryId: '19a6d21a-f8c3-5c0e-b0bb-31826c9e425c',
+    memoryExcerpt:
+      'The router makes routing decisions based on configurable policies: cost (cheapest provider), latency (fastest based on rolling average), or preferred (priority list with automatic fallback). Retry logic distinguishes between transient failures (429 triggers immediate fallback, 500 gets one retry with exponential backoff) and permanent failures (401 logged without retry).',
+    claim:
+      'The router routes by cost, latency, or preferred policies; a 429 triggers immediate fallback while a 500 gets one retry with exponential backoff.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-provider-router-unsup',
+    sourceMemoryId: '19a6d21a-f8c3-5c0e-b0bb-31826c9e425c',
+    memoryExcerpt:
+      'The router makes routing decisions based on configurable policies: cost (cheapest provider), latency (fastest based on rolling average), or preferred (priority list with automatic fallback). Retry logic distinguishes between transient failures (429 triggers immediate fallback, 500 gets one retry with exponential backoff) and permanent failures (401 logged without retry).',
+    claim: 'A 500 triggers immediate fallback while a 429 gets 3 retries with exponential backoff.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 1a0cc872 — Read-once exfil guard (TOCTOU) ------------- */
+  {
+    id: 'grd-read-once-sup',
+    sourceMemoryId: '1a0cc872-c6b1-5177-abdf-c831624fddc9',
+    memoryExcerpt:
+      'Have the guard read the file ONCE and return that exact buffer for upload — never let guard read the file and upload read it again. A second read opens a TOCTOU gap where the scanned bytes differ from the sent bytes. Also: a blocked file must be treated as NON-retryable (dead-letter on first failure) since it won’t pass on retry.',
+    claim:
+      'The guard reads the file once and upload sends that exact scanned buffer, closing the TOCTOU gap between scanned bytes and sent bytes.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-read-once-unsup',
+    sourceMemoryId: '1a0cc872-c6b1-5177-abdf-c831624fddc9',
+    memoryExcerpt:
+      'Have the guard read the file ONCE and return that exact buffer for upload — never let guard read the file and upload read it again. A second read opens a TOCTOU gap where the scanned bytes differ from the sent bytes. Also: a blocked file must be treated as NON-retryable (dead-letter on first failure) since it won’t pass on retry.',
+    claim:
+      'A blocked file should be requeued for the next delivery cycle since transient guard failures usually clear themselves.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 1a615ecf — MCP Trust Boundaries ----------------------- */
+  {
+    id: 'grd-mcp-trust-sup',
+    sourceMemoryId: '1a615ecf-1660-5c84-866a-5d4bc7dfee4e',
+    memoryExcerpt:
+      'MCP is a powerful integration point but also a significant attack surface. An untrusted MCP server could inject misleading memories into the system. This is identified as a specific security threat in the project’s threat model.',
+    claim:
+      'An untrusted MCP server injecting misleading memories is identified as a specific threat in the threat model.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-mcp-trust-unsup',
+    sourceMemoryId: '1a615ecf-1660-5c84-866a-5d4bc7dfee4e',
+    memoryExcerpt:
+      'MCP is a powerful integration point but also a significant attack surface. An untrusted MCP server could inject misleading memories into the system. This is identified as a specific security threat in the project’s threat model.',
+    claim:
+      'The threat model concludes MCP servers are safe by default once installed from the official marketplace.',
+    label: 'unsupported',
+    perturbation: 'overreach',
+  },
+
+  /* ---------------- 1d5bc88e — Cross-family LLM judge --------------------- */
+  {
+    id: 'grd-cross-family-sup',
+    sourceMemoryId: '1d5bc88e-e3b5-5e1b-b52d-2235a69601e4',
+    memoryExcerpt:
+      'In LLM-as-judge A/B evals, a judge model reliably over-scores outputs from its own model family. The rule adopted: the cross-family judge is authoritative and a same-family judge’s verdict is treated as biased. Design eval grids so at least one judge is from a different model family than every candidate being scored.',
+    claim:
+      'A same-family judge’s verdict is treated as biased, and the cross-family judge is authoritative.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-cross-family-unsup',
+    sourceMemoryId: '1d5bc88e-e3b5-5e1b-b52d-2235a69601e4',
+    memoryExcerpt:
+      'In LLM-as-judge A/B evals, a judge model reliably over-scores outputs from its own model family. The rule adopted: the cross-family judge is authoritative and a same-family judge’s verdict is treated as biased. Design eval grids so at least one judge is from a different model family than every candidate being scored.',
+    claim:
+      'The same-family judge is authoritative, and the cross-family judge’s verdict is treated as biased.',
+    label: 'unsupported',
+    perturbation: 'argument-swap',
+    knownScorerMiss: true, // swap preserves the token set — v1's admitted blind spot
+  },
+
+  /* ---------------- 1d521c56 — Additive Layering -------------------------- */
+  {
+    id: 'grd-additive-layering-sup',
+    sourceMemoryId: '1d521c56-71e3-5672-9f2e-695f2076c032',
+    memoryExcerpt:
+      'The rubric honors all spec-defined fields with the same names, types, and value sets, but adds a required-field set for marketplace publication, stricter validation for loosely-accepted fields, and polish recommendations. This approach ensures that the rubric never replaces its required-field set with the spec’s floor.',
+    claim:
+      'Additive layering keeps every spec-defined field intact while adding a required-field set for marketplace publication and stricter validation.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-additive-layering-unsup',
+    sourceMemoryId: '1d521c56-71e3-5672-9f2e-695f2076c032',
+    memoryExcerpt:
+      'The rubric honors all spec-defined fields with the same names, types, and value sets, but adds a required-field set for marketplace publication, stricter validation for loosely-accepted fields, and polish recommendations. This approach ensures that the rubric never replaces its required-field set with the spec’s floor.',
+    claim:
+      'Additive layering replaces the rubric’s required-field set with the spec’s floor to stay aligned upstream.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 25126672 — Three-Layer Defense ------------------------ */
+  {
+    id: 'grd-three-layer-sup',
+    sourceMemoryId: '25126672-1d73-5016-bd8c-4142f41bf11a',
+    memoryExcerpt:
+      'The three-layer defense system protects dashboard pages through three layers: edge middleware checks for a session cookie at the CDN edge, the layout component verifies the Firebase ID token signature and expiration server-side, and page-level guards ensure the user ID matches the Firestore path being queried.',
+    claim:
+      'Dashboard pages are protected by three layers: an edge session-cookie check, server-side ID token verification, and page-level user-ID guards.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-three-layer-unsup',
+    sourceMemoryId: '25126672-1d73-5016-bd8c-4142f41bf11a',
+    memoryExcerpt:
+      'The three-layer defense system protects dashboard pages through three layers: edge middleware checks for a session cookie at the CDN edge, the layout component verifies the Firebase ID token signature and expiration server-side, and page-level guards ensure the user ID matches the Firestore path being queried.',
+    claim:
+      'The ID token signature is verified inside the browser client, skipping server-side verification for speed.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 264536af — Policy Engine ------------------------------ */
+  {
+    id: 'grd-policy-engine-sup',
+    sourceMemoryId: '264536af-60a3-563d-afd1-08adec3bec8f',
+    memoryExcerpt:
+      'The policy engine integrates with the audit journal and fail-closed decision flow, ensuring that tool calls are denied unless explicitly approved. Manifest data is never passed to policy evaluation because “advertisements are not grants”; policy decisions use only verified signals such as user_id, channel, and tool.',
+    claim:
+      'Manifest data is never passed to policy evaluation — advertisements are not grants — so decisions use only verified signals such as user_id and channel.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-policy-engine-unsup',
+    sourceMemoryId: '264536af-60a3-563d-afd1-08adec3bec8f',
+    memoryExcerpt:
+      'The policy engine integrates with the audit journal and fail-closed decision flow, ensuring that tool calls are denied unless explicitly approved. Manifest data is never passed to policy evaluation because “advertisements are not grants”; policy decisions use only verified signals such as user_id, channel, and tool.',
+    claim:
+      'Manifest data is passed into policy evaluation so rules can use each tool’s advertised capabilities.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+
+  /* ---------------- 2122e47a — Prompt Injection --------------------------- */
+  {
+    id: 'grd-prompt-injection-sup',
+    sourceMemoryId: '2122e47a-97e3-53f7-a1aa-08e6c400235b',
+    memoryExcerpt:
+      'Defense against prompt injection requires input sanitization, content boundary definition, instruction hierarchy, and output monitoring. Additional techniques include spotlighting (transforming input text to help AI systems distinguish between valid instructions and external inputs), delimiters and datamarking (marking boundaries between trusted and untrusted data).',
+    claim:
+      'Prompt-injection defense requires input sanitization, instruction hierarchy, and output monitoring, with techniques like spotlighting and datamarking.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-prompt-injection-unsup',
+    sourceMemoryId: '2122e47a-97e3-53f7-a1aa-08e6c400235b',
+    memoryExcerpt:
+      'Defense against prompt injection requires input sanitization, content boundary definition, instruction hierarchy, and output monitoring. Additional techniques include spotlighting (transforming input text to help AI systems distinguish between valid instructions and external inputs), delimiters and datamarking (marking boundaries between trusted and untrusted data).',
+    claim:
+      'Prompt injection is fully prevented by rate limiting and CAPTCHA challenges on the ingestion API.',
+    label: 'unsupported',
+    perturbation: 'wrong-component',
+  },
+
+  /* ---------------- 00ded0e5 — Multi-Agent AI Collaboration --------------- */
+  {
+    id: 'grd-multi-agent-sup',
+    sourceMemoryId: '00ded0e5-4f88-5d01-bda6-cf891eb95d31',
+    memoryExcerpt:
+      'In the context of technical writing, it involves three specialized roles: a Technical Content Specialist that transforms technical details into narrative, a Business Impact Analyzer that quantifies business value, and a Portfolio Optimization Specialist that optimizes for professional presentation. It can transform a complex technical project into a professional case study in under 30 minutes.',
+    claim:
+      'The technical-writing pattern uses three specialized roles and can turn a complex technical project into a professional case study in under 30 minutes.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-multi-agent-unsup',
+    sourceMemoryId: '00ded0e5-4f88-5d01-bda6-cf891eb95d31',
+    memoryExcerpt:
+      'In the context of technical writing, it involves three specialized roles: a Technical Content Specialist that transforms technical details into narrative, a Business Impact Analyzer that quantifies business value, and a Portfolio Optimization Specialist that optimizes for professional presentation. It can transform a complex technical project into a professional case study in under 30 minutes.',
+    claim:
+      'The technical-writing pattern uses seven specialized roles and needs about 90 minutes per case study.',
+    label: 'unsupported',
+    perturbation: 'inverted-number',
+  },
+
+  /* ---------------- 1a47f690 — Dependency Graph Publication Order --------- */
+  {
+    id: 'grd-publication-order-sup',
+    sourceMemoryId: '1a47f690-1356-5a46-b398-43ed626dcb33',
+    memoryExcerpt:
+      'Version ordering in monorepos is a dependency graph problem; packages must be published in topological order of their dependency graph, not alphabetical order. The release prep followed a checklist for each package: update package.json version, regenerate lockfile, update cross-package workspace references, write CHANGELOG entry, and verify build passes.',
+    claim:
+      'Monorepo packages are published in topological order of the dependency graph, with a per-package checklist covering version, lockfile, changelog, and build verification.',
+    label: 'supported',
+  },
+  {
+    id: 'grd-publication-order-unsup',
+    sourceMemoryId: '1a47f690-1356-5a46-b398-43ed626dcb33',
+    memoryExcerpt:
+      'Version ordering in monorepos is a dependency graph problem; packages must be published in topological order of their dependency graph, not alphabetical order. The release prep followed a checklist for each package: update package.json version, regenerate lockfile, update cross-package workspace references, write CHANGELOG entry, and verify build passes.',
+    claim:
+      'Publishing monorepo packages in alphabetical order is fine because the registry resolves workspace references at install time.',
+    label: 'unsupported',
+    perturbation: 'negation-flip',
+  },
+];

--- a/packages/eval-surface/src/groundedness/llm-judge.ts
+++ b/packages/eval-surface/src/groundedness/llm-judge.ts
@@ -1,0 +1,85 @@
+/**
+ * OPTIONAL offline LLM judge for the groundedness fixture — a COMPARISON ARM
+ * ONLY, never a gate (Wave-2 C2).
+ *
+ * ## Hard boundaries (the platform's no-LLM-in-gating rule)
+ *
+ *   - OFF in CI: `judgeFromEnv` returns `null` unless BOTH
+ *     `GROUNDEDNESS_LLM_JUDGE=minimax` and `MINIMAX_API_KEY` are set —
+ *     neither is ever configured in any workflow. Nothing in
+ *     `evaluateGroundedness`, the CI script, or any test imports this
+ *     module's network path.
+ *   - NEVER gates: the judge's verdicts are printed side by side with
+ *     scorer v1's for a human to compare (scripts/groundedness-judge-compare.ts,
+ *     run by hand). Disagreement is information about the deterministic
+ *     scorer's blind spots, not a pass/fail signal.
+ *
+ * The judge speaks the OpenAI-compatible chat-completions shape against the
+ * MiniMax API (base URL overridable via MINIMAX_BASE_URL).
+ */
+
+import type { GroundednessItem, GroundednessLabel } from './types.js';
+
+export interface GroundednessJudge {
+  readonly name: string;
+  judge(item: GroundednessItem): Promise<GroundednessLabel>;
+}
+
+const DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+const DEFAULT_MODEL = 'MiniMax-Text-01';
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * Build the judge from the environment, or `null` when not opted in.
+ * CI never sets these variables, so in CI this is always `null`.
+ */
+export function judgeFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): GroundednessJudge | null {
+  if (env['GROUNDEDNESS_LLM_JUDGE'] !== 'minimax') return null;
+  const apiKey = env['MINIMAX_API_KEY'];
+  if (apiKey === undefined || apiKey === '') return null;
+
+  const baseUrl = env['MINIMAX_BASE_URL'] ?? DEFAULT_BASE_URL;
+  const model = env['MINIMAX_MODEL'] ?? DEFAULT_MODEL;
+
+  return {
+    name: `minimax:${model}`,
+    async judge(item: GroundednessItem): Promise<GroundednessLabel> {
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          temperature: 0,
+          messages: [
+            {
+              role: 'system',
+              content:
+                'You judge whether a MEMORY excerpt supports a CLAIM. ' +
+                'Answer with exactly one word: SUPPORTED if the memory states or ' +
+                'directly entails the claim, UNSUPPORTED otherwise (wrong numbers, ' +
+                'swapped roles, flipped polarity, or material the memory never states).',
+            },
+            {
+              role: 'user',
+              content: `MEMORY:\n${item.memoryExcerpt}\n\nCLAIM:\n${item.claim}\n\nAnswer:`,
+            },
+          ],
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`LLM judge HTTP ${response.status}`);
+      }
+      const body = (await response.json()) as ChatCompletionResponse;
+      const text = body.choices?.[0]?.message?.content ?? '';
+      return /unsupported/i.test(text) ? 'unsupported' : 'supported';
+    },
+  };
+}

--- a/packages/eval-surface/src/groundedness/scorer.ts
+++ b/packages/eval-surface/src/groundedness/scorer.ts
@@ -1,0 +1,396 @@
+/**
+ * groundedness scorer v1 — DETERMINISTIC support-by-admitted-facts check
+ * (Wave-2 C2). Pure function, zero I/O, zero model calls; safe for CI by
+ * construction (the platform's rule: no LLM in any gating path).
+ *
+ * ## How it decides
+ *
+ * A claim is predicted `supported` by a memory excerpt iff ALL of:
+ *   1. NUMBERS — every quantity in the claim (digits, `5/5` ratios, dotted
+ *      versions, and the spelled numbers two…twelve; "one" is excluded as too
+ *      ambiguous a word) also appears in the memory. An inverted/absent
+ *      number is the strongest unsupported signal.
+ *   2. NEGATION POLARITY — no term is negated in one text but asserted
+ *      plainly in the other. Markers: not/never/no/without/avoid/…; scope =
+ *      the next {@link NEGATION_WINDOW} content token(s) WITHIN the same
+ *      clause (clauses split on punctuation, so "no results, it falls back"
+ *      does not leak the negation onto "falls back"). "Plainly asserted"
+ *      means: appears in a clause carrying NO negation marker; terms the
+ *      same text uses in both polarities are treated as unreliable and
+ *      skipped. An affix-antonym check (sufficient ↔ insufficient via
+ *      in-/un-/non- prefixes) covers flips that change the token itself.
+ *   3. TOKEN SUPPORT — at least `tokenSupportThreshold` of the claim's
+ *      distinct content tokens (stopwords and numbers excluded) are present
+ *      in the memory under light suffix-variant matching
+ *      (s/es/ed/ing, e.g. "importing" ↔ "import", "shared" ↔ "share").
+ *      Wrong-component claims introduce vocabulary the memory never admitted
+ *      and fall below the floor.
+ *
+ * ## Limits — stated honestly, measured in the fixture
+ *
+ * This attests support-by-admitted-facts, NOT truth and NOT entailment:
+ *   - An ARGUMENT SWAP ("local uses X, remote uses Y" → "local uses Y,
+ *     remote uses X") preserves tokens, numbers, and polarity — v1 cannot
+ *     see it. The fixture carries such items as documented scorer misses.
+ *   - Negation matching is variant-token-exact, so a flip whose vocabulary
+ *     fully drifts from the negated head can escape the polarity check and
+ *     is only caught if its token support also drops.
+ *   - A supported paraphrase that is TOO free (mostly novel vocabulary) can
+ *     fall below the token floor — a false "unsupported".
+ * The thresholds and window sizes were tuned on the v1 fixture itself
+ * (in-sample); treat the reported metrics accordingly. An env-gated LLM judge
+ * exists as an OFFLINE COMPARISON ARM ONLY (see ./llm-judge.ts) — it never
+ * runs in CI and never gates.
+ */
+
+import type { GroundednessPrediction } from './types.js';
+
+/** Default minimum fraction of claim content tokens the memory must admit. */
+export const DEFAULT_TOKEN_SUPPORT_THRESHOLD = 0.7;
+
+const NEGATION_MARKERS = new Set([
+  'not',
+  'never',
+  'no',
+  'none',
+  'cannot',
+  'cant',
+  'dont',
+  'doesnt',
+  'isnt',
+  'arent',
+  'wont',
+  'without',
+  'non',
+  'neither',
+  'nor',
+  'avoid',
+  'avoids',
+  'avoided',
+  'avoiding',
+]);
+
+/**
+ * Content tokens after a negation marker (same clause) inside its scope.
+ * Deliberately 1 — the immediate negated head. Wider windows drag object /
+ * prepositional tokens into the scope and mis-fire on paraphrases (measured
+ * on fixture v1: window 4 falsely flagged 14 supported paraphrases).
+ */
+const NEGATION_WINDOW = 1;
+
+/** Prefixes that flip a term's polarity in place (sufficient → insufficient). */
+const ANTONYM_PREFIXES = ['in', 'un', 'non'] as const;
+
+/** Minimum base-token length for the affix-antonym check (avoids side↔inside noise). */
+const ANTONYM_MIN_BASE = 4;
+
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'but',
+  'if',
+  'then',
+  'than',
+  'that',
+  'this',
+  'these',
+  'those',
+  'it',
+  'its',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'to',
+  'of',
+  'in',
+  'on',
+  'at',
+  'by',
+  'for',
+  'from',
+  'with',
+  'as',
+  'into',
+  'about',
+  'between',
+  'through',
+  'so',
+  'such',
+  'can',
+  'could',
+  'should',
+  'would',
+  'may',
+  'might',
+  'must',
+  'will',
+  'shall',
+  'do',
+  'does',
+  'did',
+  'has',
+  'have',
+  'had',
+  'he',
+  'she',
+  'they',
+  'we',
+  'you',
+  'i',
+  'their',
+  'his',
+  'her',
+  'our',
+  'your',
+  'each',
+  'every',
+  'all',
+  'any',
+  'some',
+  'both',
+  'more',
+  'most',
+  'other',
+  'own',
+  'same',
+  'which',
+  'what',
+  'when',
+  'where',
+  'while',
+  'who',
+  'whom',
+  'how',
+  'why',
+  'also',
+  'only',
+  'very',
+  'via',
+  'per',
+  'up',
+  'out',
+  'over',
+  'under',
+  's',
+  't',
+]);
+
+const NUMBER_WORDS: Record<string, string> = {
+  zero: '0',
+  two: '2',
+  three: '3',
+  four: '4',
+  five: '5',
+  six: '6',
+  seven: '7',
+  eight: '8',
+  nine: '9',
+  ten: '10',
+  eleven: '11',
+  twelve: '12',
+};
+
+/** Raw lowercase word tokens (letters+digits runs). */
+function rawTokens(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+/** Clause strings — negation scope never crosses these boundaries. */
+function clauses(text: string): string[] {
+  return text.split(/[.,;:()!?…]|—|–|\s-\s|\n/).filter((c) => c.trim().length > 0);
+}
+
+/**
+ * Light suffix-variant forms of a token (s/es/ed/ing with an `e`-restore for
+ * ed/ing), so "importing"→"import", "shared"→"share", "packages"→"package".
+ */
+function variantsOf(token: string): string[] {
+  const out = new Set([token]);
+  if (token.length > 3 && token.endsWith('s') && !token.endsWith('ss')) {
+    out.add(token.slice(0, -1));
+  }
+  if (token.length > 4 && token.endsWith('es')) out.add(token.slice(0, -2));
+  if (token.length > 4 && token.endsWith('ed')) {
+    out.add(token.slice(0, -2));
+    out.add(`${token.slice(0, -2)}e`);
+  }
+  if (token.length > 5 && token.endsWith('ing')) {
+    out.add(token.slice(0, -3));
+    out.add(`${token.slice(0, -3)}e`);
+  }
+  return [...out];
+}
+
+function isContentToken(t: string): boolean {
+  return !STOPWORDS.has(t) && !/^\d+$/.test(t) && !(t in NUMBER_WORDS) && !NEGATION_MARKERS.has(t);
+}
+
+/** All variant forms of every content token in a text. */
+function variantSet(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const t of rawTokens(text)) {
+    if (!isContentToken(t)) continue;
+    for (const v of variantsOf(t)) out.add(v);
+  }
+  return out;
+}
+
+/** Does `token` (any of its variant forms) appear in a variant set? */
+function inVariantSet(token: string, set: ReadonlySet<string>): boolean {
+  return variantsOf(token).some((v) => set.has(v));
+}
+
+/**
+ * Quantities in a text: digit runs incl. `5/5` ratios and dotted versions
+ * (`1.2.3` contributes itself plus its segments), and spelled two…twelve.
+ */
+export function extractNumbers(text: string): Set<string> {
+  const out = new Set<string>();
+  const lower = text.toLowerCase();
+  for (const m of lower.match(/\d+(?:[./]\d+)*[a-z]?/g) ?? []) {
+    out.add(m);
+    for (const part of m.split(/[./]/)) out.add(part);
+  }
+  for (const t of rawTokens(lower)) {
+    const mapped = NUMBER_WORDS[t];
+    if (mapped !== undefined) out.add(mapped);
+  }
+  return out;
+}
+
+/** Content terms inside the (clause-bounded) scope of a negation marker. */
+export function negatedTerms(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const clause of clauses(text)) {
+    const tokens = rawTokens(clause);
+    for (let i = 0; i < tokens.length; i++) {
+      if (!NEGATION_MARKERS.has(tokens[i]!)) continue;
+      let collected = 0;
+      for (let j = i + 1; j < tokens.length && collected < NEGATION_WINDOW; j++) {
+        const t = tokens[j]!;
+        if (!isContentToken(t)) continue;
+        out.add(t);
+        collected++;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Terms PLAINLY asserted by a text: content tokens of clauses that carry no
+ * negation marker at all. Deliberately conservative — a term that only ever
+ * appears near a negation is not "plainly asserted".
+ */
+function plainTerms(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const clause of clauses(text)) {
+    const tokens = rawTokens(clause);
+    if (tokens.some((t) => NEGATION_MARKERS.has(t))) continue;
+    for (const t of tokens) {
+      if (isContentToken(t)) out.add(t);
+    }
+  }
+  return out;
+}
+
+/**
+ * Affix-antonym mismatches: a term one text asserts whose in-/un-/non-
+ * prefixed form the other text carries (sufficient ↔ insufficient). Skipped
+ * when either text carries BOTH forms (unreliable).
+ */
+function affixMismatches(
+  claimTokens: ReadonlySet<string>,
+  memoryTokens: ReadonlySet<string>,
+): string[] {
+  const out: string[] = [];
+  const flipped = (base: string, from: ReadonlySet<string>): boolean =>
+    ANTONYM_PREFIXES.some((p) => from.has(`${p}${base}`));
+  for (const t of claimTokens) {
+    if (t.length < ANTONYM_MIN_BASE) continue;
+    // claim asserts `t`, memory only carries its prefixed antonym (or vice versa)
+    if (flipped(t, memoryTokens) && !memoryTokens.has(t) && !flipped(t, claimTokens)) {
+      out.push(t);
+    }
+  }
+  for (const t of memoryTokens) {
+    if (t.length < ANTONYM_MIN_BASE) continue;
+    if (flipped(t, claimTokens) && !claimTokens.has(t) && !flipped(t, memoryTokens)) {
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+export interface ScoreOptions {
+  /** Override the token-support floor (default {@link DEFAULT_TOKEN_SUPPORT_THRESHOLD}). */
+  readonly tokenSupportThreshold?: number;
+}
+
+/** Score one (claim, memoryExcerpt) pair. Deterministic and pure. */
+export function scoreGroundedness(
+  claim: string,
+  memoryExcerpt: string,
+  options: ScoreOptions = {},
+): GroundednessPrediction {
+  const threshold = options.tokenSupportThreshold ?? DEFAULT_TOKEN_SUPPORT_THRESHOLD;
+
+  // 1. Numbers: every claim quantity must be admitted by the memory.
+  const memoryNumbers = extractNumbers(memoryExcerpt);
+  const numberMismatches = [...extractNumbers(claim)].filter((n) => !memoryNumbers.has(n));
+
+  // 2. Negation polarity, both directions (variant-matched, clause-bounded,
+  //    mixed-polarity terms skipped as unreliable).
+  const memoryVariants = variantSet(memoryExcerpt);
+  const memNeg = negatedTerms(memoryExcerpt);
+  const claimNeg = negatedTerms(claim);
+  const memNegVariants = new Set([...memNeg].flatMap(variantsOf));
+  const claimNegVariants = new Set([...claimNeg].flatMap(variantsOf));
+  const memPlain = new Set([...plainTerms(memoryExcerpt)].flatMap(variantsOf));
+  const claimPlain = new Set([...plainTerms(claim)].flatMap(variantsOf));
+  const negationMismatches = [
+    // claim plainly asserts a term the memory negates (and never plainly uses)
+    ...[...memNeg].filter(
+      (t) =>
+        !inVariantSet(t, memPlain) && // memory's own polarity must be unmixed
+        inVariantSet(t, claimPlain) &&
+        !inVariantSet(t, claimNegVariants),
+    ),
+    // claim negates a term the memory plainly asserts (and never negates)
+    ...[...claimNeg].filter(
+      (t) =>
+        !inVariantSet(t, claimPlain) && // claim's own polarity must be unmixed
+        inVariantSet(t, memPlain) &&
+        !inVariantSet(t, memNegVariants),
+    ),
+    // affix antonyms: sufficient ↔ insufficient shaped flips
+    ...affixMismatches(
+      new Set(rawTokens(claim).filter(isContentToken)),
+      new Set(rawTokens(memoryExcerpt).filter(isContentToken)),
+    ),
+  ];
+
+  // 3. Token support: fraction of DISTINCT claim content tokens the memory admits.
+  const distinct = [...new Set(rawTokens(claim).filter(isContentToken))];
+  const admitted = distinct.filter((t) => inVariantSet(t, memoryVariants)).length;
+  const tokenSupport = distinct.length === 0 ? 1 : admitted / distinct.length;
+
+  const predicted =
+    numberMismatches.length === 0 && negationMismatches.length === 0 && tokenSupport >= threshold
+      ? 'supported'
+      : 'unsupported';
+
+  return {
+    predicted,
+    tokenSupport: Number(tokenSupport.toFixed(4)),
+    numberMismatches,
+    negationMismatches,
+  };
+}

--- a/packages/eval-surface/src/groundedness/types.ts
+++ b/packages/eval-surface/src/groundedness/types.ts
@@ -1,0 +1,108 @@
+/**
+ * groundedness eval types — the labeled fixture schema and report shapes for
+ * the FAITHFULNESS/SUPPORT eval (Wave-2 C2).
+ *
+ * ## What this eval measures — and what it does NOT
+ *
+ * Given an (answer-like claim, supporting memory excerpt) pair, does the
+ * memory actually SUPPORT the claim? The scorer attests
+ * **support-by-admitted-facts**: whether the claim's material (terms, numbers,
+ * polarity) is present in the cited memory text. It does NOT attest truth —
+ * a memory can be wrong and still "support" a claim that faithfully restates
+ * it. This is an eval OF the eval surface (does citation-backed answering
+ * stay anchored to what the cited memory says), not an oracle.
+ *
+ * ## Fixture provenance — semi-synthetic-from-real, stated honestly
+ *
+ * The `memoryExcerpt` of every item is REAL: verbatim text sampled from
+ * promoted memories in the live brain's kb-export (innocuous technical /
+ * architectural memories only; anything credential- or person-shaped was
+ * excluded during selection). The `claim`s are SYNTHETIC: authored for this
+ * fixture — each memory yields one supported claim (a paraphrase of the
+ * excerpt) and one unsupported claim (plausible but not in the excerpt: an
+ * inverted number, a wrong component/mechanism, a flipped negation, a swapped
+ * argument, or an overreach). `sourceMemoryId` is the export UUID for
+ * provenance. Labels are by-construction ground truth (the author knows which
+ * claim was derived how); scorer thresholds were then tuned on THIS fixture,
+ * so reported metrics are in-sample fit, not held-out generalization — a
+ * held-out set is future work and the numbers must be read with that caveat.
+ */
+
+/** Ground-truth label of a fixture item. */
+export type GroundednessLabel = 'supported' | 'unsupported';
+
+/** How an unsupported claim was derived from its memory (documentation only). */
+export type Perturbation =
+  | 'inverted-number' // a quantity changed to a value the memory does not carry
+  | 'wrong-component' // mechanism/component replaced with a plausible other
+  | 'negation-flip' // the memory's polarity inverted (allowed → forbidden, …)
+  | 'argument-swap' // two roles/arguments exchanged, vocabulary unchanged
+  | 'overreach'; // plausible conclusion the memory never states
+
+/** One labeled (claim, memory-excerpt) pair. */
+export interface GroundednessItem {
+  /** Stable, human-readable id, e.g. `grd-confused-deputy-sup`. Unique in the set. */
+  readonly id: string;
+  /** kb-export UUID of the real promoted memory the excerpt came from. */
+  readonly sourceMemoryId: string;
+  /** Verbatim excerpt (1–3 sentences) of the real memory. */
+  readonly memoryExcerpt: string;
+  /** The answer-like claim to be checked against the excerpt. */
+  readonly claim: string;
+  /** Ground truth: does the excerpt support the claim? */
+  readonly label: GroundednessLabel;
+  /** For unsupported items: how the claim was perturbed. */
+  readonly perturbation?: Perturbation;
+  /**
+   * True when scorer v1 is EMPIRICALLY CONFIRMED to get this item wrong today
+   * (a documented limitation — e.g. argument swaps preserve the token set, so
+   * a token-overlap scorer cannot see them). Documented misses are reported,
+   * never hidden; an UNDOCUMENTED wrong prediction fails the eval closed.
+   */
+  readonly knownScorerMiss?: boolean;
+}
+
+/** Scorer v1's verdict on one item. */
+export interface GroundednessPrediction {
+  readonly predicted: GroundednessLabel;
+  /** Fraction of the claim's content tokens present in the memory (after light stemming). */
+  readonly tokenSupport: number;
+  /** Claim numbers absent from the memory (each one is an unsupported signal). */
+  readonly numberMismatches: readonly string[];
+  /** Terms whose negation polarity differs between claim and memory. */
+  readonly negationMismatches: readonly string[];
+}
+
+/** One scorer error (prediction != label). */
+export interface GroundednessError {
+  readonly itemId: string;
+  readonly label: GroundednessLabel;
+  readonly predicted: GroundednessLabel;
+  readonly perturbation?: Perturbation;
+  /** True when the item's `knownScorerMiss` already documents this error. */
+  readonly documented: boolean;
+}
+
+/** The full groundedness report (attached to EvaluatorResult details as JSON). */
+export interface GroundednessReport {
+  readonly fixtureVersion: string;
+  readonly totalItems: number;
+  readonly supportedItems: number;
+  readonly unsupportedItems: number;
+  /** Of items predicted `supported`, the fraction actually labeled supported. */
+  readonly supportedPrecision: number;
+  /** Of items labeled `supported`, the fraction predicted supported. */
+  readonly supportedRecall: number;
+  /** Of items labeled `unsupported`, the fraction predicted unsupported. */
+  readonly unsupportedCatchRate: number;
+  /** Mean of supportedRecall and unsupportedCatchRate. */
+  readonly balancedAccuracy: number;
+  /** Per-perturbation catch counts for the unsupported segment. */
+  readonly perPerturbation: ReadonlyArray<{
+    readonly perturbation: Perturbation;
+    readonly items: number;
+    readonly caught: number;
+  }>;
+  readonly errors: readonly GroundednessError[];
+  readonly undocumentedErrors: readonly GroundednessError[];
+}

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -39,7 +39,10 @@ export type {
   FalseNegative,
   GovernDecisionReport,
 } from './govern-decision/types.js';
-export { evaluateDecisionCases } from './govern-decision/decision-eval.js';
+export {
+  evaluateDecisionCases,
+  DECISION_PRECISION_FLOORS,
+} from './govern-decision/decision-eval.js';
 export {
   DECISION_CASES,
   DECISION_DATASET_VERSION,
@@ -51,6 +54,7 @@ export type {
   DecisionCheckMetrics,
   DecisionClassMetrics,
   DecisionFalseNegative,
+  DecisionFalsePositive,
   DecisionCasesReport,
 } from './govern-decision/decision-types.js';
 export {

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -53,4 +53,23 @@ export type {
   DecisionFalseNegative,
   DecisionCasesReport,
 } from './govern-decision/decision-types.js';
+export {
+  evaluateGroundedness,
+  GROUNDEDNESS_FLOORS,
+  type GroundednessOptions,
+} from './groundedness.js';
+export { scoreGroundedness, DEFAULT_TOKEN_SUPPORT_THRESHOLD } from './groundedness/scorer.js';
+export {
+  FIXTURE_VERSION as GROUNDEDNESS_FIXTURE_VERSION,
+  GROUNDEDNESS_ITEMS,
+} from './groundedness/fixture/v1/index.js';
+export { judgeFromEnv, type GroundednessJudge } from './groundedness/llm-judge.js';
+export type {
+  GroundednessItem,
+  GroundednessLabel,
+  GroundednessPrediction,
+  GroundednessError,
+  GroundednessReport,
+  Perturbation,
+} from './groundedness/types.js';
 export type { EvaluatorResult, RetrievalProbe, DedupProbe } from './types.js';

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -39,4 +39,18 @@ export type {
   FalseNegative,
   GovernDecisionReport,
 } from './govern-decision/types.js';
+export { evaluateDecisionCases } from './govern-decision/decision-eval.js';
+export {
+  DECISION_CASES,
+  DECISION_DATASET_VERSION,
+} from './govern-decision/decision-dataset/v1/index.js';
+export type {
+  DecisionCase,
+  DecisionCheck,
+  DecisionClass,
+  DecisionCheckMetrics,
+  DecisionClassMetrics,
+  DecisionFalseNegative,
+  DecisionCasesReport,
+} from './govern-decision/decision-types.js';
 export type { EvaluatorResult, RetrievalProbe, DedupProbe } from './types.js';

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -19,6 +19,7 @@ export { PolicyPipeline } from './pipeline.js';
 export {
   detectSupersession,
   computeTitleSimilarity,
+  DEFAULT_SUPERSESSION_THRESHOLD,
 } from './supersession/supersession-detector.js';
 export type {
   SupersessionMatch,

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -17,6 +17,14 @@ export { evaluateContentSanitization } from './rules/content-sanitization-rule.j
 export { evaluateContradictionCheck } from './rules/contradiction-check-rule.js';
 export { PolicyPipeline } from './pipeline.js';
 export {
+  detectSupersession,
+  computeTitleSimilarity,
+} from './supersession/supersession-detector.js';
+export type {
+  SupersessionMatch,
+  SupersessionMemorySource,
+} from './supersession/supersession-detector.js';
+export {
   RECOMMENDED_POLICY_RULES,
   buildRecommendedPolicy,
   findUncoveredRuleTypes,

--- a/packages/policy-engine/src/supersession/supersession-detector.ts
+++ b/packages/policy-engine/src/supersession/supersession-detector.ts
@@ -1,0 +1,98 @@
+import type { MemoryCandidate, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+
+/** A curated memory that may be superseded by the incoming candidate */
+export interface SupersessionMatch {
+  supersededMemoryId: string;
+  supersededTitle: string;
+  similarity: number;
+}
+
+/**
+ * The minimal read surface {@link detectSupersession} needs: "give me the
+ * active memories of this tenant". `@qmd-team-intent-kb/store`'s
+ * `MemoryRepository` satisfies it structurally — the interface exists so this
+ * detector can live in policy-engine (a package) without importing the store,
+ * keeping the package layer store-free while every caller keeps passing the
+ * real repository.
+ */
+export interface SupersessionMemorySource {
+  findByTenantAndLifecycle(
+    tenantId: string,
+    lifecycle: MemoryLifecycleState,
+  ): ReadonlyArray<{ readonly id: string; readonly title: string; readonly category: string }>;
+}
+
+/**
+ * Detects whether an incoming candidate should supersede an existing active
+ * curated memory, using Jaccard similarity on title word tokens within the
+ * same category and tenant.
+ *
+ * Only active memories in the same category as the candidate are considered.
+ * When multiple memories meet the threshold the one with the highest similarity
+ * is returned; ties are broken by whichever was found first.
+ *
+ * Moved here from `apps/curator` (Wave-2 C3) so the govern-decision eval — a
+ * package — can score the REAL detector without a package→app import (the
+ * dependency-cruiser `no-package-depends-on-app` invariant). The curator
+ * re-exports it unchanged, so every production call site is still this exact
+ * function.
+ *
+ * @param threshold - Minimum Jaccard similarity (0.0–1.0) to consider a match.
+ *                   Defaults to 0.6.
+ * @returns The best-matching memory above the threshold, or null if none found.
+ */
+export function detectSupersession(
+  candidate: MemoryCandidate,
+  memorySource: SupersessionMemorySource,
+  threshold: number = 0.6,
+): SupersessionMatch | null {
+  const existingMemories = memorySource
+    .findByTenantAndLifecycle(candidate.tenantId, 'active')
+    .filter((m) => m.category === candidate.category);
+
+  let bestMatch: SupersessionMatch | null = null;
+
+  for (const memory of existingMemories) {
+    const similarity = computeTitleSimilarity(candidate.title, memory.title);
+    if (similarity >= threshold && (bestMatch === null || similarity > bestMatch.similarity)) {
+      bestMatch = {
+        supersededMemoryId: memory.id,
+        supersededTitle: memory.title,
+        similarity,
+      };
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Computes Jaccard similarity between two strings using word-level tokenization.
+ *
+ * Jaccard similarity = |intersection| / |union|
+ *
+ * Both strings are lower-cased and split on whitespace. Empty strings produce
+ * 1.0 when both are empty (identical) and 0.0 when only one is empty.
+ */
+export function computeTitleSimilarity(a: string, b: string): number {
+  const tokensA = new Set(tokenize(a));
+  const tokensB = new Set(tokenize(b));
+
+  if (tokensA.size === 0 && tokensB.size === 0) return 1.0;
+  if (tokensA.size === 0 || tokensB.size === 0) return 0.0;
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) intersection++;
+  }
+
+  const union = tokensA.size + tokensB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}

--- a/packages/policy-engine/src/supersession/supersession-detector.ts
+++ b/packages/policy-engine/src/supersession/supersession-detector.ts
@@ -1,5 +1,13 @@
 import type { MemoryCandidate, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 
+/**
+ * The production default title-similarity threshold for supersession
+ * detection. Single source of truth — the curator, the API promotion service,
+ * and the govern-decision eval all consume THIS constant, so the eval can
+ * never silently measure a different threshold than production runs.
+ */
+export const DEFAULT_SUPERSESSION_THRESHOLD = 0.6;
+
 /** A curated memory that may be superseded by the incoming candidate */
 export interface SupersessionMatch {
   supersededMemoryId: string;
@@ -38,13 +46,13 @@ export interface SupersessionMemorySource {
  * function.
  *
  * @param threshold - Minimum Jaccard similarity (0.0–1.0) to consider a match.
- *                   Defaults to 0.6.
+ *                   Defaults to {@link DEFAULT_SUPERSESSION_THRESHOLD}.
  * @returns The best-matching memory above the threshold, or null if none found.
  */
 export function detectSupersession(
   candidate: MemoryCandidate,
   memorySource: SupersessionMemorySource,
-  threshold: number = 0.6,
+  threshold: number = DEFAULT_SUPERSESSION_THRESHOLD,
 ): SupersessionMatch | null {
   const existingMemories = memorySource
     .findByTenantAndLifecycle(candidate.tenantId, 'active')


### PR DESCRIPTION
## What

GSB Wave-2 tracks C2, C3, and C5 in one branch (four logical commits):

- **C2 — groundedness layer** (`packages/eval-surface/src/groundedness*`): a new eval scoring FAITHFULNESS/SUPPORT — given an answer-like claim and a memory excerpt, does the memory actually support the claim? Ships fixture v1 (60 labeled items from 30 real promoted memories), deterministic scorer v1, segmented reporting, a fail-closed `groundedness:ci` gate wired into nightly.yml, and an env-gated MiniMax LLM-judge scaffold that is an offline comparison arm only.
- **C3 — govern-decision decision classes** (`packages/eval-surface/src/govern-decision/decision-*`): the govern-decision eval's labeled set now covers dedup, contradiction, and supersession cases wired through the REAL machinery (in-memory store + production `PolicyPipeline` with `dedup_check` + the Phase-1 `contradiction_check` rule + the real `detectSupersession`), with the precision/recall report broken out per check AND per relationship class, folded into the existing fail-closed CI gate.
- **Enabling refactor**: the supersession detector moved from `apps/curator` into `packages/policy-engine` (curator re-exports it unchanged) so a package-layer eval can score the real detector without violating the depcruise `no-package-depends-on-app` invariant.
- **C5 — grounding audit doc** (`000-docs/048-TQ-AUDT`): enumerates all eight improvement loops with their anchor, gate, and anchor location; loops without a real anchor are listed as DEFECTS with proposed bead titles (no beads created).

## Why + decision rationale

Retrieval evals measure whether the right memory comes back; nothing measured whether what gets said on top stays anchored to it (C2), and the three state-dependent govern decisions passed vacuously whenever context wiring broke, invisible to the existing adversarial set (C3). Chose a **deterministic scorer over an LLM judge for the C2 gate** because no LLM may sit in any CI-gating or serving path; chose **wiring C3 through the real store/pipeline/detector over stubs** because a stubbed detector cannot regress with production code; chose **extracting the supersession detector into policy-engine over duplicating it** because a copy would silently drift from the production decision (the depcruise config itself prescribes extraction).

## Layers touched + invariant note

`packages/eval-surface` (eval layer, pure/no durable state), `packages/policy-engine` (gains the supersession detector behind a minimal `SupersessionMemorySource` interface — stays store-free), `apps/curator` (re-export shim only; public surface unchanged), `.github/workflows/nightly.yml` (one new step), `000-docs`. No serving-path behavior changes; the govern write path remains LLM-free; no `.beads/` changes.

## How it works

- **C2 scorer v1** predicts `supported` iff: every claim quantity appears in the memory (digits, ratios, spelled two–twelve); no negation-polarity mismatch (clause-bounded window-1 scopes, plain-clause assertion sets, mixed-polarity guards, in/un/non affix-antonym check); and ≥0.7 of the claim's content tokens are admitted by the memory under light suffix-variant matching. It attests support-by-admitted-facts, not truth — stated in the module docs.
- **C2 fixture** is semi-synthetic-from-real: verbatim excerpts of 30 innocuous technical/architectural promoted memories (kb-export UUID recorded per item; anything credential- or person-shaped excluded at selection), with synthetically authored supported/unsupported claim pairs (perturbations: inverted-number, wrong-component, negation-flip, argument-swap, overreach).
- **C3 runner** seeds each case's existing actives into a real in-memory store via `MemoryRepository.insert`, builds the pipeline context exactly the way the curator does (`existingHashes`, live category-scoped `getActiveMemoriesInCategory`), evaluates through `PolicyPipeline.evaluate`, and calls the real `detectSupersession` at the production 0.6 threshold.
- Both gates keep the established contract: fail closed on any UNDOCUMENTED false-negative/error; documented gaps are reported, never hidden.

## Verification & evidence

- Full suite: **2211/2211 tests, 183 files** green (`pnpm validate`: format:check + lint + typecheck + tests). `pnpm depcruise`: 0 errors (warn count unchanged vs main). `pnpm harness-pin`: OK. Honesty lint passes on the new doc.
- **Measured groundedness numbers** (fixture v1.0.0, scorer v1 — floors committed FROM this run):
  - supported-precision **0.8824** (floor 0.88) · supported-recall **1.0000** · unsupported-catch-rate **0.8667** (floor 0.86) · balanced accuracy **0.9334**
  - per-perturbation catch: inverted-number **8/8**, wrong-component **7/7**, negation-flip **10/11**, argument-swap **0/3**, overreach **1/1** — the 4 misses are fixture-documented scorer limitations (3 swaps preserve the token set; 1 distant negation beyond the window-1 scope), pinned by tests.
- **Measured C3 decision numbers** (decision-dataset v1.1.0, re-measured after the review-round relabel of the compatible restatement to a KNOWN false positive): dedup-rule P=1.0 R=0.667 · contradiction-rule P=0.75 R=0.60 · supersession-detector P=1.0 R=0.75; class catch-rates: duplicate **0.80**, contradiction **0.50**, supersession **0.667**; zero undocumented FNs, 1 KNOWN FP (contra-restated-01/contradiction-rule, counted against precision), 0 undocumented FPs; per-check precision floors measured-then-committed (dedup 1.0 / contradiction 0.75 / supersession 1.0) and gated. Documented gaps: exact-hash dedup misses a re-cased duplicate; token-overlap contradiction misses low-overlap and cross-category contradictions; title-Jaccard supersession misses a reworded title.
- `ci-govern-decision.ts` and `ci-groundedness.ts` both exit 0 locally printing the full breakouts.

## Risk assessment

- Low: eval-surface is measurement-only (no durable state, no serving path). The one production-adjacent change is the supersession-detector move — mitigated by a byte-equivalent implementation behind a structural interface, a curator re-export shim keeping every import path alive, and the existing curator/api suites passing (279/279 curator).
- C2 metrics are in-sample (scorer tuned on the same fixture) — disclosed in the module docs and listed as DEFECT G2 in 048-TQ-AUDT; the gate still catches regressions deterministically.
- The nightly gains one step; a groundedness regression fails nightly, not PRs (mirrors the intended C2 scope).

## Operational impact

None to deploys/env/migrations/secrets. No new dependencies. The LLM judge requires explicit `GROUNDEDNESS_LLM_JUDGE=minimax` + `MINIMAX_API_KEY` env opt-in that no workflow sets (tested off-by-default). The live brain `~/.teamkb` was read-only sampled for fixture authoring; nothing writes to it.

## Follow-up & deferred (proposed beads, not created)

- Run the Stryker mutation suite on a schedule and fail the run when the committed break threshold is not met (048-TQ-AUDT DEFECT G1).
- Author a held-out groundedness validation set independently of scorer tuning and report both in-sample and held-out numbers (DEFECT G2).
- Publish a freshness heartbeat from the brain-host eval timers that a repo-side check can verify (DEFECT G3).
- Converge the boundary filter with the collapse/decode secret-scan passes (pre-existing documented gap, restated by the C3 report).

## Governance links

- GSB blueprint Wave-2 tracks C2/C3/C5 (umbrella `bobs-big-brain-umbrella` cited development blueprint).
- 000-docs/048-TQ-AUDT (this PR) — the loop/anchor inventory.
- Honesty law respected throughout: tamper-evident (never -proof), qualified append-only claims, no LLM in gating paths.

**Refs:** Wave-2 epic #287 (beads qmd-team-intent-kb-5uq C2/C3/C5)

**Merge-order note:** doc 046 is claimed by four parallel branches; #300 (B1) keeps 046, then this and #298/#299 renumber at merge time.

## Review round 1 (coordinator findings, addressed on-branch)

1. **Known-FP lane (finding 1, accepted):** `contra-restated-01` relabeled contradiction→clean under decision-dataset v1.1.0 with `knownFalsePositiveOf: ['contradiction-rule']` — the heuristic's firing now counts against precision as a DOCUMENTED false positive instead of inflating contradiction recall; the precision invariant is a measured-then-committed per-check floor (`DECISION_PRECISION_FLOORS`), fail-closed on any new clean-case firing. Contradiction recall dropped to its true value (0.60; class catch 0.50) — that is the point.
2. **Threshold single-source (finding 2):** `DEFAULT_SUPERSESSION_THRESHOLD` exported from the policy-engine supersession module and consumed by the detector default, curator, the API promotion service, and the decision eval — the 0.6 literal no longer exists at any call site.
3. **Rebase + renumber:** rebased onto main (post-#298); the grounding audit doc renumbered 046→047→048-TQ-AUDT across two rebases (046 taken by merged #298, 047 by merged #299; 048 assigned centrally, 049 reserved for another in-flight PR).

Gates after the round: 2219/2219 tests, typecheck/lint/format clean, depcruise 0 errors, both eval CI scripts exit 0.


