### PR TITLE
ci(seam): three seam-independence gates — delete-Compile, swap-model zero-migration, model-free receipts (GSB Wave-2 B3)

### DIFF
--- a/.github/workflows/seam-independence.yml
+++ b/.github/workflows/seam-independence.yml
@@ -1,0 +1,186 @@
+name: Seam independence
+
+# GSB Wave-2 track B3 — three CI gates that prove the compile/govern seam
+# holds BY CONSTRUCTION, dynamically (the dependency-cruiser rule
+# `no-govern-imports-retrieval` is the static half; these jobs are the runtime
+# half — each FAILS when the property breaks, not just when a happy path runs):
+#
+#   delete-compile              deleting the Compile-side retrieval sources
+#                               (qmd executor, native FTS5 backend, rerank
+#                               client/stage — all of packages/qmd-adapter/src)
+#                               leaves the GOVERN core building and passing its
+#                               tests untouched.
+#   swap-model-zero-migration   changing the reranker model identity (file +
+#                               weights sha) is a cache-NAMESPACE change in the
+#                               derived sidecar — zero governed-state migration,
+#                               no governed table touched.
+#   verify-receipts-model-free  every receipt verifier reaches its verdict in
+#                               an environment where NO ML dependency is
+#                               loadable (no qmd binary on PATH, retrieval
+#                               sources deleted).
+#
+# Why a separate workflow instead of jobs in ci.yml: every ci.yml job is a
+# branch-protection-REQUIRED check. These three start as NON-required jobs
+# (marking them required is a later human/API step once they prove stable), and
+# they share one conceptual property, so they group under their own
+# individually-named workflow — the same pattern as the moat-evals /
+# retrieval-eval split (a property gate a ci.yml refactor cannot silently
+# absorb or weaken).
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: 'seam-independence-${{ github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  delete-compile:
+    # Claim: deleting Compile-side retrieval does not break Govern.
+    #
+    # Mechanism — physical deletion, not a vitest alias/module-mock layer:
+    # after install, `packages/qmd-adapter/src` (executor + native FTS5 +
+    # rerank) is rm -rf'd, then the govern surface is built and tested through
+    # its normal package scripts. Deletion is the least-hacky stub because
+    # there is no indirection that could silently keep the real modules
+    # reachable (an alias map drifts; an empty src cannot). The failure paths
+    # are real compiler/loader failures (all locally rehearsed red):
+    #   - a govern package that DECLARES qmd-adapter as a dependency pulls it
+    #     into the `--filter ...` closure, whose `tsc` fails on the empty src;
+    #   - a govern BINDING import without the declared dep fails tsc module
+    #     resolution (TS2307, pnpm isolated node_modules) in the build step;
+    #   - a side-effect-only `import 'pkg'` (which tsc deliberately does not
+    #     type-resolve) is caught by the TEST step instead: node/vite module
+    #     resolution fails at runtime. The build+test pair is load-bearing —
+    #     do not drop either step.
+    # This is the dynamic twin of the static dependency-cruiser rule
+    # `no-govern-imports-retrieval`.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Delete the Compile-side retrieval sources (qmd executor, FTS5 backend, rerank)
+        run: |
+          rm -rf packages/qmd-adapter/src packages/qmd-adapter/dist
+          test ! -d packages/qmd-adapter/src
+
+      # Deliberately NOT putting workspace bins on PATH — the govern core must
+      # also build and test without the qmd binary being resolvable.
+
+      - name: Build the govern core (schema, policy-engine, store, curator promoter, audit chain)
+        # `--filter <pkg>...` = the package plus its full dependency closure,
+        # built in topological order. curator + eval-surface together close
+        # over every govern package (schema, common, claude-runtime,
+        # repo-resolver, policy-engine, store, test-fixtures). qmd-adapter is
+        # in NEITHER closure — and if a change ever adds it, this step builds
+        # the deleted package and fails.
+        run: >
+          pnpm --filter @qmd-team-intent-kb/curator...
+          --filter @qmd-team-intent-kb/eval-surface...
+          run build
+
+      - name: Test the govern core with retrieval deleted
+        run: >
+          pnpm exec vitest run
+          packages/schema packages/common packages/claude-runtime
+          packages/repo-resolver packages/store packages/policy-engine
+          packages/eval-surface apps/curator
+
+  swap-model-zero-migration:
+    # Claim: swapping the reranker model identity needs ZERO governed-state
+    # migration — the content-addressed sidecar cache keys on (model file,
+    # weights sha256), exactly what buildRerankStage reads from the weights
+    # manifest, so a model bump changes the cache NAMESPACE, never a schema,
+    # and never touches a governed table. The tsx script swaps in a fixture
+    # identity (different file + sha) and asserts: stale score MISSes, old and
+    # new rows coexist, sidecar schema byte-identical, governed DB file bytes
+    # untouched, re-open applies no new migration, governed schema hash
+    # unchanged. Any broken assertion exits non-zero.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Build workspace (the script imports @qmd-team-intent-kb/store via dist)
+        run: pnpm build
+      - name: Swap-model zero-migration proof
+        run: pnpm --filter @qmd-team-intent-kb/qmd-adapter seam:swap-model:ci
+
+  verify-receipts-model-free:
+    # Claim: receipts verify model-free. All four receipt verifiers —
+    # verify-audit-chain, verify-corpus-accounting, provenance-walk (on a
+    # seeded on-disk fixture), and the provenance-integrity eval — reach their
+    # verdicts in an environment with NO ML dependency loadable: the retrieval
+    # sources are deleted (same mechanism as delete-compile) and no qmd binary
+    # is on PATH (the workspace bin is removed and asserted absent). If a
+    # verifier ever grows an import of the rerank/executor modules, the
+    # filtered build fails on the deleted src; if one ever shells out to qmd,
+    # the missing binary fails it.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Make ML dependencies unloadable (delete retrieval sources, drop the qmd binary)
+        run: |
+          rm -rf packages/qmd-adapter/src packages/qmd-adapter/dist
+          rm -f node_modules/.bin/qmd
+          rm -rf node_modules/.pnpm/@tobilu+qmd@*
+          if command -v qmd; then
+            echo "qmd binary still resolvable — environment is not model-free" >&2
+            exit 1
+          fi
+
+      - name: Build the verifier surface (govern core only)
+        run: >
+          pnpm --filter @qmd-team-intent-kb/curator...
+          --filter @qmd-team-intent-kb/eval-surface...
+          run build
+
+      - name: Provenance-integrity eval (forks pass / tamper fails), model-free
+        run: pnpm --filter @qmd-team-intent-kb/eval-surface provenance:ci
+
+      - name: Seed the on-disk receipts fixture (real promoter path + spool manifest + trace)
+        run: >
+          pnpm --filter @qmd-team-intent-kb/curator seam:receipts-fixture
+          -- --out "$RUNNER_TEMP/receipts-fixture"
+
+      - name: verify-audit-chain, model-free
+        run: node apps/curator/dist/main.js verify-audit-chain --db "$RUNNER_TEMP/receipts-fixture/teamkb.db" --json
+
+      - name: verify-corpus-accounting, model-free
+        run: node apps/curator/dist/main.js verify-corpus-accounting --db "$RUNNER_TEMP/receipts-fixture/teamkb.db" --json
+
+      - name: provenance-walk over the fixture (all 7 links PASS), model-free
+        run: |
+          MEMORY_ID="$(node -p "require('$RUNNER_TEMP/receipts-fixture/fixture.json').memoryId")"
+          node apps/curator/dist/main.js provenance-walk \
+            --memory-id "$MEMORY_ID" \
+            --db "$RUNNER_TEMP/receipts-fixture/teamkb.db" \
+            --brain "$RUNNER_TEMP/receipts-fixture/brain" \
+            --spool "$RUNNER_TEMP/receipts-fixture/spool" \
+            --json

