### PR TITLE
feat(provenance): verify HMAC origin tokens before promotion and allowlist capture channels (GSB Wave-2 H1–H3)

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -55,6 +55,7 @@
 - `045-OD-RNBK-anchor-remote-divergence-recovery.md` — Anchor remote divergence recovery: the private anchor-witness remote (`bobs-big-brain-anchors`, force-push-blocked), the fetch/status divergence check, per-state recovery (ahead = plain push; behind/diverged = investigate with the HISTORY_REWRITTEN tooling before ANY reconciliation), honest trust framing (detectable, not impossible)
 - `046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md` — Substrate-boundary doctrine: the ICO trace chain proves COMPILE, the INTKB audit chain proves GOVERN admission; neither proves the other's claims (nor content truth); the spool manifest SHA-256 + UUID-v5 id lineage are the bridge; walked end-to-end by `curator-cli provenance-walk`
 - `047-OD-RNBK-merge-govern-and-anchor-receipts-runbook.md` — merge-govern operator runbook (Wave-2 E3/F3/F4): when/how to run the govern-at-merge CLI, what it does NOT do, signed merge-anchor key custody + rotation (SOPS-encrypted private / committed public), and the opt-in OpenTimestamps receipt for anchor heads with its honest network/trust limits
+- `049-AT-DECR-write-time-provenance-origin-tokens.md` — Write-time provenance (GSB Wave-2 H1–H5): HMAC-SHA256 origin tokens over (id, tenantId, capturedAt) keyed by the 0600 `~/.teamkb/origin-secret`, verified structurally before promotion (`origin_token_invalid` receipted reject), accept-with-`unattested` backward compatibility, team-API channel allowlist (`unrecognized_channel` 422), local-mode channel attestation out of scope v1, honest insider-poisoning residual
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
 - `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)
@@ -122,5 +123,6 @@
 | 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0                     | v0.7.0 release report            |
 | 040 | OD-OPSM | brain-api-tailnet-deploy                              | Brain API tailnet deploy runbook |
 | 048 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
+| 049 | AT-DECR | write-time-provenance-origin-tokens                   | Origin-token decision record     |
 
-## Next Available Sequence: 049
+## Next Available Sequence: 051

--- a/000-docs/049-AT-DECR-write-time-provenance-origin-tokens.md
+++ b/000-docs/049-AT-DECR-write-time-provenance-origin-tokens.md
@@ -1,0 +1,116 @@
+# Decision Record — Write-time provenance origin tokens (GSB Wave-2, tracks H1–H5)
+
+**Date:** 2026-07-19
+**Status:** Ratified (shipped with the H1–H5 change set)
+**Scope:** Registrar (`packages/schema`, `packages/common`, `packages/store`, `apps/curator`, `apps/api`, `apps/edge-daemon`) + the plugin (`bobs-big-brain-plugin`) capture paths + the compiler's vendored contract snapshot.
+
+## Decision
+
+Every capture may carry a verifiable **origin**: an HMAC-SHA256 token minted at
+capture time over the candidate identity tuple `(id, tenantId, capturedAt)`,
+keyed by a **per-installation secret**. The govern/promotion path (curator batch
+sweep AND the API single-candidate promote) verifies the token **before**
+promotion. An invalid claim is a **receipted, policy-pipeline-shaped reject**
+(`origin_token_invalid`), never a crash.
+
+### Verdict table (v1 — the load-bearing choices)
+
+| Candidate state                                                        | Outcome                                                                        | Why                                                                                                                                                                                                                                         |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No `origin` at all                                                     | **Accepted**, promotion receipt records channel `unattested`                   | Backward compatibility. Every pre-H1 spool line, ICO emission, and legacy capture carries no origin; a hard-reject flag-day would orphan **all** of them. The gap stays _visible_ on every receipt instead of silently passing as attested. |
+| `origin` present, HMAC verifies                                        | Accepted, receipt records channel + truncated token hash (H2)                  | The attestation held.                                                                                                                                                                                                                       |
+| `origin` present, HMAC mismatch                                        | **Reject** `origin_token_invalid` (receipted; 422 with stable code on the API) | Forged / replayed across identities / minted under a different secret.                                                                                                                                                                      |
+| `origin` present, govern path has no secret                            | **Reject** `origin_token_unverifiable` (fail-closed)                           | A claimed attestation we cannot check must not promote as if it verified.                                                                                                                                                                   |
+| `origin.channel` not on the deployment allowlist (team API intake, H3) | **422** with stable code `unrecognized_channel`                                | Only an _explicit claim_ of an unknown channel is refused; origin-less captures skip the check.                                                                                                                                             |
+
+**Honest framing of the accept-with-`unattested` choice:** this is a
+compatibility posture, not a security claim. Until a deployment's clients all
+mint origins, an attacker who can write to the spool/API can simply omit
+`origin` and be governed as an unattested candidate — exactly like every write
+before H1. What H1 adds is (a) a _positive_ attestation channel whose forgery is
+detectable and receipted, and (b) receipt-level visibility (`unattested`) of
+which promotions lack it, so a future flag-day (reject-unattested) can be
+data-driven per deployment.
+
+## Identity-tuple binding and id stability
+
+The spool contract is **UUID-v5 content-stable**: candidate `id` =
+`uuidV5(SPOOL_UUID_NAMESPACE, "{workspaceId}\0{relPath}\0{bodySha256}")`
+(`packages/common/src/uuid-v5.ts`; vendored byte-identical from ICO). The id
+derivation reads **only** those three content fields — never the whole
+candidate object — so adding the optional `origin` field **cannot** change any
+id. The origin token conversely binds `(id, tenantId, capturedAt)` and is
+therefore _downstream_ of id derivation; the two derivations share no coupling.
+The compiler's contract snapshot + test were resynced in lock-step.
+
+## Secret storage
+
+- **Location:** `~/.teamkb/origin-secret` (one line, 64 lowercase hex = 32
+  random bytes), mode **0600**, auto-generated on first use by the brain's own
+  processes (local govern, API boot, curator CLI, edge daemon).
+- **Override:** env `TEAMKB_ORIGIN_SECRET` wins over the file and is never
+  written to disk. This mirrors the existing `~/.teamkb/tokens.json` posture
+  (per-installation credential material lives under the brain base dir, never
+  in the repo; the API tokens are scrypt-hashed at rest — the origin secret is
+  a symmetric MAC key, so it is stored raw but 0600).
+- **Team mode clients** mint **only** when `TEAMKB_ORIGIN_SECRET` is explicitly
+  set (deliberate admin distribution). A client must never auto-generate: a
+  freshly-invented client secret would mint tokens the server's secret rejects
+  at promotion, silently poisoning the member's own proposals. No secret ⇒ the
+  client sends no `origin` ⇒ unattested path (works exactly as pre-H1).
+- Receipts persist only `sha256(tokenHmac)` truncated to 16 hex chars — never
+  the token — so no audit surface leaks replay-mint material, and there is no
+  verify-arbitrary-token oracle anywhere.
+
+## H4 — local-mode channel attestation is OUT OF SCOPE (v1)
+
+In **local mode** the plugin, the brain, and the secret all live on the user's
+own box under one trust domain. The origin token still binds each capture to the
+installation (a spool line minted elsewhere fails verification), but the
+`channel` value (`local-mcp`) is **self-asserted**: any local process that can
+read `~/.teamkb/origin-secret` can claim any channel. Enforcing channel
+authenticity locally would require an OS-level identity boundary that does not
+exist on a single-user box — so v1 explicitly does not pretend to. Channel
+_authorization_ is enforced only where a real trust boundary exists: the team
+API's allowlist (H3). Mirrored in the plugin repo's AGENTS.md.
+
+## H5 — the residual, named honestly
+
+An **authenticated insider** — any holder of a valid bearer token and/or the
+origin secret — can still poison L2/L3 content with validly-attested captures.
+Origin tokens prove **where a capture came from, not that it is true**. The
+mitigations for content poisoning remain the deterministic govern policy
+(secret/disclosure/dedup/contradiction rules), human review of the
+inbox/quarantine queues, and supersession — not the token. This wording also
+lands in the plugin repo's AGENTS.md and brain skill docs.
+
+## Alternatives considered
+
+- **Policy-rule implementation** (a new `PolicyRuleType` `origin_attestation`):
+  rejected — rule sets are per-tenant _configuration_, so the gate would be
+  dormant on every pre-H1 policy (and silently absent when no policy is
+  enabled). Provenance verification is an integrity property of the write path;
+  it now runs **structurally** (like the dedup check) on every promotion path,
+  while still emitting a policy-pipeline-shaped result so receipts/422s look
+  exactly like a policy reject (`ruleType: origin_attestation`).
+- **HMAC over content:** redundant on the spool path (id already binds content)
+  and would break the outbox replay path in team mode (content is frozen with
+  the token; identity binding survives replay by design).
+- **Asymmetric signatures (per-user keys):** the right long-term shape for
+  cross-actor non-repudiation, but heavier (key distribution/rotation UX) and
+  explicitly out of scope for v1 — consistent with the umbrella's trust-model
+  framing that local mode never claims non-repudiation.
+
+## Verification
+
+- `packages/common/src/__tests__/origin-token.test.ts` — mint/verify round-trip,
+  forgery + replay negatives, malformed-token tolerance, secret file 0600 +
+  idempotence + env override.
+- `apps/curator/src/__tests__/origin-gate.test.ts` — verdict table, forged-token
+  receipted reject, unattested legacy candidate still governs, receipt carries
+  channel + truncated hash, store round-trip.
+- `apps/api/src/__tests__/origin-provenance.test.ts` — H3 `unrecognized_channel`
+  422 (+ allowlist override), forged-token promote 422 `origin_token_invalid`,
+  fail-closed no-secret promote, H2 receipt assertions.
+- Store migration 11 (`add_candidates_origin`) — additive nullable
+  `origin_json`; every pre-H1 row reads back `origin: undefined`.

--- a/apps/api/src/__tests__/origin-provenance.test.ts
+++ b/apps/api/src/__tests__/origin-provenance.test.ts
@@ -99,6 +99,35 @@ describe('origin provenance over the API', () => {
       }
     });
 
+    it("a claimed channel 'unattested' is refused at the SCHEMA boundary even when an operator mistakenly allowlists it", async () => {
+      // `unattested` is receipt vocabulary, reserved by a CandidateOrigin
+      // schema refine — so the refusal happens at parse (400 invalid
+      // candidate), BEFORE allowlist logic, and a misconfigured allowlist
+      // containing 'unattested' cannot make the claim land.
+      const misconfigured = buildApp({
+        db,
+        silent: true,
+        originSecret: SECRET,
+        allowedChannels: ['unattested', 'team-mcp'],
+      });
+      await misconfigured.ready();
+      try {
+        const base = makeAttestedCandidate(SECRET, {}, 'team-mcp');
+        const payload = JSON.parse(JSON.stringify(base)) as Record<string, unknown>;
+        (payload['origin'] as Record<string, unknown>)['channel'] = 'unattested';
+        const res = await misconfigured.inject({
+          method: 'POST',
+          url: '/api/candidates',
+          payload,
+        });
+        expect(res.statusCode).toBe(400);
+        expect((res.json() as { error: string }).error).toMatch(/Invalid candidate/);
+        expect(candidateRepo.findById(base.id)).toBeNull();
+      } finally {
+        await misconfigured.close();
+      }
+    });
+
     it('a legacy origin-less capture skips the channel check entirely', async () => {
       const legacy = makeCandidate();
       const res = await intake(legacy);

--- a/apps/api/src/__tests__/origin-provenance.test.ts
+++ b/apps/api/src/__tests__/origin-provenance.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Write-time provenance over the HTTP surface (GSB Wave-2 H1/H3).
+ *
+ * H3 — authorized-channel allowlist at intake: a capture CLAIMING an
+ * unrecognized `origin.channel` gets a distinct 422 with the stable code
+ * `unrecognized_channel`; allowed channels intake normally; origin-less
+ * captures skip the check entirely (pre-H1 clients keep working).
+ *
+ * H1 — promotion-path verification: a forged origin token is refused at
+ * `POST /api/candidates/:id/promote` with the stable code
+ * `origin_token_invalid`; a validly-attested candidate promotes and its
+ * receipt carries channel + a truncated token hash (H2).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash, hashOriginToken, mintOriginToken } from '@qmd-team-intent-kb/common';
+import { makeAttestedCandidate, makeCandidate } from '@qmd-team-intent-kb/test-fixtures';
+import { buildApp } from '../app.js';
+
+const SECRET = 'a1'.repeat(32);
+const WRONG_SECRET = 'b2'.repeat(32);
+const TENANT = 'team-alpha';
+
+describe('origin provenance over the API', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let candidateRepo: CandidateRepository;
+  let auditRepo: AuditRepository;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+    auditRepo = new AuditRepository(db);
+    app = buildApp({ db, silent: true, originSecret: SECRET });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  const intake = (payload: unknown) =>
+    app.inject({ method: 'POST', url: '/api/candidates', payload: payload as object });
+  const promote = (id: string) =>
+    app.inject({ method: 'POST', url: `/api/candidates/${id}/promote?tenantId=${TENANT}` });
+
+  describe('H3 — channel allowlist at intake', () => {
+    it('422s an unrecognized origin channel with the stable code unrecognized_channel', async () => {
+      const candidate = makeAttestedCandidate(SECRET, {}, 'rogue-channel');
+      const res = await intake(candidate);
+      expect(res.statusCode).toBe(422);
+      const body = res.json() as { error: string; code?: string };
+      expect(body.code).toBe('unrecognized_channel');
+      expect(body.error).toContain('rogue-channel');
+      // Nothing was written.
+      expect(candidateRepo.findById(candidate.id)).toBeNull();
+    });
+
+    it('accepts a capture claiming an allowed channel (default allowlist)', async () => {
+      const candidate = makeAttestedCandidate(SECRET, {}, 'team-mcp');
+      const res = await intake(candidate);
+      expect(res.statusCode).toBe(201);
+      expect(candidateRepo.findById(candidate.id)?.origin?.channel).toBe('team-mcp');
+    });
+
+    it('respects a deployment-supplied allowlist override', async () => {
+      const custom = buildApp({
+        db,
+        silent: true,
+        originSecret: SECRET,
+        allowedChannels: ['ci-import'],
+      });
+      await custom.ready();
+      try {
+        const allowed = makeAttestedCandidate(SECRET, {}, 'ci-import');
+        const denied = makeAttestedCandidate(SECRET, {}, 'team-mcp');
+        const okRes = await custom.inject({
+          method: 'POST',
+          url: '/api/candidates',
+          payload: allowed,
+        });
+        const badRes = await custom.inject({
+          method: 'POST',
+          url: '/api/candidates',
+          payload: denied,
+        });
+        expect(okRes.statusCode).toBe(201);
+        expect(badRes.statusCode).toBe(422);
+        expect((badRes.json() as { code?: string }).code).toBe('unrecognized_channel');
+      } finally {
+        await custom.close();
+      }
+    });
+
+    it('a legacy origin-less capture skips the channel check entirely', async () => {
+      const legacy = makeCandidate();
+      const res = await intake(legacy);
+      expect(res.statusCode).toBe(201);
+      expect(candidateRepo.findById(legacy.id)?.origin).toBeUndefined();
+    });
+  });
+
+  describe('H1 — origin verification before promotion', () => {
+    it('refuses a FORGED origin token with the stable code origin_token_invalid, leaving the candidate in the inbox', async () => {
+      const forged = makeAttestedCandidate(WRONG_SECRET, {}, 'team-mcp');
+      // Intake accepts it (channel is allowed; the HMAC is only verifiable at
+      // the govern path, which holds the secret) …
+      expect((await intake(forged)).statusCode).toBe(201);
+      // … but promotion refuses it.
+      const res = await promote(forged.id);
+      expect(res.statusCode).toBe(422);
+      const body = res.json() as { error: string; code?: string };
+      expect(body.code).toBe('origin_token_invalid');
+      // Left in the inbox for review; never promoted.
+      expect(candidateRepo.findById(forged.id)?.status).toBe('inbox');
+    });
+
+    it('promotes a validly-attested candidate and receipts channel + truncated token hash (H2)', async () => {
+      const attested = makeAttestedCandidate(SECRET, {}, 'team-mcp');
+      expect((await intake(attested)).statusCode).toBe(201);
+      const res = await promote(attested.id);
+      expect(res.statusCode).toBe(200);
+      const memory = res.json() as { id: string };
+
+      const promoted = auditRepo.findByMemory(memory.id).find((e) => e.action === 'promoted');
+      expect(promoted?.details['originChannel']).toBe('team-mcp');
+      expect(promoted?.details['originTokenHash']).toBe(
+        hashOriginToken(attested.origin!.tokenHmac).slice(0, 16),
+      );
+      // The receipt never carries the token itself.
+      expect(JSON.stringify(promoted)).not.toContain(attested.origin!.tokenHmac);
+    });
+
+    it('refuses an attested candidate as unverifiable when the server has no origin secret (fail-closed)', async () => {
+      const bare = buildApp({ db, silent: true }); // no originSecret
+      await bare.ready();
+      try {
+        const attested = makeAttestedCandidate(SECRET, {}, 'team-mcp');
+        candidateRepo.insert(attested, computeContentHash(attested.content));
+        const res = await bare.inject({
+          method: 'POST',
+          url: `/api/candidates/${attested.id}/promote?tenantId=${TENANT}`,
+        });
+        expect(res.statusCode).toBe(422);
+        expect((res.json() as { code?: string }).code).toBe('origin_token_unverifiable');
+      } finally {
+        await bare.close();
+      }
+    });
+
+    it('sanity: the fixture really mints over (id, tenantId, capturedAt)', () => {
+      const attested = makeAttestedCandidate(SECRET);
+      expect(attested.origin?.tokenHmac).toBe(
+        mintOriginToken(SECRET, {
+          candidateId: attested.id,
+          tenantId: attested.tenantId,
+          capturedAt: attested.capturedAt,
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -87,6 +87,22 @@ export interface AppDependencies {
    */
   qmdAdapter?: QmdQueryPort;
   /**
+   * Origin channels a capture may claim in `origin.channel` (GSB Wave-2 H3).
+   * Defaults to the shipped capture surfaces (see
+   * `DEFAULT_ALLOWED_ORIGIN_CHANNELS`); main.ts wires `TEAMKB_ALLOWED_CHANNELS`.
+   * A capture claiming a channel outside this list is refused with a stable
+   * 422 `unrecognized_channel`.
+   */
+  allowedChannels?: readonly string[];
+  /**
+   * Per-installation origin secret for verifying candidate `origin`
+   * attestations at promotion time (GSB Wave-2 H1). main.ts resolves it via
+   * `loadOrCreateOriginSecret()` (env `TEAMKB_ORIGIN_SECRET` overrides). Left
+   * unset in tests → unattested candidates promote; origin-claiming candidates
+   * are refused fail-closed.
+   */
+  originSecret?: string;
+  /**
    * Optional post-promotion index refresher (D1). When provided, a successful
    * `POST /api/candidates/:id/promote` triggers the export→reindex chain AFTER
    * the promotion transaction commits, so the new memory is searchable
@@ -147,7 +163,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
 
   // The candidate service takes the audit repo so every accepted intake writes a
   // `proposed` provenance receipt (R8, compile-then-govern-jfv.6.7).
-  const candidateService = new CandidateService(candidateRepo, auditRepo);
+  const candidateService = new CandidateService(candidateRepo, auditRepo, deps.allowedChannels);
   const memoryService = new MemoryService(memoryRepo, auditRepo);
   const policyService = new PolicyService(policyRepo);
   const healthService = new HealthService(deps.db);
@@ -159,6 +175,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     policyRepo,
     auditRepo,
     linksRepo,
+    deps.originSecret,
   );
 
   // Routes are wrapped in an inner register() so they load AFTER the

--- a/apps/api/src/errors.ts
+++ b/apps/api/src/errors.ts
@@ -1,11 +1,14 @@
 /**
- * Typed API error carrying an HTTP status code.
- * Routes catch these and convert them to JSON responses.
+ * Typed API error carrying an HTTP status code, plus an optional STABLE
+ * machine-readable `code` (e.g. `unrecognized_channel`, `origin_token_invalid`)
+ * for clients that must branch on the rejection class without parsing prose.
+ * Routes catch these and convert them to JSON responses (`{ error, code? }`).
  */
 export class ApiError extends Error {
   constructor(
     public readonly statusCode: number,
     message: string,
+    public readonly code?: string,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -23,8 +26,8 @@ export function badRequest(message: string): ApiError {
 }
 
 /** Produce a 422 Unprocessable Content error (well-formed but disallowed). */
-export function unprocessable(message: string): ApiError {
-  return new ApiError(422, message);
+export function unprocessable(message: string, code?: string): ApiError {
+  return new ApiError(422, message, code);
 }
 
 /** Produce a 500 Internal Server Error. */

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -26,7 +26,11 @@
  */
 import { resolve } from 'node:path';
 import { createDatabase, IndexStateRepository } from '@qmd-team-intent-kb/store';
-import { loadOrCreateOriginSecret, resolveTeamKbPath } from '@qmd-team-intent-kb/common';
+import {
+  loadOrCreateOriginSecret,
+  ORIGIN_SECRET_UNAVAILABLE_WARNING,
+  resolveTeamKbPath,
+} from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
@@ -98,7 +102,7 @@ async function main(): Promise<void> {
     originSecret = loadOrCreateOriginSecret();
   } catch (e) {
     process.stderr.write(
-      `[teamkb-api] origin secret unavailable (${e instanceof Error ? e.message : String(e)}) — origin-claiming candidates will be refused as unverifiable\n`,
+      `[teamkb-api] ${ORIGIN_SECRET_UNAVAILABLE_WARNING} (${e instanceof Error ? e.message : String(e)})\n`,
     );
   }
   const allowedChannelsRaw = process.env['TEAMKB_ALLOWED_CHANNELS'];

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,10 +19,14 @@
  *   TEAMKB_TENANT_ID    — tenant scope for qmd isolation (default intent-solutions)
  *   TEAMKB_EXPORT_DIR   — git-exporter output dir qmd indexes (default ~/.teamkb/kb-export)
  *   TEAMKB_REVOKED_FILE — durable revoke-by-actor list (default ~/.teamkb/revoked-actors.json)
+ *   TEAMKB_ALLOWED_CHANNELS — comma-separated origin channels captures may claim
+ *                         (H3; default: team-mcp,local-mcp)
+ *   TEAMKB_ORIGIN_SECRET — per-installation origin-token secret override (H1;
+ *                         default: auto-generated ~/.teamkb/origin-secret, 0600)
  */
 import { resolve } from 'node:path';
 import { createDatabase, IndexStateRepository } from '@qmd-team-intent-kb/store';
-import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
+import { loadOrCreateOriginSecret, resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
@@ -84,6 +88,28 @@ async function main(): Promise<void> {
   const revokedFile =
     process.env['TEAMKB_REVOKED_FILE'] ?? resolveTeamKbPath('revoked-actors.json');
 
+  // Write-time provenance wiring (GSB Wave-2 H1/H3). The origin secret is the
+  // brain installation's — auto-created 0600 under ~/.teamkb on first boot (env
+  // TEAMKB_ORIGIN_SECRET overrides; never logged). Best-effort: a read-only
+  // base dir degrades to "unattested candidates only" rather than refusing to
+  // boot (origin-claiming candidates then reject fail-closed at promotion).
+  let originSecret: string | undefined;
+  try {
+    originSecret = loadOrCreateOriginSecret();
+  } catch (e) {
+    process.stderr.write(
+      `[teamkb-api] origin secret unavailable (${e instanceof Error ? e.message : String(e)}) — origin-claiming candidates will be refused as unverifiable\n`,
+    );
+  }
+  const allowedChannelsRaw = process.env['TEAMKB_ALLOWED_CHANNELS'];
+  const allowedChannels =
+    allowedChannelsRaw !== undefined && allowedChannelsRaw.trim() !== ''
+      ? allowedChannelsRaw
+          .split(',')
+          .map((c) => c.trim())
+          .filter((c) => c.length > 0)
+      : undefined;
+
   // Pass the real bind host so the no-auth dev path is refused off-loopback:
   // an empty registry on a tailnet/0.0.0.0 bind throws at boot rather than
   // serving every request as role=admin. Loopback stays the default.
@@ -94,6 +120,8 @@ async function main(): Promise<void> {
     indexRefresher,
     bindHost: config.host,
     revokedFile,
+    allowedChannels,
+    originSecret,
   });
   await app.ready();
 

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -46,7 +46,11 @@ export function registerCandidateRoutes(
         return reply.status(status).send({ ...candidate, intake });
       } catch (err) {
         if (err instanceof ApiError) {
-          return reply.status(err.statusCode).send({ error: err.message });
+          // `code` is the stable machine-readable rejection class (H3 —
+          // e.g. `unrecognized_channel`) so clients can branch without prose.
+          return reply
+            .status(err.statusCode)
+            .send({ error: err.message, ...(err.code !== undefined ? { code: err.code } : {}) });
         }
         throw err;
       }
@@ -116,7 +120,11 @@ export function registerCandidateRoutes(
         return reply.status(200).send(memory);
       } catch (err) {
         if (err instanceof ApiError) {
-          return reply.status(err.statusCode).send({ error: err.message });
+          // `code` carries the stable rejection class (H1 — e.g.
+          // `origin_token_invalid` when the provenance HMAC fails to verify).
+          return reply
+            .status(err.statusCode)
+            .send({ error: err.message, ...(err.code !== undefined ? { code: err.code } : {}) });
         }
         throw err;
       }

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -105,6 +105,24 @@ export function applyIntakeOverrides(
   });
 }
 
+/**
+ * Channels a team-mode capture may CLAIM in `origin.channel` when no
+ * deployment-specific allowlist is configured (H3 — env `TEAMKB_ALLOWED_CHANNELS`,
+ * comma-separated, overrides). The shipped capture surfaces:
+ *
+ *  - `team-mcp`  — the plugin's team-mode `brain_capture` proxy.
+ *  - `local-mcp` — the plugin's local-mode capture (spool path; listed so a
+ *    locally-minted candidate replayed through the API is not misclassified as
+ *    unrecognized).
+ *
+ * `unattested` is deliberately ABSENT: it is receipt vocabulary for candidates
+ * carrying NO origin, never a claimable channel. A candidate with no `origin`
+ * object skips this check entirely (backward compatibility with pre-H1
+ * clients); only an EXPLICIT claim of an unknown channel is refused, with the
+ * stable 422 code `unrecognized_channel`.
+ */
+export const DEFAULT_ALLOWED_ORIGIN_CHANNELS: readonly string[] = ['team-mcp', 'local-mcp'];
+
 /** Outcome of {@link CandidateService.intake} — safety vs knowledge (created ≠ replay). */
 export type IntakeResult = {
   candidate: MemoryCandidate;
@@ -124,9 +142,16 @@ export class CandidateService {
    *                   so the direct-service unit tests can construct a service
    *                   without an audit sink; the HTTP app always wires it.
    */
+  /**
+   * @param allowedChannels  Origin channels a capture may claim (H3). Defaults
+   *                         to {@link DEFAULT_ALLOWED_ORIGIN_CHANNELS};
+   *                         deployments override via `TEAMKB_ALLOWED_CHANNELS`
+   *                         (wired in main.ts / buildApp).
+   */
   constructor(
     private readonly repo: CandidateRepository,
     private readonly auditRepo?: AuditRepository,
+    private readonly allowedChannels: readonly string[] = DEFAULT_ALLOWED_ORIGIN_CHANNELS,
   ) {}
 
   /**
@@ -157,6 +182,23 @@ export class CandidateService {
     const parsed = MemoryCandidate.safeParse(data);
     if (!parsed.success) {
       throw badRequest(`Invalid candidate: ${parsed.error.message}`);
+    }
+
+    // Authorized-channel gate (GSB Wave-2 H3): a capture that CLAIMS an origin
+    // channel this deployment does not recognize is refused with a distinct,
+    // stable 422 code before any override/scan/insert work. A candidate with NO
+    // `origin` skips this entirely (pre-H1 clients stay compatible; it governs
+    // later as `unattested`). Note this checks the channel CLAIM only — the
+    // token HMAC is verified at promotion time, where the govern path holds the
+    // installation secret.
+    if (
+      parsed.data.origin !== undefined &&
+      !this.allowedChannels.includes(parsed.data.origin.channel)
+    ) {
+      throw unprocessable(
+        `Candidate rejected: origin channel '${parsed.data.origin.channel}' is not an authorized capture channel on this deployment.`,
+        'unrecognized_channel',
+      );
     }
 
     // R8 (bead compile-then-govern-jfv.6.7): never trust the team-mode client for

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -9,6 +9,7 @@ import {
   promote,
   detectSupersession,
   DEFAULT_SUPERSESSION_THRESHOLD,
+  checkOriginAttestation,
 } from '@qmd-team-intent-kb/curator';
 import { AuditEvent as AuditEventSchema } from '@qmd-team-intent-kb/schema';
 import type { CuratedMemory, Author } from '@qmd-team-intent-kb/schema';
@@ -43,12 +44,21 @@ const SUPERSESSION_THRESHOLD = DEFAULT_SUPERSESSION_THRESHOLD;
  * rejected the way the batch path does.
  */
 export class PromotionService {
+  /**
+   * @param originSecret  Per-installation origin secret for verifying candidate
+   *                      `origin` attestations before promotion (GSB Wave-2 H1).
+   *                      Resolved in main.ts via `loadOrCreateOriginSecret()`.
+   *                      When unset, unattested candidates promote normally but
+   *                      an origin-CLAIMING candidate is refused fail-closed
+   *                      (`origin_token_unverifiable`).
+   */
   constructor(
     private readonly candidateRepo: CandidateRepository,
     private readonly memoryRepo: MemoryRepository,
     private readonly policyRepo: PolicyRepository,
     private readonly auditRepo: AuditRepository,
     private readonly linksRepo?: MemoryLinksRepository,
+    private readonly originSecret?: string,
   ) {}
 
   /**
@@ -93,6 +103,23 @@ export class PromotionService {
         );
       }
       throw err;
+    }
+
+    // Write-time provenance gate (GSB Wave-2 H1): a candidate CLAIMING an
+    // origin must verify its HMAC against this installation's secret BEFORE any
+    // promotion work. Runs the same structural gate as the curator sweep, so
+    // the single-candidate admin path and the batch path agree. Unattested
+    // candidates (no `origin`) pass through — their promotion receipt records
+    // channel `unattested` (H2). The candidate is left in the inbox (a 422),
+    // consistent with policy rejects on this path.
+    const originGate = checkOriginAttestation(candidate, this.originSecret);
+    if (originGate.verdict === 'rejected') {
+      throw unprocessable(
+        originGate.code === 'origin_token_invalid'
+          ? 'Candidate rejected: origin token does not verify against the installation secret — claimed provenance is invalid. Left in the inbox for review.'
+          : 'Candidate rejected: it claims an origin attestation but no origin secret is configured on this server — cannot verify. Left in the inbox for review.',
+        originGate.code,
+      );
     }
 
     const contentHash = computeContentHash(candidate.content);

--- a/apps/curator/src/__tests__/fixtures.ts
+++ b/apps/curator/src/__tests__/fixtures.ts
@@ -7,6 +7,7 @@
  */
 export {
   makeCandidate,
+  makeAttestedCandidate,
   makeMemory,
   makeMemory as makeCuratedMemory,
   makePolicy,

--- a/apps/curator/src/__tests__/origin-gate.test.ts
+++ b/apps/curator/src/__tests__/origin-gate.test.ts
@@ -7,7 +7,8 @@
  */
 import type Database from 'better-sqlite3';
 import { describe, expect, it, beforeEach } from 'vitest';
-import { hashOriginToken, mintOriginToken } from '@qmd-team-intent-kb/common';
+import { deriveCandidateId, hashOriginToken, mintOriginToken } from '@qmd-team-intent-kb/common';
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import {
   createTestDatabase,
   CandidateRepository,
@@ -152,5 +153,52 @@ describe('Curator integration — origin gate on the promotion path', () => {
         capturedAt: attested.capturedAt,
       }),
     );
+  });
+});
+
+describe('spool id derivation is independent of origin (the id-stability contract, load-bearing)', () => {
+  it('deriveCandidateId over the same (workspaceId, relPath, bodySha256) yields the same id with and without origin attached', () => {
+    const workspaceId = 'my-workspace';
+    const relPath = 'wiki/concepts/provenance.md';
+    const bodySha256 = 'ab'.repeat(32);
+
+    // The derivation's ONLY inputs are the three content fields — derive once,
+    // then build two full candidates around that id, one attested, one not.
+    const id = deriveCandidateId(workspaceId, relPath, bodySha256);
+    expect(id).toBe(deriveCandidateId(workspaceId, relPath, bodySha256));
+
+    const baseFields = {
+      id,
+      status: 'inbox',
+      source: 'import',
+      content: 'A compiled page body about provenance.',
+      title: 'Provenance',
+      category: 'reference',
+      trustLevel: 'medium',
+      author: { type: 'system', id: 'ico-compiler' },
+      tenantId: TENANT,
+      metadata: { filePaths: [relPath], tags: [] },
+      prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+      capturedAt: '2026-07-19T00:00:00.000Z',
+    };
+    const without = MemoryCandidate.parse(baseFields);
+    const withOrigin = MemoryCandidate.parse({
+      ...baseFields,
+      origin: {
+        tokenHmac: mintOriginToken(SECRET, {
+          candidateId: id,
+          tenantId: TENANT,
+          capturedAt: '2026-07-19T00:00:00.000Z',
+        }),
+        channel: 'local-mcp',
+        mintedAt: '2026-07-19T00:00:00.000Z',
+      },
+    });
+
+    // Same content fields → same id, origin present or not: attaching an
+    // attestation can never re-identify (and thus never un-dedupe) a candidate.
+    expect(without.id).toBe(id);
+    expect(withOrigin.id).toBe(id);
+    expect(withOrigin.id).toBe(without.id);
   });
 });

--- a/apps/curator/src/__tests__/origin-gate.test.ts
+++ b/apps/curator/src/__tests__/origin-gate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Write-time provenance gate (GSB Wave-2 H1) — unit verdicts for
+ * `checkOriginAttestation` plus the Curator integration: a forged/unverifiable
+ * origin claim is REJECTED with a receipted, policy-pipeline-shaped result;
+ * an unattested legacy candidate still governs; a valid attestation promotes
+ * and its 'promoted' receipt carries channel + truncated token hash (H2).
+ */
+import type Database from 'better-sqlite3';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { hashOriginToken, mintOriginToken } from '@qmd-team-intent-kb/common';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { makeAttestedCandidate, makeCandidate, TENANT } from './fixtures.js';
+import { checkOriginAttestation } from '../origin/origin-gate.js';
+import { Curator } from '../curator.js';
+
+const SECRET = 'a1'.repeat(32);
+const WRONG_SECRET = 'b2'.repeat(32);
+
+describe('checkOriginAttestation — verdict table', () => {
+  it('no origin → unattested (accepted for backward compatibility)', () => {
+    expect(checkOriginAttestation(makeCandidate(), SECRET)).toEqual({ verdict: 'unattested' });
+    // Even with no secret configured, an unattested candidate is not rejected.
+    expect(checkOriginAttestation(makeCandidate(), undefined)).toEqual({ verdict: 'unattested' });
+  });
+
+  it('valid origin under the installation secret → attested', () => {
+    const candidate = makeAttestedCandidate(SECRET);
+    expect(checkOriginAttestation(candidate, SECRET)).toEqual({ verdict: 'attested' });
+  });
+
+  it('forged origin (minted under a different secret) → rejected origin_token_invalid', () => {
+    const candidate = makeAttestedCandidate(WRONG_SECRET);
+    const res = checkOriginAttestation(candidate, SECRET);
+    expect(res.verdict).toBe('rejected');
+    if (res.verdict === 'rejected') {
+      expect(res.code).toBe('origin_token_invalid');
+      expect(res.pipelineResult.outcome).toBe('rejected');
+      expect(res.pipelineResult.rejectedBy).toBe('origin_token_invalid');
+      expect(res.pipelineResult.evaluations[0]?.ruleType).toBe('origin_attestation');
+    }
+  });
+
+  it('valid token replayed onto a different identity → rejected origin_token_invalid', () => {
+    const original = makeAttestedCandidate(SECRET);
+    // Replay the token onto a candidate with a different id/capturedAt.
+    const replayed = makeCandidate({ origin: original.origin });
+    const res = checkOriginAttestation(replayed, SECRET);
+    expect(res.verdict).toBe('rejected');
+    if (res.verdict === 'rejected') expect(res.code).toBe('origin_token_invalid');
+  });
+
+  it('origin claimed but no secret configured → rejected origin_token_unverifiable (fail-closed)', () => {
+    const candidate = makeAttestedCandidate(SECRET);
+    const res = checkOriginAttestation(candidate, undefined);
+    expect(res.verdict).toBe('rejected');
+    if (res.verdict === 'rejected') expect(res.code).toBe('origin_token_unverifiable');
+  });
+});
+
+describe('Curator integration — origin gate on the promotion path', () => {
+  let db: Database.Database;
+  let candidateRepo: CandidateRepository;
+  let memoryRepo: MemoryRepository;
+  let policyRepo: PolicyRepository;
+  let auditRepo: AuditRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+    memoryRepo = new MemoryRepository(db);
+    policyRepo = new PolicyRepository(db);
+    auditRepo = new AuditRepository(db);
+  });
+
+  function curator(originSecret?: string): Curator {
+    return new Curator(
+      { candidateRepo, memoryRepo, policyRepo, auditRepo },
+      { tenantId: TENANT, originSecret },
+    );
+  }
+
+  it('REJECTS a forged origin before promotion, with a receipted reject naming origin_token_invalid', () => {
+    const forged = makeAttestedCandidate(WRONG_SECRET);
+    const result = curator(SECRET).processSingle(forged);
+
+    expect(result.outcome).toBe('rejected');
+    expect(result.reason).toContain('origin_token_invalid');
+    expect(memoryRepo.findByTenant(TENANT)).toHaveLength(0);
+
+    // The rejection receipt is on the chain (curator default path — receipts on).
+    const receipts = auditRepo.findByMemory(forged.id);
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]?.reason).toContain('origin_token_invalid');
+  });
+
+  it('still governs an unattested legacy candidate, receipting its promotion as channel=unattested (H2)', () => {
+    const legacy = makeCandidate();
+    const result = curator(SECRET).processSingle(legacy);
+
+    expect(result.outcome).toBe('promoted');
+    const promoted = auditRepo
+      .findByMemory(result.memoryId ?? '')
+      .find((e) => e.action === 'promoted');
+    expect(promoted?.details['originChannel']).toBe('unattested');
+    expect(promoted?.details['originTokenHash']).toBeUndefined();
+  });
+
+  it('promotes a validly-attested candidate and receipts channel + TRUNCATED token hash, never the token (H2)', () => {
+    const attested = makeAttestedCandidate(SECRET);
+    const result = curator(SECRET).processSingle(attested);
+
+    expect(result.outcome).toBe('promoted');
+    const promoted = auditRepo
+      .findByMemory(result.memoryId ?? '')
+      .find((e) => e.action === 'promoted');
+    expect(promoted?.details['originChannel']).toBe('local-mcp');
+    const surfaced = promoted?.details['originTokenHash'];
+    expect(surfaced).toBe(hashOriginToken(attested.origin!.tokenHmac).slice(0, 16));
+    // Never enough to replay-mint: not the token, not even its full hash.
+    expect(surfaced).not.toBe(attested.origin!.tokenHmac);
+    expect(String(surfaced)).toHaveLength(16);
+  });
+
+  it('rejects an attested candidate as unverifiable when the govern path has no secret (fail-closed)', () => {
+    const attested = makeAttestedCandidate(SECRET);
+    const result = curator(undefined).processSingle(attested);
+    expect(result.outcome).toBe('rejected');
+    expect(result.reason).toContain('origin_token_unverifiable');
+    expect(memoryRepo.findByTenant(TENANT)).toHaveLength(0);
+  });
+
+  it('round-trips origin through the candidates store (persisted claim, verified at govern time)', () => {
+    const attested = makeAttestedCandidate(SECRET);
+    candidateRepo.insert(attested, 'c'.repeat(64));
+    const readBack = candidateRepo.findById(attested.id);
+    expect(readBack?.origin).toEqual(attested.origin);
+    // A legacy row without origin reads back with origin undefined.
+    const legacy = makeCandidate();
+    candidateRepo.insert(legacy, 'd'.repeat(64));
+    expect(candidateRepo.findById(legacy.id)?.origin).toBeUndefined();
+    // Sanity: the token really was minted from identity fields.
+    expect(attested.origin?.tokenHmac).toBe(
+      mintOriginToken(SECRET, {
+        candidateId: attested.id,
+        tenantId: attested.tenantId,
+        capturedAt: attested.capturedAt,
+      }),
+    );
+  });
+});

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -52,6 +52,8 @@ import type {
   AuditChainRow,
 } from '@qmd-team-intent-kb/store';
 
+import { loadOrCreateOriginSecret } from '@qmd-team-intent-kb/common';
+
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
 import { mergeGovern } from './merge/merge-gate.js';
@@ -305,9 +307,18 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     const disclosureRejected = ingestResult.value.rejected;
 
     // Stage B: Curator.processBatch — dedup + policy + promote.
+    // Write-time provenance (H1): resolve the installation origin secret so
+    // origin-claiming candidates verify; unreadable → undefined, and only
+    // origin-CLAIMING candidates then reject (fail-closed) as unverifiable.
+    let originSecret: string | undefined;
+    try {
+      originSecret = loadOrCreateOriginSecret();
+    } catch {
+      originSecret = undefined;
+    }
     const curator = new Curator(
       { candidateRepo, memoryRepo, policyRepo, auditRepo, linksRepo },
-      { tenantId },
+      { tenantId, originSecret },
     );
     const batch = curator.processBatch(candidates);
 

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -52,7 +52,10 @@ import type {
   AuditChainRow,
 } from '@qmd-team-intent-kb/store';
 
-import { loadOrCreateOriginSecret } from '@qmd-team-intent-kb/common';
+import {
+  loadOrCreateOriginSecret,
+  ORIGIN_SECRET_UNAVAILABLE_WARNING,
+} from '@qmd-team-intent-kb/common';
 
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
@@ -310,11 +313,16 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     // Write-time provenance (H1): resolve the installation origin secret so
     // origin-claiming candidates verify; unreadable → undefined, and only
     // origin-CLAIMING candidates then reject (fail-closed) as unverifiable.
+    // The degradation is WARNED, not silent — same shared message as the API
+    // boot + edge-daemon, so operators can grep one phrase across surfaces.
     let originSecret: string | undefined;
     try {
       originSecret = loadOrCreateOriginSecret();
-    } catch {
+    } catch (e) {
       originSecret = undefined;
+      process.stderr.write(
+        `[curator-cli] ${ORIGIN_SECRET_UNAVAILABLE_WARNING} (${e instanceof Error ? e.message : String(e)})\n`,
+      );
     }
     const curator = new Curator(
       { candidateRepo, memoryRepo, policyRepo, auditRepo, linksRepo },

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -17,6 +17,7 @@ import {
 } from './supersession/supersession-detector.js';
 import { promote } from './promotion/promoter.js';
 import { reject } from './rejection/rejector.js';
+import { checkOriginAttestation } from './origin/origin-gate.js';
 
 /** Repository dependencies required by the Curator */
 export interface CuratorDependencies {
@@ -81,6 +82,34 @@ export class Curator {
       };
     }
 
+    // Suppress the per-candidate reject receipt when configured (B1 sweep) — the
+    // outcome still returns, only the audit write is skipped (see
+    // CuratorConfig.suppressRejectionReceipts). `dryRun` also suppresses it.
+    const suppressReject =
+      this.config.dryRun === true || this.config.suppressRejectionReceipts === true;
+
+    // Write-time provenance gate (GSB Wave-2 H1) — STRUCTURAL, before the
+    // configurable policy pipeline, so a candidate claiming an origin that does
+    // not verify against this installation's secret can never reach promotion
+    // regardless of tenant policy. Unattested candidates (no `origin`) pass
+    // through for backward compatibility; their promotion receipt records
+    // channel `unattested` (H2). Rejections reuse the receipted rejection path.
+    const originGate = checkOriginAttestation(candidate, this.config.originSecret);
+    if (originGate.verdict === 'rejected') {
+      const reason = reject(
+        candidate,
+        originGate.pipelineResult,
+        this.deps.auditRepo,
+        suppressReject,
+      );
+      return {
+        candidateId: candidate.id,
+        outcome: 'rejected',
+        pipelineResult: originGate.pipelineResult,
+        reason,
+      };
+    }
+
     const policies = this.deps.policyRepo.findByTenant(this.config.tenantId);
     const policy = policies.find((p) => p.enabled);
 
@@ -123,12 +152,6 @@ export class Curator {
           .filter((m) => m.category === category)
           .map((m) => ({ id: m.id, content: m.content })),
     });
-
-    // Suppress the per-candidate reject receipt when configured (B1 sweep) — the
-    // outcome still returns, only the audit write is skipped (see
-    // CuratorConfig.suppressRejectionReceipts). `dryRun` also suppresses it.
-    const suppressReject =
-      this.config.dryRun === true || this.config.suppressRejectionReceipts === true;
 
     if (pipelineResult.outcome === 'rejected') {
       const reason = reject(candidate, pipelineResult, this.deps.auditRepo, suppressReject);

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -19,6 +19,8 @@ export type { SupersessionMatch } from './supersession/supersession-detector.js'
 export { promote } from './promotion/promoter.js';
 export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
+export { checkOriginAttestation, ORIGIN_ATTESTATION_RULE_TYPE } from './origin/origin-gate.js';
+export type { OriginGateResult, OriginRejectCode } from './origin/origin-gate.js';
 export { mergeGovern, MergeIdInvariantError } from './merge/merge-gate.js';
 export type {
   MergeGovernResult,

--- a/apps/curator/src/origin/origin-gate.ts
+++ b/apps/curator/src/origin/origin-gate.ts
@@ -1,0 +1,107 @@
+import { verifyOriginToken } from '@qmd-team-intent-kb/common';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+
+/**
+ * Write-time provenance gate (GSB Wave-2 H1) — the promotion-path check that a
+ * candidate CLAIMING an origin attestation actually verifies against this
+ * installation's origin secret.
+ *
+ * STRUCTURAL, not policy-configured: like the curator's dedup check (and unlike
+ * the rules in `governance_policies.rules_json`), this gate runs on every
+ * govern/promotion path regardless of tenant policy. Provenance verification is
+ * an integrity property of the write path; making it a configurable policy rule
+ * would leave it dormant on every pre-H1 policy.
+ *
+ * v1 verdict table (documented choice — see the H1 decision record):
+ *
+ *  - `origin` ABSENT   → `unattested`, ACCEPTED. Every pre-H1 spool line and
+ *    legacy capture carries no origin; a hard-reject flag-day would orphan all
+ *    of them. The promotion receipt records channel `unattested` (H2) so the
+ *    gap stays visible instead of silently passing as attested.
+ *  - `origin` PRESENT, no secret available to the govern path →
+ *    `origin_token_unverifiable` REJECT (fail-closed: a claimed attestation we
+ *    cannot check must not promote as if it verified).
+ *  - `origin` PRESENT, HMAC mismatch → `origin_token_invalid` REJECT.
+ *  - `origin` PRESENT, HMAC verifies → `attested`, proceeds to policy.
+ *
+ * Rejections are POLICY-PIPELINE-SHAPED (`PipelineResult` with
+ * `outcome:'rejected'`) so they flow through the existing receipted rejection
+ * path (`reject()` / the API's 422), never a crash. The verdict is only ever
+ * surfaced on the candidate's own governance outcome — there is deliberately NO
+ * verify-arbitrary-token surface (no oracle).
+ */
+
+/** `ruleType` stamped on origin-gate rule results (a structural pseudo-rule). */
+export const ORIGIN_ATTESTATION_RULE_TYPE = 'origin_attestation';
+
+/** Stable reject codes — these land verbatim in `PipelineResult.rejectedBy`. */
+export type OriginRejectCode = 'origin_token_invalid' | 'origin_token_unverifiable';
+
+/** Outcome of the origin gate for one candidate. */
+export type OriginGateResult =
+  | { verdict: 'unattested' }
+  | { verdict: 'attested' }
+  | { verdict: 'rejected'; code: OriginRejectCode; pipelineResult: PipelineResult };
+
+/**
+ * Evaluate the origin gate for a candidate. Pure — no I/O; the caller resolves
+ * the installation secret (curator config / API wiring).
+ */
+export function checkOriginAttestation(
+  candidate: MemoryCandidate,
+  originSecret: string | undefined,
+): OriginGateResult {
+  if (candidate.origin === undefined) {
+    return { verdict: 'unattested' };
+  }
+  if (originSecret === undefined || originSecret.length === 0) {
+    return rejected(
+      candidate,
+      'origin_token_unverifiable',
+      'Candidate claims an origin attestation but no installation origin secret is configured on this govern path — cannot verify, refusing to promote.',
+    );
+  }
+  const ok = verifyOriginToken(
+    originSecret,
+    {
+      candidateId: candidate.id,
+      tenantId: candidate.tenantId,
+      capturedAt: candidate.capturedAt,
+    },
+    candidate.origin.tokenHmac,
+  );
+  if (!ok) {
+    return rejected(
+      candidate,
+      'origin_token_invalid',
+      'Origin token HMAC does not verify against the installation secret for (id, tenantId, capturedAt) — the claimed provenance is forged, replayed across identities, or minted under a different secret.',
+    );
+  }
+  return { verdict: 'attested' };
+}
+
+/** Build the policy-pipeline-shaped rejection for a failed origin check. */
+function rejected(
+  candidate: MemoryCandidate,
+  code: OriginRejectCode,
+  reason: string,
+): OriginGateResult {
+  return {
+    verdict: 'rejected',
+    code,
+    pipelineResult: {
+      candidateId: candidate.id,
+      outcome: 'rejected',
+      evaluations: [
+        {
+          ruleId: code,
+          ruleType: ORIGIN_ATTESTATION_RULE_TYPE,
+          outcome: 'fail',
+          reason,
+        },
+      ],
+      rejectedBy: code,
+    },
+  };
+}

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -3,6 +3,9 @@ import {
   deriveAuditEventId,
   derivePolicyEvaluationId,
   deriveLinkId,
+  hashOriginToken,
+  ORIGIN_TOKEN_HASH_SURFACE_LEN,
+  UNATTESTED_CHANNEL,
 } from '@qmd-team-intent-kb/common';
 import {
   CuratedMemory as CuratedMemorySchema,
@@ -288,7 +291,25 @@ export function promote(
               input.promotionReason !== undefined && input.promotionReason.trim().length > 0
                 ? `${input.promotionReason} (passed all governance rules)`
                 : 'Passed all governance rules',
-            details: { candidateId: input.candidate.id },
+            // Write-time provenance on the receipt (GSB Wave-2 H2): the origin
+            // CHANNEL plus a TRUNCATED SHA-256 of the token HMAC — never the
+            // token itself, so surfaced audit details can identify an
+            // attestation without enabling replay-minting (no oracle). An
+            // origin-less candidate is receipted honestly as `unattested`.
+            // Deterministic (a pure function of candidate fields), so
+            // cross-clone entry_hash reproducibility (8da.5/8da.6) holds.
+            details: {
+              candidateId: input.candidate.id,
+              originChannel: input.candidate.origin?.channel ?? UNATTESTED_CHANNEL,
+              ...(input.candidate.origin !== undefined
+                ? {
+                    originTokenHash: hashOriginToken(input.candidate.origin.tokenHmac).slice(
+                      0,
+                      ORIGIN_TOKEN_HASH_SURFACE_LEN,
+                    ),
+                  }
+                : {}),
+            },
             timestamp: now,
           }),
         );

--- a/apps/curator/src/types.ts
+++ b/apps/curator/src/types.ts
@@ -49,4 +49,14 @@ export interface CuratorConfig {
    * receipts).
    */
   suppressRejectionReceipts?: boolean;
+  /**
+   * Per-installation origin secret used to verify candidate `origin`
+   * attestations before promotion (GSB Wave-2 H1 — see `origin/origin-gate.ts`).
+   * When unset, UNATTESTED candidates still govern normally (backward
+   * compatibility), but a candidate that CLAIMS an origin is rejected as
+   * `origin_token_unverifiable` (fail-closed: a claimed attestation we cannot
+   * check must not promote as if it verified). Callers on an installation with
+   * a brain base dir should resolve it via `loadOrCreateOriginSecret()`.
+   */
+  originSecret?: string;
 }

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { ingestFromSpool, Curator } from '@qmd-team-intent-kb/curator';
+import { loadOrCreateOriginSecret } from '@qmd-team-intent-kb/common';
 import { runExport } from '@qmd-team-intent-kb/git-exporter';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { resolveRepoContext } from '@qmd-team-intent-kb/repo-resolver';
@@ -167,6 +168,10 @@ function curateStep(
       {
         tenantId: config.tenantId,
         supersessionThreshold: config.supersessionThreshold,
+        // Write-time provenance (H1): resolve the installation origin secret so
+        // origin-claiming candidates verify; absent/unreadable → they reject
+        // fail-closed as unverifiable while unattested candidates flow as before.
+        originSecret: resolveOriginSecretSafe(),
       },
     );
 
@@ -381,4 +386,17 @@ export async function runCycle(
 
   result.completedAt = nowFn();
   return result;
+}
+
+/**
+ * Resolve the installation origin secret (H1) without letting a filesystem
+ * fault abort the curation cycle. Returns undefined on failure, which the
+ * origin gate treats fail-closed for origin-CLAIMING candidates only.
+ */
+function resolveOriginSecretSafe(): string | undefined {
+  try {
+    return loadOrCreateOriginSecret();
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -2,7 +2,10 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { ingestFromSpool, Curator } from '@qmd-team-intent-kb/curator';
-import { loadOrCreateOriginSecret } from '@qmd-team-intent-kb/common';
+import {
+  loadOrCreateOriginSecret,
+  ORIGIN_SECRET_UNAVAILABLE_WARNING,
+} from '@qmd-team-intent-kb/common';
 import { runExport } from '@qmd-team-intent-kb/git-exporter';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { resolveRepoContext } from '@qmd-team-intent-kb/repo-resolver';
@@ -171,7 +174,7 @@ function curateStep(
         // Write-time provenance (H1): resolve the installation origin secret so
         // origin-claiming candidates verify; absent/unreadable → they reject
         // fail-closed as unverifiable while unattested candidates flow as before.
-        originSecret: resolveOriginSecretSafe(),
+        originSecret: resolveOriginSecretSafe(logger),
       },
     );
 
@@ -391,12 +394,17 @@ export async function runCycle(
 /**
  * Resolve the installation origin secret (H1) without letting a filesystem
  * fault abort the curation cycle. Returns undefined on failure, which the
- * origin gate treats fail-closed for origin-CLAIMING candidates only.
+ * origin gate treats fail-closed for origin-CLAIMING candidates only. The
+ * degradation is WARNED with the same shared message the API boot and
+ * curator CLI emit, so operators can grep one phrase across all surfaces.
  */
-function resolveOriginSecretSafe(): string | undefined {
+function resolveOriginSecretSafe(logger: DaemonLogger): string | undefined {
   try {
     return loadOrCreateOriginSecret();
-  } catch {
+  } catch (e) {
+    logger.warn(
+      `${ORIGIN_SECRET_UNAVAILABLE_WARNING} (${e instanceof Error ? e.message : String(e)})`,
+    );
     return undefined;
   }
 }

--- a/packages/common/src/__tests__/origin-token.test.ts
+++ b/packages/common/src/__tests__/origin-token.test.ts
@@ -3,7 +3,16 @@
  * forgery/tamper negatives, receipt-hash truncation (H2), and the on-disk
  * per-installation secret lifecycle (0600, idempotent, env override).
  */
-import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -119,5 +128,35 @@ describe('per-installation secret file', () => {
     expect(loadOriginSecret(base)).toBe('e'.repeat(64));
     expect(loadOrCreateOriginSecret(base)).toBe('e'.repeat(64));
     expect(existsSync(originSecretPath(base))).toBe(false);
+  });
+
+  it('TOCTOU: a file created by another process is adopted via the EEXIST re-read path, never clobbered', () => {
+    // Simulate losing the create race: the file appears (another process won)
+    // before this process's exclusive-create attempt. loadOrCreateOriginSecret
+    // opens with flag 'wx', takes EEXIST, and re-reads the winner's secret —
+    // this pre-created file exercises exactly that branch (the 'wx' write is
+    // unconditional; there is no separate pre-check to interleave with).
+    const winner = 'c3'.repeat(32);
+    mkdirSync(base, { recursive: true });
+    writeFileSync(originSecretPath(base), `${winner}\n`, { encoding: 'utf8', mode: 0o600 });
+    expect(loadOrCreateOriginSecret(base)).toBe(winner);
+    // The winner's bytes were never overwritten by the loser's minted secret.
+    expect(readFileSync(originSecretPath(base), 'utf8').trim()).toBe(winner);
+  });
+
+  it('TOCTOU: an existing-but-empty secret file throws instead of being silently overwritten', () => {
+    mkdirSync(base, { recursive: true });
+    writeFileSync(originSecretPath(base), '', { encoding: 'utf8', mode: 0o600 });
+    expect(() => loadOrCreateOriginSecret(base)).toThrow(/exists but is empty or unreadable/);
+    // Still empty — no blind overwrite of a file another writer may own.
+    expect(readFileSync(originSecretPath(base), 'utf8')).toBe('');
+  });
+
+  it('defensively clamps a widened file mode back to 0600 on read', () => {
+    const secret = loadOrCreateOriginSecret(base);
+    chmodSync(originSecretPath(base), 0o644);
+    // Any read path (loadOriginSecret or the create wrapper) re-asserts 0600.
+    expect(loadOriginSecret(base)).toBe(secret);
+    expect(statSync(originSecretPath(base)).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/common/src/__tests__/origin-token.test.ts
+++ b/packages/common/src/__tests__/origin-token.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Write-time provenance origin tokens (GSB Wave-2 H1) — mint/verify round-trip,
+ * forgery/tamper negatives, receipt-hash truncation (H2), and the on-disk
+ * per-installation secret lifecycle (0600, idempotent, env override).
+ */
+import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildOriginTokenPayload,
+  hashOriginToken,
+  loadOriginSecret,
+  loadOrCreateOriginSecret,
+  mintOriginToken,
+  originSecretPath,
+  ORIGIN_SECRET_ENV,
+  ORIGIN_TOKEN_HASH_SURFACE_LEN,
+  verifyOriginToken,
+} from '../origin-token.js';
+
+const IDENTITY = {
+  candidateId: '6c6f6e67-7368-6f72-6500-69636f73706c',
+  tenantId: 'team-alpha',
+  capturedAt: '2026-01-15T10:00:00.000Z',
+};
+const SECRET = 'f'.repeat(64);
+
+describe('mint/verify round-trip', () => {
+  it('a minted token verifies under the same secret and identity', () => {
+    const token = mintOriginToken(SECRET, IDENTITY);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(verifyOriginToken(SECRET, IDENTITY, token)).toBe(true);
+  });
+
+  it('is deterministic — same inputs mint the same token', () => {
+    expect(mintOriginToken(SECRET, IDENTITY)).toBe(mintOriginToken(SECRET, IDENTITY));
+  });
+
+  it('a token minted under a DIFFERENT secret does not verify (forgery)', () => {
+    const forged = mintOriginToken('0'.repeat(64), IDENTITY);
+    expect(verifyOriginToken(SECRET, IDENTITY, forged)).toBe(false);
+  });
+
+  it('a valid token replayed over a different identity tuple does not verify', () => {
+    const token = mintOriginToken(SECRET, IDENTITY);
+    expect(verifyOriginToken(SECRET, { ...IDENTITY, tenantId: 'team-beta' }, token)).toBe(false);
+    expect(
+      verifyOriginToken(SECRET, { ...IDENTITY, capturedAt: '2026-01-15T10:00:01.000Z' }, token),
+    ).toBe(false);
+    expect(
+      verifyOriginToken(
+        SECRET,
+        { ...IDENTITY, candidateId: '00000000-0000-4000-8000-000000000001' },
+        token,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects malformed tokens without throwing (uppercase, short, non-hex)', () => {
+    const token = mintOriginToken(SECRET, IDENTITY);
+    expect(verifyOriginToken(SECRET, IDENTITY, token.toUpperCase())).toBe(false);
+    expect(verifyOriginToken(SECRET, IDENTITY, token.slice(0, 32))).toBe(false);
+    expect(verifyOriginToken(SECRET, IDENTITY, 'z'.repeat(64))).toBe(false);
+    expect(verifyOriginToken(SECRET, IDENTITY, '')).toBe(false);
+  });
+
+  it('NUL-joins the identity tuple injectively (no field-boundary collision)', () => {
+    // "ab"+"c" vs "a"+"bc" across the candidateId/tenantId boundary must differ.
+    const a = mintOriginToken(SECRET, { candidateId: 'ab', tenantId: 'c', capturedAt: 'x' });
+    const b = mintOriginToken(SECRET, { candidateId: 'a', tenantId: 'bc', capturedAt: 'x' });
+    expect(a).not.toBe(b);
+    expect(buildOriginTokenPayload(IDENTITY)).toContain(String.fromCharCode(0));
+  });
+});
+
+describe('receipt hashing (H2 — never enough to replay-mint)', () => {
+  it('hashOriginToken is a one-way SHA-256 of the token, distinct from it', () => {
+    const token = mintOriginToken(SECRET, IDENTITY);
+    const hash = hashOriginToken(token);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).not.toBe(token);
+    // The truncated surface form is 16 hex chars — far below token material.
+    expect(hash.slice(0, ORIGIN_TOKEN_HASH_SURFACE_LEN)).toHaveLength(16);
+  });
+});
+
+describe('per-installation secret file', () => {
+  let base: string;
+  const savedEnv = process.env[ORIGIN_SECRET_ENV];
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'origin-secret-'));
+    delete process.env[ORIGIN_SECRET_ENV];
+  });
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env[ORIGIN_SECRET_ENV];
+    else process.env[ORIGIN_SECRET_ENV] = savedEnv;
+  });
+
+  it('auto-creates a 64-hex secret with mode 0600 on first use, then is idempotent', () => {
+    const first = loadOrCreateOriginSecret(base);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    const mode = statSync(originSecretPath(base)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    // Second call reads the same secret — no re-mint.
+    expect(loadOrCreateOriginSecret(base)).toBe(first);
+    expect(readFileSync(originSecretPath(base), 'utf8').trim()).toBe(first);
+  });
+
+  it('loadOriginSecret never creates the file (team-client safety)', () => {
+    expect(loadOriginSecret(base)).toBeUndefined();
+    expect(existsSync(originSecretPath(base))).toBe(false);
+  });
+
+  it('the env override wins over the file and is never written to disk', () => {
+    process.env[ORIGIN_SECRET_ENV] = 'e'.repeat(64);
+    expect(loadOriginSecret(base)).toBe('e'.repeat(64));
+    expect(loadOrCreateOriginSecret(base)).toBe('e'.repeat(64));
+    expect(existsSync(originSecretPath(base))).toBe(false);
+  });
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -14,6 +14,7 @@ export { DEFAULT_TEAMKB_BASE, getTeamKbBasePath, resolveTeamKbPath } from './pat
 export {
   ORIGIN_SECRET_FILENAME,
   ORIGIN_SECRET_ENV,
+  ORIGIN_SECRET_UNAVAILABLE_WARNING,
   UNATTESTED_CHANNEL,
   ORIGIN_TOKEN_HASH_SURFACE_LEN,
   buildOriginTokenPayload,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -11,6 +11,20 @@ export {
   deriveLinkId,
 } from './uuid-v5.js';
 export { DEFAULT_TEAMKB_BASE, getTeamKbBasePath, resolveTeamKbPath } from './paths.js';
+export {
+  ORIGIN_SECRET_FILENAME,
+  ORIGIN_SECRET_ENV,
+  UNATTESTED_CHANNEL,
+  ORIGIN_TOKEN_HASH_SURFACE_LEN,
+  buildOriginTokenPayload,
+  mintOriginToken,
+  verifyOriginToken,
+  hashOriginToken,
+  loadOriginSecret,
+  loadOrCreateOriginSecret,
+  originSecretPath,
+} from './origin-token.js';
+export type { OriginTokenIdentity } from './origin-token.js';
 export { isPathSafe } from './path-safety.js';
 export type { PathSafetyResult } from './path-safety.js';
 export {

--- a/packages/common/src/origin-token.ts
+++ b/packages/common/src/origin-token.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { getTeamKbBasePath } from './paths.js';
 
@@ -53,10 +53,25 @@ export const ORIGIN_SECRET_ENV = 'TEAMKB_ORIGIN_SECRET';
  * The receipt channel recorded for a candidate that carries NO origin
  * attestation (pre-H1 spools, legacy captures, team clients without the
  * distributed secret). Reserved: it is a RECEIPT vocabulary word, never a
- * client-claimable `origin.channel` value (the schema's tag shape allows it,
- * but intake allowlists must not include it).
+ * client-claimable `origin.channel` value — enforced IN THE SCHEMA by the
+ * `CandidateOrigin` refine in `@qmd-team-intent-kb/schema` (which repeats this
+ * literal because schema is the base package and cannot import common; keep
+ * the two in sync), so a claim of `unattested` fails parse before any
+ * allowlist logic runs.
  */
 export const UNATTESTED_CHANNEL = 'unattested';
+
+/**
+ * The one operator-visible degradation warning for a govern/promotion
+ * entrypoint that cannot resolve the installation origin secret. Every caller
+ * (API boot, curator CLI, edge-daemon cycle) emits THIS string (plus its own
+ * prefix/detail) so operators can grep one phrase across all surfaces. The
+ * degradation it names: unattested candidates still govern normally, but any
+ * candidate CLAIMING an origin is refused fail-closed as
+ * `origin_token_unverifiable`.
+ */
+export const ORIGIN_SECRET_UNAVAILABLE_WARNING =
+  'origin secret unavailable — origin-claiming candidates will be refused as unverifiable';
 
 /** NUL field separator — injective over ids/tenants/timestamps (mirrors uuid-v5.ts). */
 const FIELD_SEPARATOR = String.fromCharCode(0);
@@ -126,9 +141,22 @@ export const ORIGIN_TOKEN_HASH_SURFACE_LEN = 16;
 export function loadOriginSecret(basePath?: string): string | undefined {
   const env = process.env[ORIGIN_SECRET_ENV]?.trim();
   if (env !== undefined && env.length > 0) return env;
+  const path = originSecretPath(basePath);
   try {
-    const secret = readFileSync(originSecretPath(basePath), 'utf8').trim();
-    return secret.length > 0 ? secret : undefined;
+    const secret = readFileSync(path, 'utf8').trim();
+    if (secret.length === 0) return undefined;
+    // Defensive re-assert on READ (not only at creation): a secret file that
+    // pre-dates this code, or whose mode was widened out-of-band, is clamped
+    // back to owner-only the next time any component touches it — the
+    // never-group/world-readable claim holds for the whole lifecycle, not
+    // just the creation instant. Best-effort: a chmod failure (e.g. not the
+    // owner) must not turn a readable secret into a resolution failure.
+    try {
+      if ((statSync(path).mode & 0o777) !== 0o600) chmodSync(path, 0o600);
+    } catch {
+      /* best-effort */
+    }
+    return secret;
   } catch {
     return undefined;
   }
@@ -139,18 +167,34 @@ export function loadOriginSecret(basePath?: string): string | undefined {
  * mode / the brain's own box): 32 random bytes, lowercase hex, written 0600.
  * The env override still wins. Throws only if the file can neither be read nor
  * created — callers on best-effort paths should contain that.
+ *
+ * TOCTOU-safe: creation uses the ATOMIC `wx` open flag (exclusive create with
+ * mode 0600) instead of a check-then-write, so two processes racing first-use
+ * (e.g. a capture and the nightly govern) cannot clobber each other — exactly
+ * one writer wins the create; the loser takes `EEXIST` and re-reads the
+ * winner's secret. The winner returns the bytes it wrote (no read-back race).
  */
 export function loadOrCreateOriginSecret(basePath?: string): string {
-  const existing = loadOriginSecret(basePath);
-  if (existing !== undefined) return existing;
+  const env = process.env[ORIGIN_SECRET_ENV]?.trim();
+  if (env !== undefined && env.length > 0) return env;
   const path = originSecretPath(basePath);
-  const secret = randomBytes(32).toString('hex');
+  const minted = randomBytes(32).toString('hex');
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${secret}\n`, { encoding: 'utf8', mode: 0o600 });
-  // writeFileSync's mode only applies at creation; re-assert for pre-existing
-  // empty files so the secret is never group/world readable.
-  chmodSync(path, 0o600);
-  return secret;
+  try {
+    writeFileSync(path, `${minted}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    return minted;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e;
+  }
+  // EEXIST: another process (or an earlier run) already created the file —
+  // the normal idempotent path. Read the winner's secret.
+  const existing = loadOriginSecret(basePath);
+  if (existing === undefined) {
+    throw new Error(
+      `origin secret file exists but is empty or unreadable: ${path} — refusing to overwrite a concurrent writer; inspect/remove it and retry`,
+    );
+  }
+  return existing;
 }
 
 /** Absolute path of the origin-secret file for a given (or default) base dir. */

--- a/packages/common/src/origin-token.ts
+++ b/packages/common/src/origin-token.ts
@@ -1,0 +1,159 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getTeamKbBasePath } from './paths.js';
+
+/**
+ * Write-time provenance origin tokens (GSB Wave-2 H1/H2).
+ *
+ * A capture must carry a verifiable origin: an HMAC-SHA256 token minted at
+ * capture time over the candidate's identity tuple `(id, tenantId, capturedAt)`
+ * keyed by a per-installation secret. The govern/promotion path re-derives the
+ * HMAC with the SAME secret and rejects a candidate whose token does not verify
+ * — a receipted policy-style reject (`origin_token_invalid`), never a crash.
+ *
+ * ## What the token does — and does not — prove
+ *
+ * The token binds a capture to an INSTALLATION (whoever holds the secret) and
+ * to a claimed identity tuple. It proves *where a capture came from*, not that
+ * its content is true: an AUTHENTICATED insider holding the secret can still
+ * mint valid tokens over poisoned content. The mitigations for that residual
+ * are governance policy, human review, and supersession — not this token
+ * (named honestly in the plugin repo's AGENTS.md, H5).
+ *
+ * ## Why HMAC over the identity tuple, not the content
+ *
+ * The spool candidate id is already content-derived
+ * (`uuidV5(ns, workspaceId\0relPath\0bodySha256)` — see `uuid-v5.ts`), so
+ * binding `(id, tenantId, capturedAt)` transitively covers content identity on
+ * the spool path while keeping the token derivation INDEPENDENT of the id
+ * derivation: adding `origin` to a candidate never changes its `id`.
+ *
+ * ## No verification oracle
+ *
+ * Verification results are only ever surfaced as governance outcomes on the
+ * candidate's own promotion path (promote vs `origin_token_invalid` reject).
+ * No API/tool exposes "verify this arbitrary token" — and receipts persist only
+ * a SHA-256 *hash* of the token (see {@link hashOriginToken}), so surfaced
+ * audit details are never enough to replay-mint.
+ */
+
+/** Filename of the per-installation origin secret under the TeamKB base dir. */
+export const ORIGIN_SECRET_FILENAME = 'origin-secret';
+
+/**
+ * Env override for the origin secret (lowercase-hex string). Takes precedence
+ * over the on-disk file. In TEAM mode this is the ONLY client-side source —
+ * a team client must never auto-generate a secret of its own (it would mint
+ * tokens the server's secret cannot verify).
+ */
+export const ORIGIN_SECRET_ENV = 'TEAMKB_ORIGIN_SECRET';
+
+/**
+ * The receipt channel recorded for a candidate that carries NO origin
+ * attestation (pre-H1 spools, legacy captures, team clients without the
+ * distributed secret). Reserved: it is a RECEIPT vocabulary word, never a
+ * client-claimable `origin.channel` value (the schema's tag shape allows it,
+ * but intake allowlists must not include it).
+ */
+export const UNATTESTED_CHANNEL = 'unattested';
+
+/** NUL field separator — injective over ids/tenants/timestamps (mirrors uuid-v5.ts). */
+const FIELD_SEPARATOR = String.fromCharCode(0);
+
+/** The identity tuple an origin token binds. */
+export interface OriginTokenIdentity {
+  /** The candidate's id (UUID). */
+  candidateId: string;
+  /** The tenant the capture claims. */
+  tenantId: string;
+  /** The candidate's `capturedAt` ISO-8601 timestamp, byte-exact. */
+  capturedAt: string;
+}
+
+/** Canonical HMAC input for an identity tuple — NUL-joined, byte-stable. */
+export function buildOriginTokenPayload(identity: OriginTokenIdentity): string {
+  return [identity.candidateId, identity.tenantId, identity.capturedAt].join(FIELD_SEPARATOR);
+}
+
+/**
+ * Mint an origin token: HMAC-SHA256 (lowercase hex) over the identity tuple,
+ * keyed by the installation secret.
+ */
+export function mintOriginToken(secret: string, identity: OriginTokenIdentity): string {
+  return createHmac('sha256', secret)
+    .update(buildOriginTokenPayload(identity), 'utf8')
+    .digest('hex');
+}
+
+/**
+ * Verify a presented origin token against the installation secret in constant
+ * time. Returns false (never throws) for malformed tokens, so a garbage
+ * `tokenHmac` degrades to the same receipted reject as a forged one.
+ */
+export function verifyOriginToken(
+  secret: string,
+  identity: OriginTokenIdentity,
+  tokenHmac: string,
+): boolean {
+  if (!/^[0-9a-f]{64}$/.test(tokenHmac)) return false;
+  const expected = Buffer.from(mintOriginToken(secret, identity), 'hex');
+  const presented = Buffer.from(tokenHmac, 'hex');
+  if (expected.length !== presented.length) return false;
+  return timingSafeEqual(expected, presented);
+}
+
+/**
+ * SHA-256 hex of a token HMAC — what promotion receipts persist (H2). Receipts
+ * must never carry the token itself: the stored/ surfaced value is a one-way
+ * hash, truncated further at surfacing, so audit output can identify a token
+ * without enabling replay-minting.
+ */
+export function hashOriginToken(tokenHmac: string): string {
+  return createHash('sha256').update(tokenHmac, 'utf8').digest('hex');
+}
+
+/** Truncation applied when a receipt/detail surface shows a token hash (H2). */
+export const ORIGIN_TOKEN_HASH_SURFACE_LEN = 16;
+
+/**
+ * Resolve the per-installation origin secret WITHOUT creating one:
+ * `TEAMKB_ORIGIN_SECRET` env first, then `<base>/origin-secret`. Returns
+ * undefined when neither exists. Team-mode clients use exactly this (never the
+ * auto-creating variant): minting under a freshly-invented secret would
+ * produce tokens the server rejects.
+ */
+export function loadOriginSecret(basePath?: string): string | undefined {
+  const env = process.env[ORIGIN_SECRET_ENV]?.trim();
+  if (env !== undefined && env.length > 0) return env;
+  try {
+    const secret = readFileSync(originSecretPath(basePath), 'utf8').trim();
+    return secret.length > 0 ? secret : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the per-installation origin secret, CREATING it on first use (local
+ * mode / the brain's own box): 32 random bytes, lowercase hex, written 0600.
+ * The env override still wins. Throws only if the file can neither be read nor
+ * created — callers on best-effort paths should contain that.
+ */
+export function loadOrCreateOriginSecret(basePath?: string): string {
+  const existing = loadOriginSecret(basePath);
+  if (existing !== undefined) return existing;
+  const path = originSecretPath(basePath);
+  const secret = randomBytes(32).toString('hex');
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${secret}\n`, { encoding: 'utf8', mode: 0o600 });
+  // writeFileSync's mode only applies at creation; re-assert for pre-existing
+  // empty files so the secret is never group/world readable.
+  chmodSync(path, 0o600);
+  return secret;
+}
+
+/** Absolute path of the origin-secret file for a given (or default) base dir. */
+export function originSecretPath(basePath?: string): string {
+  return join(basePath ?? getTeamKbBasePath(), ORIGIN_SECRET_FILENAME);
+}