--- a/apps/curator/package.json
+++ b/apps/curator/package.json
@@ -20,7 +20,8 @@
     "dev": "tsx watch src/index.ts",
     "test": "vitest run",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "seam:receipts-fixture": "tsx scripts/ci-seed-receipts-fixture.ts"
   },
   "dependencies": {
     "@intentsolutions/core": "^0.10.0",

--- a/apps/curator/scripts/ci-seed-receipts-fixture.ts
+++ b/apps/curator/scripts/ci-seed-receipts-fixture.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env tsx
+/**
+ * ci-seed-receipts-fixture — seed a small ON-DISK governed brain fixture for
+ * the `verify-receipts-model-free` seam-independence CI job (blueprint bead
+ * B3; workflow `.github/workflows/seam-independence.yml`).
+ *
+ * The job's claim: every receipt verifier (verify-audit-chain,
+ * verify-corpus-accounting, provenance-walk, the provenance-integrity eval)
+ * runs to a verdict in an environment where NO ML dependency is loadable —
+ * no qmd binary on PATH, the retrieval package's source deleted. To exercise
+ * the verifiers for real (not against an empty in-memory DB), this script
+ * builds the same fixture shape as `__tests__/provenance-walk.test.ts`, but
+ * on disk and WITHOUT importing test-fixtures (which production-adjacent
+ * code must not import — dep-cruiser invariant 5):
+ *
+ *   <out>/teamkb.db   governed store: 1 candidate + 1 promoted memory +
+ *                     the 'promoted' audit receipt, all planted through the
+ *                     REAL CandidateRepository.insert + promote() path
+ *   <out>/brain/      fabricated ICO brain root with one compile-trace event
+ *   <out>/spool/      spool file + SHA-256 manifest sidecar naming the candidate
+ *   <out>/fixture.json  { dbPath, brainDir, spoolDir, memoryId }
+ *
+ * The candidate id is content-addressed exactly as ICO derives it
+ * (deriveCandidateId(workspaceId, relPath, sha256(body))), so a
+ * `provenance-walk` over this fixture walks all 7 links to PASS / exit 0.
+ *
+ * Usage: tsx scripts/ci-seed-receipts-fixture.ts --out <dir>
+ * Exit 0 on success; 1 on any failure.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+
+import { computeContentHash, deriveCandidateId } from '@qmd-team-intent-kb/common';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import {
+  AuditRepository,
+  CandidateRepository,
+  MemoryRepository,
+  createDatabase,
+} from '@qmd-team-intent-kb/store';
+
+import { promote } from '../src/promotion/promoter.js';
+
+const REL_PATH = 'wiki/concepts/seam-receipts-fixture.md';
+const BODY = '## Seam fixture\n\nA compiled page body used to content-address the candidate.';
+const TENANT = 'ci-seam-receipts';
+
+function main(): void {
+  const outFlag = process.argv.indexOf('--out');
+  if (outFlag === -1 || process.argv[outFlag + 1] === undefined) {
+    process.stderr.write('usage: ci-seed-receipts-fixture --out <dir>\n');
+    process.exit(1);
+  }
+  const out = resolve(process.argv[outFlag + 1] as string);
+  rmSync(out, { recursive: true, force: true });
+  const brainDir = join(out, 'brain');
+  const spoolDir = join(out, 'spool');
+  mkdirSync(join(brainDir, 'audit', 'traces'), { recursive: true });
+  mkdirSync(spoolDir, { recursive: true });
+
+  // Candidate id derived exactly as ICO derives it: workspaceId is the
+  // basename of the brain root; body sha is the sha256 of the page body.
+  const bodySha256 = computeContentHash(BODY);
+  const candidateId = deriveCandidateId(basename(brainDir), REL_PATH, bodySha256);
+  const candidate = MemoryCandidate.parse({
+    id: candidateId,
+    status: 'inbox',
+    source: 'import',
+    content: BODY,
+    title: 'Seam receipts fixture',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'ci-seam' },
+    tenantId: TENANT,
+    metadata: { filePaths: [REL_PATH], projectContext: 'ico', tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  const dbPath = join(out, 'teamkb.db');
+  const db = createDatabase({ path: dbPath });
+  try {
+    const contentHash = computeContentHash(candidate.content);
+    new CandidateRepository(db).insert(candidate, contentHash);
+    const pipelineResult: PipelineResult = {
+      candidateId: candidate.id,
+      outcome: 'approved',
+      evaluations: [],
+    };
+    const memory = promote(
+      { candidate, contentHash, pipelineResult },
+      new MemoryRepository(db),
+      new AuditRepository(db),
+    );
+
+    // Spool file + manifest sidecar, shaped like ICO's emit (spoolFileSha256
+    // pins the file bytes; candidateIds lists the emitted ids).
+    const spoolFile = join(spoolDir, 'spool-2026-01-01T000000Z.jsonl');
+    const spoolBody = JSON.stringify({ id: candidateId }) + '\n';
+    writeFileSync(spoolFile, spoolBody);
+    writeFileSync(
+      `${spoolFile}.manifest.json`,
+      JSON.stringify({
+        schemaVersion: '1',
+        emittedCount: 1,
+        spoolFile: basename(spoolFile),
+        spoolFileSha256: createHash('sha256').update(spoolBody, 'utf8').digest('hex'),
+        candidateIds: [candidateId],
+      }),
+    );
+
+    // One hash-chained ICO trace event referencing the compiled page.
+    writeFileSync(
+      join(brainDir, 'audit', 'traces', '2026-01-01.jsonl'),
+      JSON.stringify({
+        timestamp: '2026-01-01T00:00:00.000Z',
+        event_type: 'compile.summarize',
+        event_id: 'seam-fixture-event-1',
+        payload: { sourceId: 'seam-fixture-source', outputPath: REL_PATH },
+        prev_hash: 'a'.repeat(64),
+      }) + '\n',
+    );
+
+    writeFileSync(
+      join(out, 'fixture.json'),
+      JSON.stringify({ dbPath, brainDir, spoolDir, memoryId: memory.id }, null, 2) + '\n',
+    );
+    process.stderr.write(`seeded receipts fixture: ${out} (memory ${memory.id})\n`);
+  } finally {
+    db.close();
+  }
+}
+
+main();

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -23,6 +23,7 @@
     "reindex": "node dist/cli.js reindex",
     "search-canary": "node dist/cli.js canary",
     "eval:retrieval:ci": "node dist/eval/ci-retrieval-ratchet.js",
+    "seam:swap-model:ci": "tsx scripts/ci-swap-model-zero-migration.ts",
     "eval:governed:local": "node dist/eval/governed-eval-anchor.js"
   },
   "dependencies": {

--- a/packages/qmd-adapter/scripts/ci-swap-model-zero-migration.ts
+++ b/packages/qmd-adapter/scripts/ci-swap-model-zero-migration.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env tsx
+/**
+ * ci-swap-model-zero-migration — prove that swapping the reranker model
+ * identity requires ZERO governed-state migration (seam-independence CI job
+ * `swap-model-zero-migration`; blueprint bead B3; workflow
+ * `.github/workflows/seam-independence.yml`).
+ *
+ * The property, by construction: `buildRerankStage` (adapter.ts) keys the
+ * content-addressed sidecar score cache on the PINNED reranker identity —
+ * `(model file, weights sha256)` from QMD_WEIGHTS_MANIFEST — and the sidecar
+ * lives beside the other derived indexes, never inside the governed store. So
+ * a model bump is a CACHE-NAMESPACE change, not a schema change: prior scores
+ * become invisible (and are lazily rebuilt), and no governed table is touched.
+ *
+ * This script proves it dynamically, using a SWAPPED model identity exactly
+ * where buildRerankStage reads the manifest entry (a fixture identity with a
+ * different file + sha256):
+ *
+ *   1. Creates a real governed store (createDatabase → full DDL + migrations)
+ *      in a temp dir, closes it, and byte-hashes the DB file.
+ *   2. Opens a RerankCache under the PINNED reranker identity, stores a score.
+ *   3. Re-opens the SAME sidecar file under the SWAPPED identity and asserts:
+ *        a. the stale score is a MISS (namespace change — a swapped model can
+ *           never serve another model's scores),
+ *        b. writing under the swapped identity coexists with the old row
+ *           (2 rows; nothing destroyed, nothing migrated),
+ *        c. the sidecar's sqlite schema is BYTE-IDENTICAL before/after the
+ *           swap (a namespace change, not a schema change).
+ *   4. Asserts the governed store needed ZERO migration for the swap:
+ *        d. the DB file bytes are untouched (the rerank path never opened it),
+ *        e. re-opening the store applies no new migration
+ *           (MAX(schema_migrations.version) unchanged),
+ *        f. the governed schema hash (sqlite_master) is unchanged.
+ *
+ * Any failed assertion exits 1 with a diagnostic — the CI job goes red if the
+ * cache stops keying on model identity, if a model swap starts mutating the
+ * governed store, or if it starts requiring a migration.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { createDatabase } from '@qmd-team-intent-kb/store';
+
+import { RerankCache } from '../src/rerank/rerank-cache.js';
+import { rerankScore } from '../src/rerank/rerank-client.js';
+import { QMD_WEIGHTS_MANIFEST } from '../src/weights/weights-manifest.js';
+
+function fail(msg: string): never {
+  throw new Error(msg);
+}
+
+function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/** Canonical hash of a SQLite database's schema (sqlite_master DDL, sorted). */
+function schemaHash(dbPath: string): string {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare("SELECT type, name, COALESCE(sql, '') AS sql FROM sqlite_master ORDER BY type, name")
+      .all() as Array<{ type: string; name: string; sql: string }>;
+    return createHash('sha256')
+      .update(rows.map((r) => `${r.type}\x00${r.name}\x00${r.sql}`).join('\x01'))
+      .digest('hex');
+  } finally {
+    db.close();
+  }
+}
+
+function maxMigrationVersion(db: ReturnType<typeof createDatabase>): number {
+  return (
+    db.prepare('SELECT COALESCE(MAX(version), 0) AS v FROM schema_migrations').get() as {
+      v: number;
+    }
+  ).v;
+}
+
+const root = mkdtempSync(join(tmpdir(), 'seam-swap-model-'));
+try {
+  // ---- 1. A real governed store, then hands off it -------------------------
+  const governedDbPath = join(root, 'governed', 'teamkb.db');
+  const governed = createDatabase({ path: governedDbPath });
+  const migrationsBefore = maxMigrationVersion(governed);
+  governed.close();
+  const governedBytesBefore = sha256File(governedDbPath);
+  const governedSchemaBefore = schemaHash(governedDbPath);
+
+  // ---- 2. Pinned identity — exactly what buildRerankStage reads -----------
+  const pinned = QMD_WEIGHTS_MANIFEST.models.find((m) => m.id === 'reranker');
+  if (pinned === undefined) fail('weights manifest has no reranker entry');
+
+  // Swapped identity fixture: a different GGUF file + sha256, i.e. the model
+  // bump buildRerankStage would pick up from an updated manifest entry.
+  const swapped = {
+    file: 'hf_fixture_swapped-reranker-q8_0.gguf',
+    sha256: createHash('sha256').update('seam-swapped-reranker-weights').digest('hex'),
+  };
+  if (swapped.file === pinned.file || swapped.sha256 === pinned.sha256) {
+    fail('fixture identity must differ from the pinned identity');
+  }
+
+  const sidecarPath = join(root, 'qmd-index', 'tenant', 'rerank-cache.sqlite');
+  const query = 'what does the seam firewall enforce?';
+  const docContentHash = createHash('sha256').update('seam doc body').digest('hex');
+
+  const cacheA = new RerankCache({
+    path: sidecarPath,
+    modelId: pinned.file,
+    modelVersion: pinned.sha256,
+  });
+  cacheA.set(query, docContentHash, rerankScore(0.91));
+  if (cacheA.get(query, docContentHash) === null) {
+    fail('pinned-identity score did not round-trip through the sidecar cache');
+  }
+  cacheA.close();
+  const sidecarSchemaBefore = schemaHash(sidecarPath);
+
+  // ---- 3. Same sidecar, swapped model identity ----------------------------
+  const cacheB = new RerankCache({
+    path: sidecarPath,
+    modelId: swapped.file,
+    modelVersion: swapped.sha256,
+  });
+  const stale = cacheB.get(query, docContentHash);
+  if (stale !== null) {
+    fail(
+      'PROPERTY BROKEN: the swapped model identity HIT a score cached under the ' +
+        'pinned identity — the sidecar cache no longer keys on (model file, weights sha), ' +
+        'so a model bump would silently serve stale scores',
+    );
+  }
+  cacheB.set(query, docContentHash, rerankScore(0.42));
+  if (cacheB.get(query, docContentHash) === null) {
+    fail('swapped-identity score did not round-trip through the sidecar cache');
+  }
+  const rows = cacheB.count();
+  if (rows !== 2) {
+    fail(
+      `PROPERTY BROKEN: expected the old and new identity rows to coexist (2 rows), got ${rows} — ` +
+        'a model swap must not destroy or migrate prior cache state',
+    );
+  }
+  cacheB.close();
+
+  const sidecarSchemaAfter = schemaHash(sidecarPath);
+  if (sidecarSchemaAfter !== sidecarSchemaBefore) {
+    fail(
+      'PROPERTY BROKEN: the sidecar sqlite schema changed across the model swap — ' +
+        'a model bump must be a cache-NAMESPACE change, never a schema change',
+    );
+  }
+
+  // ---- 4. The governed store needed zero migration ------------------------
+  const governedBytesAfter = sha256File(governedDbPath);
+  if (governedBytesAfter !== governedBytesBefore) {
+    fail(
+      'PROPERTY BROKEN: the governed store file changed during the model swap — ' +
+        'the rerank path must never touch a governed table',
+    );
+  }
+  const reopened = createDatabase({ path: governedDbPath });
+  const migrationsAfter = maxMigrationVersion(reopened);
+  reopened.close();
+  if (migrationsAfter !== migrationsBefore) {
+    fail(
+      `PROPERTY BROKEN: re-opening the governed store after the model swap applied new ` +
+        `migrations (${migrationsBefore} -> ${migrationsAfter}) — a model swap must need ` +
+        'zero governed-state migration',
+    );
+  }
+  const governedSchemaAfter = schemaHash(governedDbPath);
+  if (governedSchemaAfter !== governedSchemaBefore) {
+    fail('PROPERTY BROKEN: the governed schema hash changed across the model swap');
+  }
+
+  process.stdout.write(
+    'swap-model zero-migration: OK\n' +
+      `  pinned reranker    ${pinned.file} (${pinned.sha256.slice(0, 12)}…)\n` +
+      `  swapped fixture    ${swapped.file} (${swapped.sha256.slice(0, 12)}…)\n` +
+      `  sidecar            stale score MISS under swapped identity; 2 rows coexist; schema identical\n` +
+      `  governed store     bytes identical; migrations ${migrationsBefore} -> ${migrationsAfter}; schema hash identical\n`,
+  );
+} catch (error) {
+  process.stderr.write(`swap-model zero-migration: FAIL — ${(error as Error).message}\n`);
+  process.exitCode = 1;
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

A new workflow `.github/workflows/seam-independence.yml` with three individually-named, **NON-required** CI jobs that prove the compile/govern seam holds **by construction, dynamically** — the runtime twin of the static dependency-cruiser rule `no-govern-imports-retrieval`:

| Job | Claim | Mechanism |
|---|---|---|
| `delete-compile` | Deleting Compile-side retrieval does not break Govern | After `pnpm install`, `rm -rf packages/qmd-adapter/src` (qmd executor + native FTS5 backend + rerank client/stage), then build the govern closure (`pnpm --filter @qmd-team-intent-kb/curator... --filter @qmd-team-intent-kb/eval-surface... run build`) and run its tests (`vitest run` over the 8 govern dirs). No qmd on PATH. |
| `swap-model-zero-migration` | Changing the reranker model identity needs ZERO governed-state migration | `packages/qmd-adapter/scripts/ci-swap-model-zero-migration.ts` (tsx): swaps the reranker identity (different GGUF file + sha256 — exactly the `(model file, weights sha)` pair `buildRerankStage` keys the sidecar cache on) and asserts 6 properties (below). |
| `verify-receipts-model-free` | Receipts verify with NO ML dependency loadable | Same deletion mechanism + `rm node_modules/.bin/qmd` (absence asserted), then runs the provenance-integrity eval, `verify-audit-chain`, `verify-corpus-accounting`, and `provenance-walk` (7/7 links PASS, exit 0) over an on-disk fixture seeded through the REAL `CandidateRepository.insert` + `promote()` path (`apps/curator/scripts/ci-seed-receipts-fixture.ts`). |

## Why + decision rationale

Blueprint track B3: the seam claims were only enforced statically (dep-cruiser + the branded `DeterministicScore` type). These jobs are the dynamic proof, and each one **fails when its property breaks** — verified by intentional-red rehearsals below.

- **Separate workflow over jobs in `ci.yml`** because every `ci.yml` job is branch-protection-required; these three start **non-required** (marking them required is a later human/API step after they prove stable over real PRs — this PR does not change branch protection). Same pattern as the existing `moat-evals` / `retrieval-eval` split: an individually-named property gate a `ci.yml` refactor can't silently absorb.
- **Physical deletion over a vitest alias/module-mock layer** (job 1 stub mechanism) because deletion has no indirection that could silently keep the real modules reachable — an alias map drifts; an empty `src/` cannot. Failure paths are real compiler/loader failures, not mock bookkeeping.
- **Direct `RerankCache` construction with a swapped fixture identity** (job 2) over an env override in `buildRerankStage`, because no such override exists and adding production code purely for a test would widen the surface; the script constructs the cache with exactly the manifest fields `buildRerankStage` reads (`pinned.file`, `pinned.sha256`), so the keying under test is the production keying.
- **Fixture seeded via the real promoter** (job 3) rather than hand-inserted rows, so `verify-corpus-accounting` and `provenance-walk` verify a genuinely-governed row (content-addressed candidate id, `promoted` receipt on the hash chain, spool manifest sidecar, compile-trace event) — not a synthetic shape the verifiers were never meant to see. It deliberately does NOT import `test-fixtures` (dep-cruiser invariant 5 forbids production-adjacent imports of it).

## Layers touched / invariants

CI only + two new proof scripts + two package-script entries. No production source, no schema, no governed-state change, no branch-protection change. The jobs *enforce* existing invariants (seam firewall, content-addressed sidecar, model-free receipts); they add none.

## How it works

**Job 1 failure paths** (all rehearsed): a govern package that *declares* `qmd-adapter` pulls it into the `--filter ...` closure, whose `tsc` fails on the empty src; a *binding* import without the declared dep fails tsc module resolution (TS2307, pnpm isolated node_modules) in the build step; a *side-effect-only* `import 'pkg'` — which tsc deliberately does not type-resolve — is caught by the **test** step via runtime module resolution. The build+test pair is load-bearing; the workflow comment says so.

**Job 2 assertions** (any failure exits 1): (a) score cached under the pinned identity MISSes under the swapped identity — the namespace change; (b) old + new rows coexist (2 rows, nothing destroyed/migrated); (c) sidecar `sqlite_master` byte-identical across the swap — namespace change, NOT a schema change; (d) governed DB file bytes untouched (sha256 before/after); (e) re-opening the governed store applies no new migration (`MAX(schema_migrations.version)` unchanged, 11 → 11); (f) governed schema hash unchanged.

**Job 3**: asserts `command -v qmd` fails before running anything; every verifier must then reach its verdict (provenance-walk must be a full 7/7 PASS / exit 0, not the exit-3 UNVERIFIABLE lane — the fixture ships its own spool manifest + trace).

## Verification & evidence — intentional-red rehearsals (centerpiece)

All run locally end-to-end (`act` unavailable, so the exact commands each job runs were executed directly). Each rehearsal: violate the property → job commands go red → revert → green again.

**Rehearsal 1 (delete-compile)** — added a binding import of the retrieval package to govern code (`packages/policy-engine/src/index.ts`):

```
packages/policy-engine build: src/index.ts(50,29): error TS2307: Cannot find module '@qmd-team-intent-kb/qmd-adapter' or its corresponding type declarations.
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @qmd-team-intent-kb/policy-engine@0.1.0 build: `tsc`
REHEARSAL-1 BUILD EXIT: 2   →   reverted, build green
```

**Rehearsal 1b (honesty finding)** — a *side-effect-only* `import '@qmd-team-intent-kb/qmd-adapter';` passes tsc (it does not type-resolve bindingless imports), but the job's TEST step catches it at runtime:

```
Test Files  1 failed | 11 passed (12)
REHEARSAL-1b TEST EXIT: 1   →   reverted, green
```

This is why the job keeps both build AND test steps, documented in the workflow.

**Rehearsal 2 (swap-model)** — made the cache lookup identity-blind (`WHERE key = ?` ignoring model_id/model_version):

```
swap-model zero-migration: FAIL — PROPERTY BROKEN: the swapped model identity HIT a score cached under the pinned identity — the sidecar cache no longer keys on (model file, weights sha), so a model bump would silently serve stale scores
REHEARSAL-2 EXIT: 1   →   after revert: 0
```

**Rehearsal 3 (verify-receipts-model-free)** — made `verify-audit-chain` shell out to `qmd --version`, ran under a qmd-free PATH:

```
/bin/sh: 1: qmd: not found
Error: Command failed: qmd --version
REHEARSAL-3 EXIT: 1   →   after revert: {"ok":true,"tamperFree":true,...} exit 0
```

**Green-path evidence (local, per job):**

- Job 1: govern closure cold-builds with `packages/qmd-adapter/src` deleted; `vitest run` over the 8 govern dirs: **102 files, 1359 tests passed**.
- Job 2: `swap-model zero-migration: OK — sidecar stale score MISS; 2 rows coexist; schema identical; governed store bytes identical; migrations 11 -> 11; schema hash identical`.
- Job 3 (under `env -i PATH=/usr/bin:/bin`, no qmd resolvable): provenance-integrity eval `OK — forks pass (disclosed), tamper fails closed, anchor truncation fails closed`; `verify-audit-chain {"ok":true,"tamperFree":true,...}`; `verify-corpus-accounting {"ok":true,...,"orphanCount":0}`; `provenance-walk` **7/7 PASS, exit 0**.

**Full gate suite green locally:** `format:check` · `lint` · `typecheck` · `depcruise` (0 errors; the 4 orphan warnings are pre-existing, none in this diff) · `crap` · `harness-pin` · `vitest` **2306 passed, 2 skipped**.

## Risk assessment

- The jobs are non-required: a red seam job cannot block merges until it is deliberately promoted. Conversely, until promoted, a seam break only *surfaces* — accepted for the stabilization window.
- Job 1/3's deletion step runs on a throwaway CI checkout; nothing is mutated outside the runner.
- Job 2's temp-dir SQLite work never touches `~/.teamkb` or any live brain.
- False-red exposure: job 3's fixture depends on the promoter/verifier contracts; a legitimate contract change will turn the job red and the fixture script must be updated alongside — that coupling is the point of the gate.

## Operational impact

None at runtime. No env vars, no secrets, no migrations, no deploy-order concerns. CI cost: three additional ~2–4 min ubuntu jobs per PR. **These gates start as NON-required checks; marking them branch-protection-required is a later human/API step once they prove stable — deliberately not part of this PR.**

## Follow-up & deferred

- Promote the three jobs to required checks after they prove stable across real PRs (human/API step).
- Optional hardening: a lint that flags side-effect-only imports of workspace packages (would move the rehearsal-1b catch from test-time to lint-time).

## Governance links

- Seam firewall (static half): `.dependency-cruiser.cjs` rule `no-govern-imports-retrieval`; branded type `packages/policy-engine/src/deterministic-score.ts`.
- Reranker + content-addressed sidecar (B1): PR #305; decision 044-AT-DECR; `packages/qmd-adapter/src/rerank/rerank-cache.ts`.
- Receipt verifiers: `apps/curator/src/cli.ts` (`verify-audit-chain` / `verify-corpus-accounting` / `provenance-walk`), `packages/eval-surface/scripts/ci-provenance-integrity.ts`.

---
## Review response (adversarial)
- The "7 links" count is defined by the merged verifier itself — `apps/curator/src/provenance/provenance-walk.ts` (#298): memory-row → memory-id-derivation → promotion-receipt → candidate-row → candidate-id-derivation → spool-manifest → compile-trace. The job runs that verifier verbatim; the count is its runtime output, now cited.
- The fixture's fabricated trace `prev_hash` matches the walker's documented scope: the compile-trace link checks event PRESENCE + candidate linkage; chain-hash validity is `verify-audit-chain`'s job (also run by this workflow) — the fixture seeds a single-event day file where a genesis-style prev_hash is the honest shape.