--- a/packages/schema/src/__tests__/memory-candidate.test.ts
+++ b/packages/schema/src/__tests__/memory-candidate.test.ts
@@ -158,3 +158,25 @@ describe('CandidateOrigin (GSB Wave-2 H1 — write-time provenance)', () => {
     expect(() => CandidateOrigin.parse({ ...validOrigin, mintedAt: 'yesterday' })).toThrow();
   });
 });
+
+describe("CandidateOrigin — 'unattested' is reserved receipt vocabulary (schema-enforced)", () => {
+  const origin = {
+    tokenHmac: 'ab'.repeat(32),
+    channel: 'unattested',
+    mintedAt: '2026-01-15T10:00:00.000Z',
+  };
+
+  it("rejects a client-claimed channel 'unattested' at parse time", () => {
+    const res = CandidateOrigin.safeParse(origin);
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error.issues[0]?.message).toMatch(/reserved receipt vocabulary/);
+      expect(res.error.issues[0]?.path).toEqual(['channel']);
+    }
+  });
+
+  it("rejects a full MemoryCandidate claiming channel 'unattested'", () => {
+    const input = makeMemoryCandidate({ origin });
+    expect(MemoryCandidate.safeParse(input).success).toBe(false);
+  });
+});

--- a/packages/schema/src/__tests__/memory-candidate.test.ts
+++ b/packages/schema/src/__tests__/memory-candidate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MemoryCandidate, PrePolicyFlags } from '../memory-candidate.js';
+import { CandidateOrigin, MemoryCandidate, PrePolicyFlags } from '../memory-candidate.js';
 import { makeMemoryCandidate } from './fixtures.js';
 
 describe('PrePolicyFlags', () => {
@@ -119,5 +119,42 @@ describe('MemoryCandidate', () => {
     );
     expect(result.metadata.filePaths).toEqual(['src/main.ts']);
     expect(result.metadata.language).toBe('typescript');
+  });
+});
+
+describe('CandidateOrigin (GSB Wave-2 H1 — write-time provenance)', () => {
+  const validOrigin = {
+    tokenHmac: 'ab'.repeat(32),
+    channel: 'local-mcp',
+    mintedAt: '2026-01-15T10:00:00.000Z',
+  };
+
+  it('origin is OPTIONAL — a candidate without it parses (backward compatibility)', () => {
+    const result = MemoryCandidate.parse(makeMemoryCandidate());
+    expect(result.origin).toBeUndefined();
+  });
+
+  it('parses a candidate WITH a well-formed origin, without touching id derivation inputs', () => {
+    const input = makeMemoryCandidate({ origin: validOrigin });
+    const result = MemoryCandidate.parse(input);
+    expect(result.origin).toEqual(validOrigin);
+    // The identity fields the spool id derives from are unchanged by origin.
+    expect(result.id).toBe((input as { id: string }).id);
+  });
+
+  it('rejects a tokenHmac that is not 64 lowercase hex chars', () => {
+    for (const bad of ['AB'.repeat(32), 'ab'.repeat(31), 'zz'.repeat(32), '']) {
+      expect(() => CandidateOrigin.parse({ ...validOrigin, tokenHmac: bad })).toThrow();
+    }
+  });
+
+  it('rejects channels that are not bounded kebab tags', () => {
+    for (const bad of ['Team MCP', '-leading-dash', 'UPPER', 'a'.repeat(65), '']) {
+      expect(() => CandidateOrigin.parse({ ...validOrigin, channel: bad })).toThrow();
+    }
+  });
+
+  it('rejects a non-ISO mintedAt', () => {
+    expect(() => CandidateOrigin.parse({ ...validOrigin, mintedAt: 'yesterday' })).toThrow();
   });
 });

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -33,6 +33,8 @@ export {
   PrePolicyFlags,
   MemoryCandidate,
   MEMORY_CANDIDATE_SCHEMA_VERSION,
+  CandidateOrigin,
+  OriginChannel,
 } from './memory-candidate.js';
 export { PolicyEvaluation, SupersessionLink, CuratedMemory } from './curated-memory.js';
 export type { ActiveMemory, SupersededMemory } from './curated-memory.js';

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -20,6 +20,49 @@ export type PrePolicyFlags = z.infer<typeof PrePolicyFlags>;
  */
 export const MEMORY_CANDIDATE_SCHEMA_VERSION = '1' as const;
 
+/**
+ * Capture channel identifier carried inside {@link CandidateOrigin} (H1/H3,
+ * write-time provenance). Tag-shaped (lowercase kebab) and bounded so it can
+ * never carry free-form prose; the team API additionally checks the value
+ * against its authorized-channel allowlist at intake (H3). This is a SHAPE
+ * constraint only — which channels are *authorized* is deployment config, not
+ * schema.
+ */
+export const OriginChannel = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9-]*$/)
+  .max(64);
+export type OriginChannel = z.infer<typeof OriginChannel>;
+
+/**
+ * Write-time provenance attestation (H1). Minted by the CAPTURING client at
+ * capture time: `tokenHmac` is an HMAC-SHA256 (lowercase hex) over the
+ * candidate's identity tuple `(id, tenantId, capturedAt)` keyed by the
+ * per-installation origin secret (see `@qmd-team-intent-kb/common`
+ * origin-token utilities). The govern/promotion path re-derives the HMAC and
+ * rejects a candidate whose token does not verify (`origin_token_invalid`) —
+ * a receipted policy-style reject, never a crash.
+ *
+ * OPTIONAL by design (v1 backward compatibility): every pre-H1 spool line and
+ * legacy capture carries no `origin`, and hard-requiring it would orphan all
+ * of them. An origin-less candidate is accepted and its promotion receipt
+ * records channel `unattested`; only a PRESENT-but-invalid origin rejects.
+ *
+ * Deliberately NOT part of any id derivation: the spool candidate id stays
+ * `uuidV5(namespace, workspaceId\0relPath\0bodySha256)` (content-only inputs),
+ * so adding/removing `origin` never changes `id` and content-stable dedupe is
+ * preserved.
+ */
+export const CandidateOrigin = z.object({
+  /** HMAC-SHA256 of (id, tenantId, capturedAt) under the installation secret — lowercase hex. */
+  tokenHmac: z.string().regex(/^[0-9a-f]{64}$/),
+  /** Which capture surface minted this (e.g. `local-mcp`, `team-mcp`). Self-asserted in local mode (H4). */
+  channel: OriginChannel,
+  /** When the token was minted (ISO-8601). Informational; the HMAC binds `capturedAt`, not this. */
+  mintedAt: IsoDatetime,
+});
+export type CandidateOrigin = z.infer<typeof CandidateOrigin>;
+
 /** A raw memory proposal captured from a Claude Code session, before governance */
 export const MemoryCandidate = z.object({
   schemaVersion: z
@@ -41,5 +84,7 @@ export const MemoryCandidate = z.object({
     duplicateSuspect: false,
   }),
   capturedAt: IsoDatetime,
+  /** Optional write-time provenance attestation (H1) — verified before promotion when present. */
+  origin: CandidateOrigin.optional(),
 });
 export type MemoryCandidate = z.infer<typeof MemoryCandidate>;

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -53,14 +53,28 @@ export type OriginChannel = z.infer<typeof OriginChannel>;
  * so adding/removing `origin` never changes `id` and content-stable dedupe is
  * preserved.
  */
-export const CandidateOrigin = z.object({
-  /** HMAC-SHA256 of (id, tenantId, capturedAt) under the installation secret — lowercase hex. */
-  tokenHmac: z.string().regex(/^[0-9a-f]{64}$/),
-  /** Which capture surface minted this (e.g. `local-mcp`, `team-mcp`). Self-asserted in local mode (H4). */
-  channel: OriginChannel,
-  /** When the token was minted (ISO-8601). Informational; the HMAC binds `capturedAt`, not this. */
-  mintedAt: IsoDatetime,
-});
+export const CandidateOrigin = z
+  .object({
+    /** HMAC-SHA256 of (id, tenantId, capturedAt) under the installation secret — lowercase hex. */
+    tokenHmac: z.string().regex(/^[0-9a-f]{64}$/),
+    /** Which capture surface minted this (e.g. `local-mcp`, `team-mcp`). Self-asserted in local mode (H4). */
+    channel: OriginChannel,
+    /** When the token was minted (ISO-8601). Informational; the HMAC binds `capturedAt`, not this. */
+    mintedAt: IsoDatetime,
+  })
+  // `unattested` is RECEIPT vocabulary — the promotion receipt's marker for a
+  // candidate that carries NO origin at all. Enforcing the reservation here in
+  // the schema (not just by allowlist convention) means a client can never
+  // CLAIM it, and even an operator who mistakenly adds `unattested` to the
+  // intake allowlist cannot make such a claim parse: the candidate is refused
+  // at the schema boundary before any allowlist logic runs. Keep the literal
+  // in sync with `UNATTESTED_CHANNEL` in `@qmd-team-intent-kb/common`
+  // (schema is the base package and cannot import common).
+  .refine((o) => o.channel !== 'unattested', {
+    message:
+      "origin.channel 'unattested' is reserved receipt vocabulary for candidates without an origin — a client cannot claim it",
+    path: ['channel'],
+  });
 export type CandidateOrigin = z.infer<typeof CandidateOrigin>;
 
 /** A raw memory proposal captured from a Claude Code session, before governance */

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -23,6 +23,8 @@ const CandidateRowSchema = z.object({
   content_hash: z.string(),
   captured_at: z.string(),
   created_at: z.string(),
+  /** Optional write-time provenance attestation (H1) — NULL on every pre-H1 row. */
+  origin_json: z.string().nullable(),
 });
 
 /**
@@ -44,6 +46,7 @@ function rowToCandidate(row: unknown): MemoryCandidate {
   let author: unknown;
   let metadata: unknown;
   let prePolicyFlags: unknown;
+  let origin: unknown;
 
   try {
     author = JSON.parse(flat.author_json);
@@ -62,6 +65,11 @@ function rowToCandidate(row: unknown): MemoryCandidate {
       `candidates row id=${flat.id}: pre_policy_flags_json is not valid JSON: ${String(e)}`,
     );
   }
+  try {
+    origin = flat.origin_json === null ? undefined : JSON.parse(flat.origin_json);
+  } catch (e) {
+    throw new Error(`candidates row id=${flat.id}: origin_json is not valid JSON: ${String(e)}`);
+  }
 
   const domainResult = MemoryCandidate.safeParse({
     id: flat.id,
@@ -76,6 +84,7 @@ function rowToCandidate(row: unknown): MemoryCandidate {
     metadata,
     prePolicyFlags,
     capturedAt: flat.captured_at,
+    origin,
   });
 
   if (!domainResult.success) {
@@ -136,12 +145,12 @@ export class CandidateRepository {
         id, status, source, content, title, category,
         trust_level, author_json, tenant_id,
         metadata_json, pre_policy_flags_json, content_hash, captured_at,
-        import_batch_id
+        import_batch_id, origin_json
       ) VALUES (
         @id, @status, @source, @content, @title, @category,
         @trust_level, @author_json, @tenant_id,
         @metadata_json, @pre_policy_flags_json, @content_hash, @captured_at,
-        @import_batch_id
+        @import_batch_id, @origin_json
       )
     `);
 
@@ -246,6 +255,7 @@ export class CandidateRepository {
       content_hash: contentHash,
       captured_at: candidate.capturedAt,
       import_batch_id: importBatchId ?? null,
+      origin_json: candidate.origin !== undefined ? JSON.stringify(candidate.origin) : null,
     });
   }
 

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -451,4 +451,20 @@ CREATE TABLE IF NOT EXISTS index_state (
 );
     `.trim(),
   },
+  {
+    // Write-time provenance (GSB Wave-2 H1). One nullable JSON column holding
+    // the candidate's optional `origin` attestation ({ tokenHmac, channel,
+    // mintedAt } — validated by the Zod `CandidateOrigin` schema, mirroring the
+    // other *_json columns; no CHECK constraint, so future origin fields need
+    // no further migration). NULL = unattested (every pre-H1 row), which the
+    // govern path accepts for backward compatibility — only a PRESENT-but-
+    // unverifiable origin rejects. Purely additive: no existing row changes, no
+    // index (origin is never a query key; verification reads the row it
+    // already has).
+    version: 11,
+    name: 'add_candidates_origin',
+    sql: `
+ALTER TABLE candidates ADD COLUMN origin_json TEXT;
+    `.trim(),
+  },
 ];

--- a/packages/test-fixtures/src/index.ts
+++ b/packages/test-fixtures/src/index.ts
@@ -12,7 +12,7 @@
  */
 
 export { FIXED_NOW, DEFAULT_TENANT, HASH_A, HASH_B, DEFAULT_CONTENT } from './constants.js';
-export { makeCandidate, makeCandidateWithHash } from './make-candidate.js';
+export { makeCandidate, makeCandidateWithHash, makeAttestedCandidate } from './make-candidate.js';
 export { makeMemory } from './make-memory.js';
 export { makePolicy } from './make-policy.js';
 export { makeAuditEvent } from './make-audit-event.js';

--- a/packages/test-fixtures/src/make-candidate.ts
+++ b/packages/test-fixtures/src/make-candidate.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { computeContentHash, mintOriginToken } from '@qmd-team-intent-kb/common';
 import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { FIXED_NOW, DEFAULT_TENANT, DEFAULT_CONTENT } from './constants.js';
 
@@ -30,6 +30,33 @@ export function makeCandidate(overrides?: Record<string, unknown>): MemoryCandid
  * hash.  Convenient for tests that need to assert on dedup / hash behaviour
  * without re-deriving the hash themselves.
  */
+/**
+ * Build a candidate carrying a VALID origin attestation (GSB Wave-2 H1):
+ * the `origin.tokenHmac` is minted with the given secret over the candidate's
+ * final `(id, tenantId, capturedAt)` — including any overrides — so the
+ * resulting candidate verifies at the origin gate. Pass `channel` via
+ * `originChannel` (default `local-mcp`).
+ */
+export function makeAttestedCandidate(
+  secret: string,
+  overrides?: Record<string, unknown>,
+  originChannel = 'local-mcp',
+): MemoryCandidate {
+  const base = makeCandidate(overrides);
+  return MemoryCandidate.parse({
+    ...base,
+    origin: {
+      tokenHmac: mintOriginToken(secret, {
+        candidateId: base.id,
+        tenantId: base.tenantId,
+        capturedAt: base.capturedAt,
+      }),
+      channel: originChannel,
+      mintedAt: base.capturedAt,
+    },
+  });
+}
+
 export function makeCandidateWithHash(overrides?: Record<string, unknown>): {
   candidate: MemoryCandidate;
   contentHash: string;


### PR DESCRIPTION
## What

Write-time provenance for the governed brain (GSB Wave-2 tracks H1/H2/H3, govern side):

- **Schema (H1):** `MemoryCandidate` gains an **optional** `origin { tokenHmac, channel, mintedAt }` (`CandidateOrigin`, exported): `tokenHmac` = HMAC-SHA256 (lowercase hex) over the identity tuple `(id, tenantId, capturedAt)` keyed by a per-installation secret; `channel` is a bounded kebab tag; `mintedAt` is informational (the HMAC binds `capturedAt`).
- **Crypto + secret lifecycle:** new `packages/common/src/origin-token.ts` — `mintOriginToken` / `verifyOriginToken` (constant-time, never throws on malformed input) / `hashOriginToken` (receipt form) / `loadOriginSecret` / `loadOrCreateOriginSecret` (auto-creates `~/.teamkb/origin-secret`, 64-hex, **0600**; env `TEAMKB_ORIGIN_SECRET` overrides).
- **Store:** migration 11 adds nullable `candidates.origin_json`; `CandidateRepository` round-trips it (NULL = unattested on every pre-H1 row).
- **Govern gate (H1):** new `apps/curator/src/origin/origin-gate.ts` (`checkOriginAttestation`), run **structurally** in `Curator.processSingle` and in the API `PromotionService` **before** any promotion. Forged/replayed claim → receipted, policy-pipeline-shaped reject `origin_token_invalid` (API: 422 with that stable code). Claimed-but-unverifiable (no secret on the govern path) → `origin_token_unverifiable`, fail-closed. **Missing origin → accepted** and receipted as channel `unattested` (v1 backward compatibility).
- **Receipts (H2):** the `promoted` audit event's `details` now carry `originChannel` (or `unattested`) plus `originTokenHash` = SHA-256 of the token **truncated to 16 hex chars** — never the token; any surfacing of receipts (audit routes, verbose views) therefore shows only channel + truncated hash, and no verify-arbitrary-token oracle exists anywhere.
- **Channel allowlist (H3):** team API intake refuses a capture **claiming** an unrecognized `origin.channel` with a distinct **422 + stable code `unrecognized_channel`** (`ApiError` gains an optional machine `code`). Default allowlist `team-mcp, local-mcp`; `TEAMKB_ALLOWED_CHANNELS` (csv) overrides. Origin-less captures skip the check.
- Wiring: API `main.ts`/`buildApp` (secret + allowlist), curator CLI, edge-daemon cycle. Decision record: `000-docs/049-AT-DECR-write-time-provenance-origin-tokens.md` (+ index).

## Why + decision rationale

A capture must carry a **verifiable origin** so the deterministic govern path can reject forged provenance with a receipt instead of trusting every writer equally. Key choices:

- **Structural gate over a new `PolicyRuleType`** — rule sets are per-tenant *configuration*; a configurable rule would be dormant on every pre-H1 policy and absent when no policy is enabled. Provenance verification is an integrity property of the write path (same reasoning as the existing structural dedup check). The gate still emits a `PipelineResult`-shaped rejection (`ruleType: origin_attestation`) so receipts/422s look exactly like policy rejects.
- **Accept-with-`unattested` over hard-reject for missing origin** — a flag-day would orphan **every** pre-H1 spool line, ICO emission, and legacy capture. Documented honestly in 046-AT-DECR: this is a compatibility posture, not a security claim (an attacker can still omit `origin` and be governed exactly as pre-H1); what H1 adds is a positive attestation channel whose forgery is detectable + receipt-level visibility of the gap, so a future reject-unattested flag-day can be data-driven.
- **HMAC over the identity tuple, not content** — the spool id is already content-derived, so the tuple transitively covers content identity while keeping token derivation independent of id derivation.

## Candidate-id stability (the spool contract)

The spool contract stays **UUID-v5 content-stable**: `id = uuidV5(SPOOL_UUID_NAMESPACE, "{workspaceId}\0{relPath}\0{bodySha256}")` (`packages/common/src/uuid-v5.ts`). That derivation reads **only** those three content fields — never the candidate object — so adding the optional `origin` field **cannot change any id**; dedupe-by-id and cross-clone id lineage are untouched. The compiler repo's vendored contract snapshot + test were resynced in lock-step (PR below).

## Layers touched / invariants

`schema` (additive optional field), `common` (new module), `store` (additive migration 11), `curator` (structural pre-pipeline gate), `api` (intake gate + promotion gate + error code), `edge-daemon` (secret wiring). Audit-chain invariants hold: receipt `details` additions are pure functions of candidate fields, so cross-clone `entry_hash` reproducibility (8da.5/8da.6) is preserved. `unattested` is reserved receipt vocabulary, never an allowlisted claimable channel.

## Verification & evidence

- `pnpm build` + full `pnpm test`: **184 files / 2219 tests green**, including new suites:
  - `packages/common/src/__tests__/origin-token.test.ts` — mint/verify round-trip; forged-secret negative; replay-across-identity negative (tenant/id/capturedAt each); malformed-token tolerance; NUL-join injectivity; secret file 0600 + idempotent + env override; `loadOriginSecret` never creates.
  - `apps/curator/src/__tests__/origin-gate.test.ts` — verdict table; forged token → receipted reject naming `origin_token_invalid`, nothing promoted; unattested legacy candidate still promotes with `originChannel: unattested`; valid attestation promotes with channel + 16-char truncated hash (asserted ≠ token); fail-closed no-secret; store round-trip incl. legacy NULL row.
  - `apps/api/src/__tests__/origin-provenance.test.ts` — H3 `unrecognized_channel` 422 (+ nothing written), allowed-channel 201, deployment allowlist override, forged-token promote 422 `origin_token_invalid` (candidate left in inbox), H2 receipt assertions (token never serialized into the receipt), fail-closed no-secret promote 422.
- `pnpm lint` + `pnpm format` + `pnpm typecheck` clean.

## Risk assessment

Additive schema/store change; every existing row/parse path is unaffected (`origin` optional, column nullable). The only new rejection class applies to candidates that **claim** an origin: forged → rejected (intended), and on a secret-less govern path → `origin_token_unverifiable` (fail-closed by design; every shipped govern entrypoint resolves/auto-creates the secret best-effort). Disclosure scanner walks the new string fields automatically (structural walker) and the 64-hex tokenHmac matches no prefix-anchored secret pattern (verified by the full suite).

## Operational impact

- New file on brain hosts: `~/.teamkb/origin-secret` (0600, auto-created on first govern/boot/capture). Back it up like `tokens.json`; env `TEAMKB_ORIGIN_SECRET` overrides (never logged).
- New optional env: `TEAMKB_ALLOWED_CHANNELS` (csv; default `team-mcp,local-mcp`).
- DB migration 11 runs automatically (additive `ALTER TABLE`). Rollback = revert the branch; the extra column is inert to old code paths only insofar as old builds ignore unknown columns — standard additive posture.
- Team members get attested captures **only after** the admin distributes `TEAMKB_ORIGIN_SECRET`; until then their captures are unattested and work exactly as today.

## Follow-up & deferred

- A future reject-unattested flag-day per deployment, once receipt data shows attestation coverage (046-AT-DECR).
- Asymmetric per-user signatures (cross-actor non-repudiation) deliberately out of scope v1.

## Review response — MiniMax defect lane, round 1 (all five accepted, fixed in `7769012`)

1. **`unattested` reserved in-schema** — `CandidateOrigin` now carries `.refine(o => o.channel !== 'unattested', ...)`, moving the receipt-vocabulary invariant from allowlist convention into the schema. New tests: `CandidateOrigin`/`MemoryCandidate` parse rejection, plus an API test that builds the app with a **mistakenly-allowlisted** `['unattested', 'team-mcp']` and proves the claim still dies at the schema boundary (400 `Invalid candidate`, nothing written) before allowlist logic runs.
2. **TOCTOU in `loadOrCreateOriginSecret`** — creation is now an atomic exclusive-create (`flag: 'wx'`, `mode: 0o600`); `EEXIST` → re-read via `loadOriginSecret` is the *normal* idempotent path (chose always-attempt-`wx` over check-then-create precisely so the race branch is deterministically testable, not a timing window). Tests: a pre-created "winner" file is adopted un-clobbered; an existing-but-**empty** file throws (`exists but is empty or unreadable`) instead of being silently overwritten.
3. **Symmetric degradation logging** — one shared exported string, `ORIGIN_SECRET_UNAVAILABLE_WARNING` (`origin secret unavailable — origin-claiming candidates will be refused as unverifiable`), now emitted by all three entrypoints: API boot (stderr), curator CLI (stderr), edge-daemon (`DaemonLogger.warn`). Operators grep one phrase across all surfaces.
4. **chmod comment/behavior mismatch** — resolved in favor of the *real* defensive chmod: `loadOriginSecret` clamps a widened mode back to `0600` on every read (best-effort, never turns a readable secret into a failure). Test: `chmod 644` → read → asserted back at `0600`. The stale creation-time comment is gone (`wx` + `mode` handles creation).
5. **(Minor) uuid-v5 independence test** — `deriveCandidateId` over the same `(workspaceId, relPath, bodySha256)` asserted byte-identical with and without `origin` attached to the parsed candidate — the spool id-stability claim is now load-bearing, not prose.

**Rebase note:** rebased onto `origin/main` (post #297/#298). Main took doc number 046 for the chain-boundary doctrine doc, so the H1 decision record is renumbered **046→047→049** (merge-queue assignments: #298 took 046, #299 took 047, #301 holds 048; 049 assigned centrally) (`000-docs/049-AT-DECR-write-time-provenance-origin-tokens.md`; `000-INDEX` next-sequence 050). The plugin (#54) and compiler (#179) branches have been repointed to 049-AT-DECR (plugin tip `c3fcd79`); the compiler (#179) re-touches after this PR merges.

**Gates re-run at tip `7769012`:** `pnpm build` + full `pnpm test` — **185 files / 2233 tests green** (+14 new) + `pnpm lint` + `pnpm format` + `pnpm typecheck`.

## Cross-references (do not merge in isolation)

- Plugin (capture-side minting, H1/H4/H5): https://github.com/jeremylongshore/bobs-big-brain-plugin/pull/54
- Compiler (contract snapshot resync): https://github.com/jeremylongshore/bobs-big-brain-compiler/pull/179
- Decision record: `000-docs/049-AT-DECR-write-time-provenance-origin-tokens.md` (this PR).

- Jeremy Longshore
intentsolutions.io


