### PR TITLE
feat(curator): harden bulk import — brainignore exclusion, batch transitions, source-keyed relevance reject

### DIFF
--- a/.policy-hash
+++ b/.policy-hash
@@ -1,6 +1,6 @@
 9667f67176586e01b124da7513dd75aefb2742fc02f16ecbd7628b4bbcbfa468   packages/policy-engine/src/rules/secret-detection-rule.ts
 2ab7f840afb72711c13b2d14c03af114b0e74fb764b6f8eadfe7665b0997f56f   packages/policy-engine/src/rules/dedup-check-rule.ts
-f5059276302ecf768cd14de5e1889f841df6a9163675975dc3428edd6d66e245   packages/policy-engine/src/rules/relevance-score-rule.ts
+3116eb1df0aa0aeeb9fc1e3572a14c648b5c1d0fc817545a28df6edf8a9fa92e   packages/policy-engine/src/rules/relevance-score-rule.ts
 77d07f08a654c69f14d687eaec1d4243bb989c4b809ba168576a51159b000862   packages/policy-engine/src/rules/content-length-rule.ts
 f4f35a03da263da51085841eb71fb33df83f1a1c34e1bccb5963cf965de1ce05   packages/policy-engine/src/rules/source-trust-rule.ts
 c7d87405ca41bc1848bc31a9177d7b53e9e7c082567d28d700dc4268072eeeb7   packages/policy-engine/src/rules/tenant-match-rule.ts
@@ -8,3 +8,5 @@ b28f01e57900b09e33eafad6ac3bfe9e360b81216efafc63e70cbb7625876eea   packages/poli
 b596ca83e40ebefd2dcbf8df62987b5d14039643ff1ff4e4f1c96ea370200a46   packages/policy-engine/src/rules/content-sanitization-rule.ts
 fbdd22b83ce4c0793bb41613e89e8d67a427fc14d0ec8c18fe039eec62705fa9   packages/policy-engine/src/rules/contradiction-check-rule.ts
 9dcaced9c7eb0d61d1bd4c258796861f420fc50ac5b519e53e237cb7090a1359   packages/policy-engine/src/rules/index.ts
+8ef31f3d1c737c730a0e6161084721312436a6ae1fff60352e47b302ca7df9a4   apps/curator/src/import-exclusion/brainignore.ts
+c5987bb621cee201e112ede8a5a2bf56ae7689ba1e0a245c9def00a5b2785b55   apps/curator/src/import-exclusion/import-exclusion-gate.ts

--- a/apps/api/src/__tests__/promote.test.ts
+++ b/apps/api/src/__tests__/promote.test.ts
@@ -279,3 +279,67 @@ describe('POST /api/candidates/:id/reject', () => {
     expect(res.statusCode).toBe(404);
   });
 });
+
+/**
+ * Import exclusion gate on the single-candidate admin path (bead 5kw.1) —
+ * the same structural brainignore check the curator batch pipeline runs, so
+ * both paths agree (the H1 invariant). Committed defaults only; the per-brain
+ * override file is wired where the service is constructed.
+ */
+describe('POST /api/candidates/:id/promote — import exclusion gate (5kw.1)', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let candidateRepo: CandidateRepository;
+  let memoryRepo: MemoryRepository;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+    memoryRepo = new MemoryRepository(db);
+    app = buildApp({ db, silent: true });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  function promote(id: string, tenantId: string) {
+    return app.inject({
+      method: 'POST',
+      url: `/api/candidates/${id}/promote?tenantId=${tenantId}`,
+    });
+  }
+
+  it('refuses an import-source candidate on a vendored path (422, left in inbox)', async () => {
+    const candidate = makeCandidate({
+      tenantId: 'team-alpha',
+      source: 'import',
+      metadata: { filePaths: ['node_modules/@google-cloud/storage/README.md'], tags: [] },
+    });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+
+    const res = await promote(candidate.id, 'team-alpha');
+    expect(res.statusCode).toBe(422);
+    const body = res.json() as { error: string; code?: string };
+    expect(body.error).toContain('import exclusion gate');
+    expect(body.error).toContain('node_modules');
+    expect(body.code).toBe('brainignore_path');
+    // Left in the inbox for review — never silently retired.
+    expect(candidateRepo.findById(candidate.id)?.status).toBe('inbox');
+    expect(memoryRepo.findByTenant('team-alpha')).toEqual([]);
+  });
+
+  it('promotes an identical candidate from an interactive source (gate not applicable)', async () => {
+    const candidate = makeCandidate({
+      tenantId: 'team-alpha',
+      source: 'mcp',
+      metadata: { filePaths: ['node_modules/@google-cloud/storage/README.md'], tags: [] },
+    });
+    candidateRepo.insert(candidate, computeContentHash(candidate.content));
+
+    const res = await promote(candidate.id, 'team-alpha');
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/apps/api/src/__tests__/promote.test.ts
+++ b/apps/api/src/__tests__/promote.test.ts
@@ -329,6 +329,30 @@ describe('POST /api/candidates/:id/promote — import exclusion gate (5kw.1)', (
     // Left in the inbox for review — never silently retired.
     expect(candidateRepo.findById(candidate.id)?.status).toBe('inbox');
     expect(memoryRepo.findByTenant('team-alpha')).toEqual([]);
+
+    // RECEIPT PARITY (PR #309 finding 1): the rejection is on the append-only
+    // audit chain, exactly as the curator batch path receipts via reject().
+    // Without this assertion the earlier version threw a 422 with NO audit row,
+    // and the inbox-retention + no-memory checks alone let that asymmetry pass.
+    const rejectRow = db
+      .prepare(
+        `SELECT action, reason, details_json FROM audit_events
+         WHERE action='deleted' AND memory_id=@id`,
+      )
+      .get({ id: candidate.id }) as
+      { action: string; reason: string; details_json: string } | undefined;
+    expect(rejectRow).toBeDefined();
+    expect(rejectRow!.reason).toContain('brainignore_path');
+    const details = JSON.parse(rejectRow!.details_json) as {
+      candidateId: string;
+      outcome: string;
+      evaluations: Array<{ ruleId: string; ruleType: string; reason: string }>;
+    };
+    expect(details.candidateId).toBe(candidate.id);
+    expect(details.outcome).toBe('rejected');
+    expect(details.evaluations[0]?.ruleId).toBe('brainignore_path');
+    expect(details.evaluations[0]?.ruleType).toBe('import_exclusion');
+    expect(details.evaluations[0]?.reason).toContain('node_modules');
   });
 
   it('promotes an identical candidate from an interactive source (gate not applicable)', async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import {
   ImportBatchRepository,
   MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
+import type { BrainignoreRuleset } from '@qmd-team-intent-kb/curator';
 import { CandidateService } from './services/candidate-service.js';
 import { PromotionService } from './services/promotion-service.js';
 import { MemoryService } from './services/memory-service.js';
@@ -111,6 +112,15 @@ export interface AppDependencies {
    * the D2 staleness gauge reports the accumulating drift.
    */
   indexRefresher?: IndexRefresher;
+  /**
+   * Brainignore ruleset for the import exclusion gate (5kw.1) applied on the
+   * single-candidate promote path. main.ts resolves it via
+   * `loadBrainignoreRuleset()` so the API honors the per-brain override file
+   * (`~/.teamkb/brainignore`); left unset in tests → the committed defaults.
+   * The gate is on for import-source candidates regardless — this only wires
+   * the operator override.
+   */
+  importExclusions?: BrainignoreRuleset;
 }
 
 /**
@@ -176,6 +186,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     auditRepo,
     linksRepo,
     deps.originSecret,
+    deps.importExclusions,
   );
 
   // Routes are wrapped in an inner register() so they load AFTER the

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -32,6 +32,7 @@ import {
   resolveTeamKbPath,
 } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import { loadBrainignoreRuleset } from '@qmd-team-intent-kb/curator';
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
 import { loadTokenRecords } from './auth/token-registry.js';
@@ -105,6 +106,13 @@ async function main(): Promise<void> {
       `[teamkb-api] ${ORIGIN_SECRET_UNAVAILABLE_WARNING} (${e instanceof Error ? e.message : String(e)})\n`,
     );
   }
+  // Import exclusion (5kw.1): committed defaults + the per-brain override file
+  // (~/.teamkb/brainignore or $TEAMKB_BRAINIGNORE). An unreadable override warns
+  // and degrades to defaults — the gate itself is always on for import sources.
+  const importExclusions = loadBrainignoreRuleset({
+    onWarn: (m) => process.stderr.write(`[teamkb-api] ${m}\n`),
+  });
+
   const allowedChannelsRaw = process.env['TEAMKB_ALLOWED_CHANNELS'];
   const allowedChannels =
     allowedChannelsRaw !== undefined && allowedChannelsRaw.trim() !== ''
@@ -126,6 +134,7 @@ async function main(): Promise<void> {
     revokedFile,
     allowedChannels,
     originSecret,
+    importExclusions,
   });
   await app.ready();
 

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -10,6 +10,8 @@ import {
   detectSupersession,
   DEFAULT_SUPERSESSION_THRESHOLD,
   checkOriginAttestation,
+  checkImportExclusion,
+  type BrainignoreRuleset,
 } from '@qmd-team-intent-kb/curator';
 import { AuditEvent as AuditEventSchema } from '@qmd-team-intent-kb/schema';
 import type { CuratedMemory, Author } from '@qmd-team-intent-kb/schema';
@@ -59,6 +61,12 @@ export class PromotionService {
     private readonly auditRepo: AuditRepository,
     private readonly linksRepo?: MemoryLinksRepository,
     private readonly originSecret?: string,
+    /**
+     * Brainignore ruleset for the import exclusion gate (5kw.1). Omitted →
+     * the committed defaults; pass `loadBrainignoreRuleset()` to honor the
+     * per-brain override file. Only import-source candidates are checked.
+     */
+    private readonly importExclusions?: BrainignoreRuleset,
   ) {}
 
   /**
@@ -119,6 +127,22 @@ export class PromotionService {
           ? 'Candidate rejected: origin token does not verify against the installation secret — claimed provenance is invalid. Left in the inbox for review.'
           : 'Candidate rejected: it claims an origin attestation but no origin secret is configured on this server — cannot verify. Left in the inbox for review.',
         originGate.code,
+      );
+    }
+
+    // Import exclusion gate (5kw.1): the same structural brainignore check the
+    // curator batch pipeline runs, so the single-candidate admin path and the
+    // batch path agree (the H1 invariant). Import-source candidates matching a
+    // vendored-path pattern or a content heuristic are refused with the
+    // deterministic evidence; the candidate stays in the inbox, consistent
+    // with policy rejects on this path. An operator who genuinely wants such a
+    // doc re-admits it with a `!pattern` line in the brainignore override file.
+    const importGate = checkImportExclusion(candidate, this.importExclusions);
+    if (importGate.verdict === 'rejected') {
+      throw unprocessable(
+        `Candidate rejected by the import exclusion gate (${importGate.match.code}): ` +
+          `${importGate.match.evidence}. Left in the inbox for review.`,
+        importGate.match.code,
       );
     }
 

--- a/apps/api/src/services/promotion-service.ts
+++ b/apps/api/src/services/promotion-service.ts
@@ -134,11 +134,37 @@ export class PromotionService {
     // curator batch pipeline runs, so the single-candidate admin path and the
     // batch path agree (the H1 invariant). Import-source candidates matching a
     // vendored-path pattern or a content heuristic are refused with the
-    // deterministic evidence; the candidate stays in the inbox, consistent
-    // with policy rejects on this path. An operator who genuinely wants such a
-    // doc re-admits it with a `!pattern` line in the brainignore override file.
+    // deterministic evidence; the candidate stays in the inbox. An operator who
+    // genuinely wants such a doc re-admits it with a `!pattern` line in the
+    // brainignore override file.
+    //
+    // RECEIPT PARITY (PR #309 review finding 1): the curator batch path receipts
+    // every rejection via reject() → an on-chain audit event. This admin path
+    // must do the same or the determinism+receipt contract holds on one surface
+    // but not the other. So we write the rejection receipt BEFORE throwing,
+    // mirroring the curator reject() shape exactly: action 'deleted' (the schema
+    // has no 'rejected' AuditAction — 'deleted' IS the curator's rejection
+    // semantics: no curated memory was created), the gate's pipelineResult in
+    // details, and the acting reviewer as actor (promotedBy when named, else the
+    // curator system identity — same default reject() uses).
     const importGate = checkImportExclusion(candidate, this.importExclusions);
     if (importGate.verdict === 'rejected') {
+      this.auditRepo.insert(
+        AuditEventSchema.parse({
+          id: randomUUID(),
+          action: 'deleted',
+          memoryId: candidate.id,
+          tenantId,
+          actor: promotedBy ?? { type: 'system', id: 'curator' },
+          reason: `Rejected by rule: ${importGate.match.code}`,
+          details: {
+            candidateId: candidate.id,
+            outcome: importGate.pipelineResult.outcome,
+            evaluations: importGate.pipelineResult.evaluations,
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      );
       throw unprocessable(
         `Candidate rejected by the import exclusion gate (${importGate.match.code}): ` +
           `${importGate.match.evidence}. Left in the inbox for review.`,

--- a/apps/curator/src/__tests__/brainignore.test.ts
+++ b/apps/curator/src/__tests__/brainignore.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the brainignore ruleset engine + loader (bead 5kw.1): pattern
+ * compilation, gitignore-style matching (last match wins, `!` negation),
+ * the committed defaults against the 2026-07-16 junk classes, the content
+ * heuristics, and the override-file loader.
+ *
+ * @module __tests__/brainignore.test
+ */
+
+import { mkdtemp, rm, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_BRAINIGNORE_RULESET,
+  analyzeContent,
+  compilePattern,
+  matchPath,
+  parseBrainignore,
+  shannonEntropy,
+  type BrainignoreRuleset,
+} from '../import-exclusion/brainignore.js';
+import { loadBrainignoreRuleset } from '../import-exclusion/load-brainignore.js';
+
+function rulesetOf(...patterns: string[]): BrainignoreRuleset {
+  return { patterns: parseBrainignore(patterns.join('\n'), 'override'), overridePath: null };
+}
+
+describe('compilePattern', () => {
+  it('returns null for blank lines and comments', () => {
+    expect(compilePattern('', 'default')).toBeNull();
+    expect(compilePattern('   ', 'default')).toBeNull();
+    expect(compilePattern('# a comment', 'default')).toBeNull();
+    expect(compilePattern('!', 'default')).toBeNull();
+  });
+
+  it('parses negation and records provenance', () => {
+    const p = compilePattern('!**/node_modules/keep-me/**', 'override');
+    expect(p).not.toBeNull();
+    expect(p!.negated).toBe(true);
+    expect(p!.source).toBe('override');
+    expect(p!.pattern).toBe('**/node_modules/keep-me/**');
+  });
+
+  it('escapes regex metacharacters literally', () => {
+    const rs = rulesetOf('package-lock.json');
+    // The dot must not match "any char".
+    expect(matchPath('a/package-lockxjson', rs)).toBeNull();
+    expect(matchPath('a/package-lock.json', rs)).not.toBeNull();
+  });
+});
+
+describe('matchPath', () => {
+  it('basename patterns (no slash) match the final segment anywhere', () => {
+    const rs = rulesetOf('yarn.lock');
+    expect(matchPath('yarn.lock', rs)).not.toBeNull();
+    expect(matchPath('deep/nested/dir/yarn.lock', rs)).not.toBeNull();
+    expect(matchPath('deep/yarn.lock/readme.md', rs)).toBeNull();
+  });
+
+  it('`*` does not cross a slash; `**` does', () => {
+    const single = rulesetOf('docs/*.md');
+    expect(matchPath('docs/a.md', single)).not.toBeNull();
+    expect(matchPath('docs/sub/a.md', single)).toBeNull();
+    const double = rulesetOf('docs/**');
+    expect(matchPath('docs/sub/a.md', double)).not.toBeNull();
+  });
+
+  it('`**/x` also matches x at the path root (gitignore semantics)', () => {
+    const rs = rulesetOf('**/node_modules/**');
+    expect(matchPath('node_modules/pkg/README.md', rs)).not.toBeNull();
+    expect(matchPath('a/b/node_modules/pkg/README.md', rs)).not.toBeNull();
+  });
+
+  it('matching is case-insensitive (documented deviation from gitignore)', () => {
+    const rs = rulesetOf('LICENSE*');
+    expect(matchPath('vendor-pkg/license.txt', rs)).not.toBeNull();
+    expect(matchPath('vendor-pkg/License', rs)).not.toBeNull();
+  });
+
+  it('normalizes backslashes and leading ./', () => {
+    const rs = rulesetOf('**/node_modules/**');
+    expect(matchPath('./a/node_modules/x.md', rs)).not.toBeNull();
+    expect(matchPath('a\\node_modules\\x.md', rs)).not.toBeNull();
+  });
+
+  it('last match wins: a later !pattern re-includes an earlier exclusion', () => {
+    const rs = rulesetOf('**/node_modules/**', '!**/node_modules/my-own-pkg/**');
+    expect(matchPath('node_modules/other/README.md', rs)).not.toBeNull();
+    expect(matchPath('node_modules/my-own-pkg/NOTES.md', rs)).toBeNull();
+  });
+
+  it('the committed defaults exclude the 2026-07-16 junk path classes', () => {
+    const rs = DEFAULT_BRAINIGNORE_RULESET;
+    for (const junkPath of [
+      'iams-gcp-resources/node_modules/@google-cloud/storage/README.md',
+      'proj/.venv/lib/python3.12/site-packages/requests/README.md',
+      'repo/vendor/some-lib/docs.md',
+      'repo/pnpm-lock.yaml',
+      'repo/package-lock.json',
+      'repo/CODE_OF_CONDUCT.md',
+      'repo/SECURITY.md',
+      'repo/SUPPORT.md',
+      'repo/LICENSE',
+      'repo/dist/bundle.js',
+      'app/static/main.min.js',
+      'app/static/main.js.map',
+      'repo/.github/ISSUE_TEMPLATE/bug.md',
+    ]) {
+      expect(matchPath(junkPath, rs), junkPath).not.toBeNull();
+    }
+  });
+
+  it('the committed defaults do NOT exclude ordinary knowledge paths', () => {
+    const rs = DEFAULT_BRAINIGNORE_RULESET;
+    for (const goodPath of [
+      'docs/architecture/overview.md',
+      '000-docs/013-OD-STND-commit-conventions.md',
+      'src/index.ts',
+      'wiki/topics/deployment.md',
+      'README.md',
+      'CHANGELOG.md',
+    ]) {
+      expect(matchPath(goodPath, rs), goodPath).toBeNull();
+    }
+  });
+});
+
+describe('analyzeContent heuristics', () => {
+  const prose =
+    'This is an ordinary prose note about deployment conventions. It explains how the ' +
+    'team ships services, which checks gate a release, and where the runbooks live. ' +
+    'Nothing about it resembles minified or generated output in any way.';
+
+  it('passes ordinary prose', () => {
+    expect(analyzeContent(prose, 'Deployment conventions')).toBeNull();
+  });
+
+  it('rejects placeholder titles', () => {
+    for (const title of ['Untitled', ' untitled document ', 'No Title']) {
+      const match = analyzeContent(prose, title);
+      expect(match?.code).toBe('brainignore_untitled_title');
+    }
+  });
+
+  it('rejects license boilerplate by marker phrase in the head', () => {
+    const license =
+      'Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\n' +
+      'TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n';
+    const match = analyzeContent(license, 'Some vendored file');
+    expect(match?.code).toBe('brainignore_license_boilerplate');
+    expect(match?.evidence).toContain('apache license');
+
+    const mit =
+      'Permission is hereby granted, free of charge, to any person obtaining a copy of this software';
+    expect(analyzeContent(mit, 'note')?.code).toBe('brainignore_license_boilerplate');
+  });
+
+  it('does not fire the license heuristic on a marker deep in the body', () => {
+    const deep = prose + '\n'.repeat(3) + 'x'.repeat(700) + '\nApache License mention way down.';
+    expect(analyzeContent(deep, 'Licensing discussion')).toBeNull();
+  });
+
+  it('rejects minified content (long line, almost no whitespace)', () => {
+    const minified = 'a=1;b=(c||d).e(f);'.repeat(100); // one 1800-char line, zero whitespace
+    const match = analyzeContent(minified, 'bundle');
+    expect(match?.code).toBe('brainignore_minified_content');
+    expect(match?.evidence).toContain('whitespace ratio');
+  });
+
+  it('does not reject a long UNWRAPPED prose paragraph (whitespace ratio stays high)', () => {
+    const longProse = (prose + ' ').repeat(6).replace(/\n/g, ' '); // one ~1400-char line of prose
+    expect(analyzeContent(longProse, 'Long unwrapped note')).toBeNull();
+  });
+
+  it('rejects high-entropy generated/encoded blobs', () => {
+    // Pseudo-base64 soup: deterministic, high symbol diversity, > 1024 chars.
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    let blob = '';
+    for (let i = 0; i < 2048; i++) {
+      blob += alphabet[(i * 37 + (i % 53)) % alphabet.length];
+      if (i % 60 === 59) blob += '\n'; // keep lines short so the minified check stays out
+    }
+    const match = analyzeContent(blob, 'sourcemap payload');
+    expect(match?.code).toBe('brainignore_generated_content');
+  });
+
+  it('shannonEntropy is deterministic and behaves at the anchors', () => {
+    expect(shannonEntropy('')).toBe(0);
+    expect(shannonEntropy('aaaa')).toBe(0);
+    expect(shannonEntropy('ab')).toBeCloseTo(1, 5);
+    expect(shannonEntropy(prose)).toBeLessThan(5.2);
+  });
+});
+
+describe('loadBrainignoreRuleset', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'brainignore-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns defaults-only when the override file is absent', () => {
+    const rs = loadBrainignoreRuleset({ path: join(dir, 'does-not-exist') });
+    expect(rs.overridePath).toBeNull();
+    expect(rs.patterns.every((p) => p.source === 'default')).toBe(true);
+    expect(matchPath('a/node_modules/x.md', rs)).not.toBeNull();
+  });
+
+  it('appends override patterns AFTER the defaults so operator negation wins', async () => {
+    const overridePath = join(dir, 'brainignore');
+    await writeFile(
+      overridePath,
+      '# operator overrides\n!**/node_modules/my-own-pkg/**\ninternal-junk/**\n',
+      'utf8',
+    );
+    const rs = loadBrainignoreRuleset({ path: overridePath });
+    expect(rs.overridePath).toBe(overridePath);
+    // Default exclusion still applies…
+    expect(matchPath('node_modules/other/README.md', rs)).not.toBeNull();
+    // …the operator negation re-admits…
+    expect(matchPath('node_modules/my-own-pkg/NOTES.md', rs)).toBeNull();
+    // …and the operator's own exclusion applies.
+    expect(matchPath('internal-junk/scratch.md', rs)).not.toBeNull();
+  });
+
+  it('an unreadable override warns and degrades to defaults-only (never throws)', async () => {
+    const unreadable = join(dir, 'locked');
+    await mkdir(unreadable); // reading a directory as a file fails with EISDIR
+    await chmod(unreadable, 0o000);
+    const warnings: string[] = [];
+    const rs = loadBrainignoreRuleset({ path: unreadable, onWarn: (m) => warnings.push(m) });
+    expect(rs.overridePath).toBeNull();
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('continuing with the committed defaults');
+    await chmod(unreadable, 0o755);
+  });
+});

--- a/apps/curator/src/__tests__/cli-batch-transition.test.ts
+++ b/apps/curator/src/__tests__/cli-batch-transition.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for `curator-cli batch-transition` (bead 5kw.2): the receipted batch
+ * lifecycle-transition command. Covers the refusal patterns (mandatory --db,
+ * at-least-one-criterion, --to superseded, malformed ids file), dry-run
+ * read-only semantics, the per-memory one-transaction-one-receipt contract,
+ * criteria matching (source / category / imported-before / ids-file), and
+ * skipped-illegal reporting.
+ *
+ * Uses a FILE-backed database (the production wiring) so re-opening the store
+ * after dispatch proves what was durably written.
+ *
+ * @module __tests__/cli-batch-transition.test
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  AuditRepository,
+  MemoryRepository,
+  createDatabase,
+  createTestDatabase,
+} from '@qmd-team-intent-kb/store';
+import { makeMemory, DEFAULT_TENANT } from '@qmd-team-intent-kb/test-fixtures';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatch, type CuratorCliDeps } from '../cli.js';
+
+let dir: string;
+let dbPath: string;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+/** Production-shaped deps: file path → real database, honoring readonly. */
+const fileDeps: CuratorCliDeps = {
+  createDb: ({ dbPath: p, readonly }) =>
+    p !== undefined
+      ? createDatabase({ path: p, readonly: readonly ?? false })
+      : createTestDatabase(),
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'cli-batch-transition-'));
+  dbPath = join(dir, 'teamkb.db');
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+function stdoutText(): string {
+  const calls = stdoutSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+function stderrText(): string {
+  const calls = stderrSpy.mock.calls as unknown as Array<[unknown]>;
+  return calls.map((c) => String(c[0])).join('');
+}
+
+/** Seed memories into the file-backed store and return them. */
+function seed(...memories: Partial<CuratedMemory>[]): CuratedMemory[] {
+  const db = createDatabase({ path: dbPath });
+  try {
+    const repo = new MemoryRepository(db);
+    return memories.map((overrides) => {
+      const memory = makeMemory(overrides);
+      repo.insert(memory);
+      return memory;
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Re-open the store read-only for assertions after dispatch has run. */
+function inspect<T>(
+  fn: (repos: { memoryRepo: MemoryRepository; auditRepo: AuditRepository }) => T,
+): T {
+  const db = createDatabase({ path: dbPath, readonly: true });
+  try {
+    return fn({ memoryRepo: new MemoryRepository(db), auditRepo: new AuditRepository(db) });
+  } finally {
+    db.close();
+  }
+}
+
+const BASE = ['batch-transition', '--db', '', '--tenant', DEFAULT_TENANT];
+function args(...rest: string[]): string[] {
+  const a = [...BASE];
+  a[2] = dbPath;
+  return [...a, ...rest];
+}
+
+describe('batch-transition — refusal patterns', () => {
+  it('refuses a missing --db (no implicit in-memory store)', async () => {
+    const rc = await dispatch(
+      [
+        'batch-transition',
+        '--tenant',
+        't',
+        '--to',
+        'deprecated',
+        '--reason',
+        'r',
+        '--actor',
+        'a',
+        '--source',
+        'import',
+      ],
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/refusing to transition an implicit in-memory store/);
+  });
+
+  it('refuses a criterion-less invocation (tenant-wide mass transition)', async () => {
+    const rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/at least one criterion is required/);
+  });
+
+  it('refuses --to superseded (needs a per-memory supersededBy)', async () => {
+    const rc = await dispatch(
+      args('--to', 'superseded', '--reason', 'r', '--actor', 'a', '--source', 'import'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/superseded is not batchable/);
+  });
+
+  it('refuses an invalid --source / --category / --imported-before', async () => {
+    let rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a', '--source', 'bogus'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/invalid --source "bogus"/);
+
+    rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a', '--category', 'bogus'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/invalid --category "bogus"/);
+
+    rc = await dispatch(
+      args(
+        '--to',
+        'deprecated',
+        '--reason',
+        'r',
+        '--actor',
+        'a',
+        '--imported-before',
+        'not-a-date',
+      ),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/invalid --imported-before/);
+  });
+
+  it('refuses missing --reason / --actor', async () => {
+    let rc = await dispatch(
+      args('--to', 'deprecated', '--actor', 'a', '--source', 'import'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/missing required flag: --reason/);
+
+    rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--source', 'import'),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/missing required flag: --actor/);
+  });
+
+  it('refuses an ids file with a malformed line (never silently drops it)', async () => {
+    const idsFile = join(dir, 'ids.txt');
+    await writeFile(idsFile, '# sweep targets\nnot-a-uuid\n', 'utf8');
+    const rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a', '--ids-file', idsFile),
+      fileDeps,
+    );
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/line 2 is not a UUID/);
+  });
+});
+
+describe('batch-transition — dry-run', () => {
+  it('reports what would transition and writes NOTHING (db opened read-only)', async () => {
+    const [a, b] = seed(
+      { source: 'import', lifecycle: 'active' },
+      { source: 'import', lifecycle: 'active' },
+    );
+    seed({ source: 'claude_session', lifecycle: 'active' });
+
+    const rc = await dispatch(
+      args(
+        '--to',
+        'deprecated',
+        '--reason',
+        'sweep',
+        '--actor',
+        'jeremy',
+        '--source',
+        'import',
+        '--dry-run',
+        '--json',
+      ),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(true);
+    expect(parsed['dry_run']).toBe(true);
+    expect(parsed['matched']).toBe(2);
+    expect(parsed['transitioned']).toBe(2);
+    const transitions = parsed['transitions'] as Array<Record<string, unknown>>;
+    expect(new Set(transitions.map((t) => t['memory_id']))).toEqual(new Set([a!.id, b!.id]));
+    // Dry-run receipts are honestly null — no audit event was written.
+    expect(transitions.every((t) => t['audit_event_id'] === null)).toBe(true);
+
+    inspect(({ memoryRepo, auditRepo }) => {
+      expect(memoryRepo.findByTenant(DEFAULT_TENANT).every((m) => m.lifecycle === 'active')).toBe(
+        true,
+      );
+      expect(auditRepo.findByTenant(DEFAULT_TENANT)).toEqual([]);
+    });
+  });
+});
+
+describe('batch-transition — receipted transitions', () => {
+  it('transitions matched rows with ONE audit receipt per memory', async () => {
+    const [a, b] = seed(
+      { source: 'import', lifecycle: 'active' },
+      { source: 'import', lifecycle: 'active' },
+    );
+    const [untouched] = seed({ source: 'claude_session', lifecycle: 'active' });
+
+    const rc = await dispatch(
+      args(
+        '--to',
+        'deprecated',
+        '--reason',
+        'gcp junk sweep',
+        '--actor',
+        'jeremy',
+        '--source',
+        'import',
+        '--json',
+      ),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['transitioned']).toBe(2);
+
+    inspect(({ memoryRepo, auditRepo }) => {
+      // Lifecycle flipped for the matched rows only.
+      const rows = memoryRepo.findByTenant(DEFAULT_TENANT);
+      expect(rows.find((m) => m.id === a!.id)?.lifecycle).toBe('deprecated');
+      expect(rows.find((m) => m.id === b!.id)?.lifecycle).toBe('deprecated');
+      expect(rows.find((m) => m.id === untouched!.id)?.lifecycle).toBe('active');
+
+      // One receipt PER memory (never one giant batch receipt), each with the
+      // house action mapping, the actor, the reason, and the batch criteria.
+      for (const m of [a!, b!]) {
+        const events = auditRepo.findByMemory(m.id);
+        expect(events.length).toBe(1);
+        const event = events[0]!;
+        expect(event.action).toBe('demoted');
+        expect(event.actor).toEqual({ type: 'human', id: 'jeremy' });
+        expect(event.reason).toBe('gcp junk sweep');
+        const details = event.details as Record<string, unknown>;
+        expect(details['from']).toBe('active');
+        expect(details['to']).toBe('deprecated');
+        expect(details['batch']).toBe(true);
+        expect(details['criteria']).toEqual({ source: 'import' });
+      }
+      // Distinct receipts.
+      const ids = [a!, b!].map((m) => auditRepo.findByMemory(m.id)[0]!.id);
+      expect(new Set(ids).size).toBe(2);
+      // The untouched row got no receipt.
+      expect(auditRepo.findByMemory(untouched!.id)).toEqual([]);
+    });
+  });
+
+  it('skips rows whose current lifecycle cannot legally reach the target', async () => {
+    const [archived] = seed({ source: 'import', lifecycle: 'archived' });
+    const [active] = seed({ source: 'import', lifecycle: 'active' });
+
+    const rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a', '--source', 'import', '--json'),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['transitioned']).toBe(1);
+    const skipped = parsed['skipped'] as Array<Record<string, unknown>>;
+    expect(skipped.length).toBe(1);
+    expect(skipped[0]!['memory_id']).toBe(archived!.id);
+    expect(skipped[0]!['why']).toMatch(/not a legal lifecycle transition/);
+
+    inspect(({ memoryRepo }) => {
+      const rows = memoryRepo.findByTenant(DEFAULT_TENANT);
+      expect(rows.find((m) => m.id === archived!.id)?.lifecycle).toBe('archived');
+      expect(rows.find((m) => m.id === active!.id)?.lifecycle).toBe('deprecated');
+    });
+  });
+
+  it('matches on --imported-before (strictly before, against promoted_at)', async () => {
+    const [old] = seed({
+      source: 'import',
+      lifecycle: 'active',
+      promotedAt: '2026-07-01T00:00:00.000Z',
+    });
+    const [recent] = seed({
+      source: 'import',
+      lifecycle: 'active',
+      promotedAt: '2026-07-18T00:00:00.000Z',
+    });
+
+    const rc = await dispatch(
+      args(
+        '--to',
+        'archived',
+        '--reason',
+        'r',
+        '--actor',
+        'a',
+        '--imported-before',
+        '2026-07-10T00:00:00.000Z',
+        '--json',
+      ),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['matched']).toBe(1);
+
+    inspect(({ memoryRepo, auditRepo }) => {
+      const rows = memoryRepo.findByTenant(DEFAULT_TENANT);
+      expect(rows.find((m) => m.id === old!.id)?.lifecycle).toBe('archived');
+      expect(rows.find((m) => m.id === recent!.id)?.lifecycle).toBe('active');
+      expect(auditRepo.findByMemory(old!.id)[0]?.action).toBe('archived');
+    });
+  });
+
+  it('AND-combines an ids file with other criteria and reports not-found ids', async () => {
+    const [imported] = seed({ source: 'import', lifecycle: 'active' });
+    const [session] = seed({ source: 'claude_session', lifecycle: 'active' });
+    const unknownId = '00000000-0000-4000-8000-000000000000';
+
+    const idsFile = join(dir, 'ids.txt');
+    await writeFile(
+      idsFile,
+      `# sweep targets\n${imported!.id}\n${session!.id}\n${unknownId}\n\n`,
+      'utf8',
+    );
+
+    const rc = await dispatch(
+      args(
+        '--to',
+        'deprecated',
+        '--reason',
+        'r',
+        '--actor',
+        'a',
+        '--ids-file',
+        idsFile,
+        '--source',
+        'import',
+        '--json',
+      ),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    // Only the import-source id both appears in the file AND matches --source.
+    expect(parsed['transitioned']).toBe(1);
+    const notFound = parsed['not_found_ids'] as string[];
+    // The session id (excluded by the AND-criterion) and the unknown id are
+    // both reported, never silently dropped.
+    expect(new Set(notFound)).toEqual(new Set([session!.id.toLowerCase(), unknownId]));
+
+    inspect(({ memoryRepo }) => {
+      const rows = memoryRepo.findByTenant(DEFAULT_TENANT);
+      expect(rows.find((m) => m.id === imported!.id)?.lifecycle).toBe('deprecated');
+      expect(rows.find((m) => m.id === session!.id)?.lifecycle).toBe('active');
+    });
+  });
+
+  it('reports already-in-target rows as skipped no-ops', async () => {
+    seed({ source: 'import', lifecycle: 'deprecated' });
+    const rc = await dispatch(
+      args('--to', 'deprecated', '--reason', 'r', '--actor', 'a', '--source', 'import', '--json'),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['transitioned']).toBe(0);
+    const skipped = parsed['skipped'] as Array<Record<string, unknown>>;
+    expect(skipped[0]!['why']).toBe('already in target state');
+  });
+
+  it('reactivates deprecated rows with --to active (category-scoped)', async () => {
+    const [deprecated] = seed({ source: 'import', category: 'reference', lifecycle: 'deprecated' });
+    const rc = await dispatch(
+      args('--to', 'active', '--reason', 'restore', '--actor', 'a', '--category', 'reference'),
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    expect(stdoutText()).toMatch(/Transitioned: 1/);
+    inspect(({ memoryRepo, auditRepo }) => {
+      expect(memoryRepo.findByTenant(DEFAULT_TENANT)[0]?.lifecycle).toBe('active');
+      expect(auditRepo.findByMemory(deprecated!.id)[0]?.action).toBe('promoted');
+    });
+  });
+});

--- a/apps/curator/src/__tests__/cli-batch-transition.test.ts
+++ b/apps/curator/src/__tests__/cli-batch-transition.test.ts
@@ -358,7 +358,7 @@ describe('batch-transition — receipted transitions', () => {
     });
   });
 
-  it('AND-combines an ids file with other criteria and reports not-found ids', async () => {
+  it('AND-combines an ids file with other criteria, separating not-found from criteria-excluded', async () => {
     const [imported] = seed({ source: 'import', lifecycle: 'active' });
     const [session] = seed({ source: 'claude_session', lifecycle: 'active' });
     const unknownId = '00000000-0000-4000-8000-000000000000';
@@ -390,10 +390,12 @@ describe('batch-transition — receipted transitions', () => {
     const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
     // Only the import-source id both appears in the file AND matches --source.
     expect(parsed['transitioned']).toBe(1);
-    const notFound = parsed['not_found_ids'] as string[];
-    // The session id (excluded by the AND-criterion) and the unknown id are
-    // both reported, never silently dropped.
-    expect(new Set(notFound)).toEqual(new Set([session!.id.toLowerCase(), unknownId]));
+    // The two buckets are distinct (PR #309 finding 2): the session id EXISTS in
+    // the tenant but was filtered by --source (criteria_excluded); the unknown id
+    // is genuinely not in the corpus (not_found). An operator can tell a
+    // correctly-filtered id from a typo.
+    expect(parsed['not_found_ids']).toEqual([unknownId]);
+    expect(parsed['criteria_excluded_ids']).toEqual([session!.id.toLowerCase()]);
 
     inspect(({ memoryRepo }) => {
       const rows = memoryRepo.findByTenant(DEFAULT_TENANT);

--- a/apps/curator/src/__tests__/import-exclusion-gate.test.ts
+++ b/apps/curator/src/__tests__/import-exclusion-gate.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the import exclusion gate (bead 5kw.1): verdict table, the
+ * policy-pipeline-shaped rejection (mirror of the origin gate / PR #302),
+ * and the Curator integration — an import-source junk candidate is rejected
+ * WITH a receipted audit event while an identical interactive-source
+ * candidate is untouched.
+ *
+ * @module __tests__/import-exclusion-gate.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  AuditRepository,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  createTestDatabase,
+} from '@qmd-team-intent-kb/store';
+import { makeCandidate, DEFAULT_TENANT } from '@qmd-team-intent-kb/test-fixtures';
+
+import { Curator } from '../curator.js';
+import {
+  checkImportExclusion,
+  IMPORT_EXCLUSION_RULE_TYPE,
+} from '../import-exclusion/import-exclusion-gate.js';
+import { parseBrainignore, type BrainignoreRuleset } from '../import-exclusion/brainignore.js';
+
+const PROSE =
+  'A perfectly ordinary imported note about the deployment pipeline and its gates, ' +
+  'long enough to clear the content-length floor and lexically varied enough to read as prose.';
+
+describe('checkImportExclusion — verdict table', () => {
+  it('is not applicable to interactive sources, junk content or not', () => {
+    for (const source of ['claude_session', 'manual', 'mcp'] as const) {
+      const candidate = makeCandidate({
+        source,
+        metadata: { filePaths: ['node_modules/pkg/README.md'], tags: [] },
+      });
+      expect(checkImportExclusion(candidate).verdict).toBe('not_applicable');
+    }
+  });
+
+  it('clears an import candidate with clean paths and prose content', () => {
+    const candidate = makeCandidate({
+      source: 'import',
+      content: PROSE,
+      metadata: { filePaths: ['docs/deployment.md'], tags: [] },
+    });
+    expect(checkImportExclusion(candidate).verdict).toBe('clear');
+  });
+
+  it('rejects an import candidate on a vendored path with a pipeline-shaped receipt', () => {
+    const candidate = makeCandidate({
+      source: 'import',
+      content: PROSE,
+      metadata: {
+        filePaths: ['iams-gcp-resources/node_modules/@google-cloud/storage/README.md'],
+        tags: [],
+      },
+    });
+    const result = checkImportExclusion(candidate);
+    expect(result.verdict).toBe('rejected');
+    if (result.verdict !== 'rejected') throw new Error('unreachable');
+    expect(result.match.code).toBe('brainignore_path');
+    // Policy-pipeline-shaped (the #302 origin-gate mirror): flows through the
+    // existing receipted rejection path, never a crash.
+    expect(result.pipelineResult.outcome).toBe('rejected');
+    expect(result.pipelineResult.rejectedBy).toBe('brainignore_path');
+    expect(result.pipelineResult.evaluations[0]?.ruleType).toBe(IMPORT_EXCLUSION_RULE_TYPE);
+    expect(result.pipelineResult.evaluations[0]?.reason).toContain('node_modules');
+  });
+
+  it('rejects bulk_import candidates the same way', () => {
+    const candidate = makeCandidate({
+      source: 'bulk_import',
+      trustLevel: 'low',
+      content: PROSE,
+      metadata: { filePaths: ['repo/pnpm-lock.yaml'], tags: [] },
+    });
+    const result = checkImportExclusion(candidate);
+    expect(result.verdict).toBe('rejected');
+  });
+
+  it('rejects on content heuristics even when every path is clean', () => {
+    const candidate = makeCandidate({
+      source: 'import',
+      content:
+        'Permission is hereby granted, free of charge, to any person obtaining a copy of this software.',
+      metadata: { filePaths: ['docs/innocent-name.md'], tags: [] },
+    });
+    const result = checkImportExclusion(candidate);
+    expect(result.verdict).toBe('rejected');
+    if (result.verdict !== 'rejected') throw new Error('unreachable');
+    expect(result.match.code).toBe('brainignore_license_boilerplate');
+  });
+
+  it('honors an override ruleset whose negation re-admits a default exclusion', () => {
+    const ruleset: BrainignoreRuleset = {
+      patterns: parseBrainignore(
+        ['**/node_modules/**', '!**/node_modules/my-own-pkg/**'].join('\n'),
+        'override',
+      ),
+      overridePath: '/tmp/brainignore',
+    };
+    const candidate = makeCandidate({
+      source: 'import',
+      content: PROSE,
+      metadata: { filePaths: ['node_modules/my-own-pkg/NOTES.md'], tags: [] },
+    });
+    expect(checkImportExclusion(candidate, ruleset).verdict).toBe('clear');
+  });
+});
+
+describe('Curator integration (5kw.1)', () => {
+  function makeCurator(overrides: Record<string, unknown> = {}) {
+    const db = createTestDatabase();
+    const deps = {
+      candidateRepo: new CandidateRepository(db),
+      memoryRepo: new MemoryRepository(db),
+      policyRepo: new PolicyRepository(db),
+      auditRepo: new AuditRepository(db),
+    };
+    const curator = new Curator(deps, { tenantId: DEFAULT_TENANT, ...overrides });
+    return { curator, deps };
+  }
+
+  it('rejects an import-source vendored doc and writes a receipted audit event', () => {
+    const { curator, deps } = makeCurator();
+    const candidate = makeCandidate({
+      source: 'import',
+      content: PROSE,
+      metadata: { filePaths: ['node_modules/@google-cloud/storage/README.md'], tags: [] },
+    });
+
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('rejected');
+    expect(result.pipelineResult?.rejectedBy).toBe('brainignore_path');
+    expect(result.reason).toContain('brainignore_path');
+
+    // Receipted: the rejection landed on the audit chain with the evidence.
+    const events = deps.auditRepo.findByMemory(candidate.id);
+    expect(events.length).toBe(1);
+    const details = events[0]!.details as {
+      outcome: string;
+      evaluations: Array<{ ruleId: string; ruleType: string; reason: string }>;
+    };
+    expect(details.outcome).toBe('rejected');
+    expect(details.evaluations[0]?.ruleId).toBe('brainignore_path');
+    expect(details.evaluations[0]?.ruleType).toBe(IMPORT_EXCLUSION_RULE_TYPE);
+    expect(details.evaluations[0]?.reason).toContain('node_modules');
+
+    // Nothing was promoted.
+    expect(deps.memoryRepo.findByTenant(DEFAULT_TENANT).length).toBe(0);
+  });
+
+  it('promotes an identical candidate from an interactive source untouched', () => {
+    const { curator, deps } = makeCurator();
+    const candidate = makeCandidate({
+      source: 'claude_session',
+      content: PROSE,
+      metadata: { filePaths: ['node_modules/@google-cloud/storage/README.md'], tags: [] },
+    });
+
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+    expect(deps.memoryRepo.findByTenant(DEFAULT_TENANT).length).toBe(1);
+  });
+
+  it('a configured override ruleset lets a negated path promote', () => {
+    const ruleset: BrainignoreRuleset = {
+      patterns: parseBrainignore(
+        ['**/node_modules/**', '!**/node_modules/my-own-pkg/**'].join('\n'),
+        'override',
+      ),
+      overridePath: '/tmp/brainignore',
+    };
+    const { curator } = makeCurator({ importExclusions: ruleset });
+    const candidate = makeCandidate({
+      source: 'import',
+      content: PROSE,
+      metadata: { filePaths: ['node_modules/my-own-pkg/NOTES.md'], tags: [] },
+    });
+    expect(curator.processSingle(candidate).outcome).toBe('promoted');
+  });
+});

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -710,6 +710,35 @@ interface BatchApplied {
   auditEventId: string | null; // null in dry-run (no receipt was written)
 }
 
+/**
+ * Partition the --ids-file ids that were NOT transitioned into two buckets so
+ * an operator can tell a typo from a correctly-filtered id (PR #309 finding 2):
+ *   - notFound         — no such memory in THIS tenant's corpus at all (typo,
+ *                        wrong tenant, or already hard-deleted).
+ *   - criteriaExcluded — the memory EXISTS in the tenant but another
+ *                        AND-criterion (--source / --category /
+ *                        --imported-before) filtered it out. Working as
+ *                        intended, surfaced so the exclusion is visible.
+ * Returns empty buckets when no ids file was given.
+ */
+function bucketUnmatchedIds(
+  idsFilter: Set<string> | null,
+  tenantRows: readonly CuratedMemory[],
+  matched: readonly CuratedMemory[],
+): { notFoundIds: string[]; criteriaExcludedIds: string[] } {
+  const notFoundIds: string[] = [];
+  const criteriaExcludedIds: string[] = [];
+  if (idsFilter === null) return { notFoundIds, criteriaExcludedIds };
+  const tenantIdSet = new Set(tenantRows.map((m) => m.id.toLowerCase()));
+  const matchedIdSet = new Set(matched.map((m) => m.id.toLowerCase()));
+  for (const id of idsFilter) {
+    if (matchedIdSet.has(id)) continue;
+    if (tenantIdSet.has(id)) criteriaExcludedIds.push(id);
+    else notFoundIds.push(id);
+  }
+  return { notFoundIds, criteriaExcludedIds };
+}
+
 async function cmdBatchTransition(args: string[], deps: CuratorCliDeps): Promise<number> {
   const parsed = parseBatchTransitionArgs(args);
   if (!parsed.ok) {
@@ -746,13 +775,9 @@ async function cmdBatchTransition(args: string[], deps: CuratorCliDeps): Promise
       return true;
     });
 
-    // ids named in the file but absent from the matched tenant rows: reported,
-    // never silently dropped (the id may be another tenant's, already deleted,
-    // or excluded by an AND-criterion).
-    const notFoundIds: string[] =
-      idsFilter !== null
-        ? [...idsFilter].filter((id) => !matched.some((m) => m.id.toLowerCase() === id))
-        : [];
+    // ids named in the file but not transitioned, split into two buckets (see
+    // bucketUnmatchedIds / PR #309 review finding 2).
+    const { notFoundIds, criteriaExcludedIds } = bucketUnmatchedIds(idsFilter, tenantRows, matched);
 
     const applied: BatchApplied[] = [];
     const skipped: BatchSkip[] = [];
@@ -847,6 +872,7 @@ async function cmdBatchTransition(args: string[], deps: CuratorCliDeps): Promise
           })),
           skipped: skipped.map((s) => ({ memory_id: s.memoryId, from: s.from, why: s.why })),
           not_found_ids: notFoundIds,
+          criteria_excluded_ids: criteriaExcludedIds,
         }) + '\n',
       );
       return 0;
@@ -873,10 +899,18 @@ async function cmdBatchTransition(args: string[], deps: CuratorCliDeps): Promise
     }
     if (notFoundIds.length > 0) {
       process.stderr.write(
-        `\nNOT_FOUND: ${notFoundIds.length} id(s) from --ids-file matched no tenant row ` +
-          `(other tenant, deleted, or excluded by another criterion):\n`,
+        `\nNOT_FOUND: ${notFoundIds.length} id(s) from --ids-file are not in this tenant's corpus ` +
+          `(typo, wrong tenant, or already deleted):\n`,
       );
       for (const id of notFoundIds) process.stderr.write(`  ${id}\n`);
+    }
+    if (criteriaExcludedIds.length > 0) {
+      process.stdout.write(
+        `\nCRITERIA_EXCLUDED: ${criteriaExcludedIds.length} id(s) from --ids-file exist in this ` +
+          `tenant but were filtered out by another criterion (--source / --category / ` +
+          `--imported-before) — working as intended:\n`,
+      );
+      for (const id of criteriaExcludedIds) process.stdout.write(`  ${id}\n`);
     }
     return 0;
   } catch (err) {

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -21,17 +21,26 @@
  * @module cli
  */
 
-import { createPublicKey, createPrivateKey } from 'node:crypto';
+import { createPublicKey, createPrivateKey, randomUUID } from 'node:crypto';
 import {
   closeSync,
   existsSync,
   openSync,
+  readFileSync,
   statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
+
+import {
+  AuditEvent as AuditEventSchema,
+  MemoryCategory,
+  MemorySource,
+  isTransitionAllowed,
+} from '@qmd-team-intent-kb/schema';
+import type { CuratedMemory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 
 import {
   CandidateRepository,
@@ -59,6 +68,7 @@ import {
 
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
+import { loadBrainignoreRuleset } from './import-exclusion/load-brainignore.js';
 import { mergeGovern } from './merge/merge-gate.js';
 import { walkProvenance } from './provenance/provenance-walk.js';
 
@@ -83,8 +93,20 @@ export interface CuratorCliDeps {
 const USAGE = `Usage: curator-cli <subcommand> [options]
 
 Subcommands:
-  ingest <spool-dir> --tenant <id> [--db <path>] [--json]
+  ingest <spool-dir> --tenant <id> [--db <path>] [--brainignore <path>] [--json]
     Drive ingest → policy → promote pipeline against a spool directory.
+    Import-source candidates run the brainignore import exclusion gate
+    (committed defaults + the per-brain override file).
+
+  batch-transition --db <path> --tenant <id> --to <state> --reason <text>
+                   --actor <id> [--source <src>] [--category <cat>]
+                   [--imported-before <ISO>] [--ids-file <path>]
+                   [--dry-run] [--json]
+    Apply one lifecycle transition to every curated memory matching the
+    given criteria (AND-combined; at least one required). Each transition
+    writes its own hash-chained audit receipt in its own per-memory
+    transaction — never one giant receipt. --dry-run opens the DB
+    READ-ONLY and reports what would transition without writing.
 
   verify-audit-chain [--db <path>] [--json]
     Walk the audit_events hash chain and exit 2 if AUDIT_TAMPERED.
@@ -127,8 +149,33 @@ Subcommands:
 Options for 'ingest':
   --tenant <id>   Tenant id used by the policy pipeline (required).
   --db <path>     Persistent SQLite path. Default: in-memory.
+  --brainignore <path>
+                  Per-brain brainignore override file merged on top of the
+                  committed default exclusion ruleset. Default:
+                  $TEAMKB_BRAINIGNORE, else ~/.teamkb/brainignore. A missing
+                  file is normal (defaults-only).
   --json          Emit machine-readable JSON envelope to stdout in place
                   of human-readable summary.
+
+Options for 'batch-transition':
+  --db <path>     SQLite path (required — refuses an implicit in-memory store).
+  --tenant <id>   Tenant scope (required).
+  --to <state>    Target lifecycle state: deprecated | archived | active.
+                  'superseded' is refused — it requires a per-memory
+                  supersededBy id, which a batch cannot supply honestly.
+  --reason <text> Reason recorded verbatim on every per-memory receipt (required).
+  --actor <id>    Human actor recorded on every receipt (required).
+  --source <src>          Match memories with this source (e.g. import, bulk_import).
+  --category <cat>        Match memories with this category.
+  --imported-before <ISO> Match memories whose promoted_at is strictly before
+                          this instant (for import-source rows, promoted_at is
+                          the import time).
+  --ids-file <path>       File of memory UUIDs, one per line ('#' comments and
+                          blank lines allowed). AND-combined with the other
+                          criteria; ids absent from the tenant's corpus are
+                          reported as not-found, never silently dropped.
+  --dry-run       Open the DB READ-ONLY and report what would transition.
+  --json          Emit a structured JSON envelope in place of the summary.
 
 Options for 'verify-audit-chain':
   --db <path>     SQLite path (required for any meaningful verify run;
@@ -183,6 +230,8 @@ export async function dispatch(argv: string[], deps: CuratorCliDeps): Promise<nu
   switch (subcommand) {
     case 'ingest':
       return cmdIngest(argv.slice(1), deps);
+    case 'batch-transition':
+      return cmdBatchTransition(argv.slice(1), deps);
     case 'verify-audit-chain':
       return cmdVerifyAuditChain(argv.slice(1), deps);
     case 'generate-exception-manifest':
@@ -215,6 +264,7 @@ interface IngestOpts {
   spoolDir: string;
   tenantId: string;
   dbPath?: string;
+  brainignorePath?: string;
   json: boolean;
 }
 
@@ -231,6 +281,7 @@ function parseIngestArgs(args: string[]): IngestArgParseOk | IngestArgParseErr {
   let spoolDir: string | undefined;
   let tenantId: string | undefined;
   let dbPath: string | undefined;
+  let brainignorePath: string | undefined;
   let json = false;
 
   let i = 0;
@@ -243,6 +294,10 @@ function parseIngestArgs(args: string[]): IngestArgParseOk | IngestArgParseErr {
         break;
       case '--db':
         dbPath = args[i + 1];
+        i += 2;
+        break;
+      case '--brainignore':
+        brainignorePath = args[i + 1];
         i += 2;
         break;
       case '--json':
@@ -268,7 +323,7 @@ function parseIngestArgs(args: string[]): IngestArgParseOk | IngestArgParseErr {
     return { ok: false, message: 'missing required flag: --tenant <id>' };
   }
 
-  return { ok: true, opts: { spoolDir, tenantId, dbPath, json } };
+  return { ok: true, opts: { spoolDir, tenantId, dbPath, brainignorePath, json } };
 }
 
 async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> {
@@ -277,7 +332,7 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     process.stderr.write(`curator-cli ingest: ${parsed.message}\n\n${USAGE}`);
     return 2;
   }
-  const { spoolDir, tenantId, dbPath, json } = parsed.opts;
+  const { spoolDir, tenantId, dbPath, brainignorePath, json } = parsed.opts;
 
   const db = deps.createDb(dbPath !== undefined ? { dbPath } : {});
   try {
@@ -324,9 +379,17 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
         `[curator-cli] ${ORIGIN_SECRET_UNAVAILABLE_WARNING} (${e instanceof Error ? e.message : String(e)})\n`,
       );
     }
+    // Import exclusion (5kw.1): committed defaults + the per-brain override
+    // file (--brainignore > $TEAMKB_BRAINIGNORE > ~/.teamkb/brainignore). An
+    // unreadable override warns and degrades to defaults-only — the gate
+    // itself always runs for import-source candidates.
+    const importExclusions = loadBrainignoreRuleset({
+      ...(brainignorePath !== undefined ? { path: brainignorePath } : {}),
+      onWarn: (m) => process.stderr.write(`[curator-cli] ${m}\n`),
+    });
     const curator = new Curator(
       { candidateRepo, memoryRepo, policyRepo, auditRepo, linksRepo },
-      { tenantId, originSecret },
+      { tenantId, originSecret, importExclusions },
     );
     const batch = curator.processBatch(candidates);
 
@@ -382,6 +445,455 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
       (db as unknown as { close?: () => void }).close?.();
     } catch {
       // closing twice or on a torn-down db is a non-fatal cleanup error.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// batch-transition (5kw.2)
+//
+// Receipted batch lifecycle transitions so a hygiene sweep does not need one
+// MCP call per memory (the 2026-07-17 cleanup drove brain_transition 11 times
+// by hand plus a 681-target one-off stdio script). Contract:
+//
+//   - Criteria (--source / --category / --imported-before / --ids-file) are
+//     AND-combined and AT LEAST ONE is required — a criterion-less invocation
+//     would be a tenant-wide mass transition and is refused at parse time.
+//   - Each eligible memory transitions in ITS OWN SQLite transaction that
+//     writes the lifecycle update AND that memory's hash-chained audit receipt
+//     together — one receipt per transition, never one giant batch receipt, so
+//     a kill mid-sweep leaves every completed transition fully receipted and
+//     no half-written one.
+//   - --to superseded is refused: a legal superseded transition carries a
+//     per-memory supersededBy id (schema TransitionRequest), which a batch
+//     criterion cannot supply honestly.
+//   - Rows whose CURRENT lifecycle cannot legally reach the target (schema
+//     ALLOWED_TRANSITIONS) are skipped and reported, never fatal — a sweep
+//     over a mixed corpus must not abort at the first archived row.
+//   - --dry-run opens the DB READ-ONLY (structurally cannot write) and
+//     reports what would transition.
+//   - --db is mandatory: an implicit in-memory store would "transition"
+//     nothing durable and report success about nothing (same refusal as
+//     verify-corpus-accounting).
+// ---------------------------------------------------------------------------
+
+/** Batch targets. 'superseded' is deliberately absent (needs per-memory supersededBy). */
+const BATCH_TRANSITION_TARGETS = ['deprecated', 'archived', 'active'] as const;
+type BatchTransitionTarget = (typeof BATCH_TRANSITION_TARGETS)[number];
+
+/** Map a target lifecycle state to the audit action verb (house mapping —
+ *  same table as the API MemoryService.lifecycleToAction). */
+function batchLifecycleToAction(to: BatchTransitionTarget): 'demoted' | 'archived' | 'promoted' {
+  switch (to) {
+    case 'deprecated':
+      return 'demoted';
+    case 'archived':
+      return 'archived';
+    case 'active':
+      return 'promoted';
+  }
+}
+
+/** Generic UUID shape (any version — curated memory ids are content-derived UUIDv5). */
+const MEMORY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface BatchTransitionOpts {
+  dbPath: string;
+  tenantId: string;
+  to: BatchTransitionTarget;
+  reason: string;
+  actor: string;
+  source?: string;
+  category?: string;
+  importedBefore?: string;
+  idsFile?: string;
+  dryRun: boolean;
+  json: boolean;
+}
+
+/** Value-taking (`--flag value`) and boolean (`--flag`) flag names for
+ *  batch-transition. Kept as data so the tokenizer stays a simple loop. */
+const BATCH_VALUE_FLAGS = new Set([
+  '--db',
+  '--tenant',
+  '--to',
+  '--reason',
+  '--actor',
+  '--source',
+  '--category',
+  '--imported-before',
+  '--ids-file',
+]);
+const BATCH_BOOL_FLAGS = new Set(['--dry-run', '--json']);
+
+/** Tokenize argv into a flag→value map + a boolean-flag set. Deliberately
+ *  dumb (no per-flag validation) so its complexity stays flat; the semantic
+ *  checks live in {@link validateBatchTransition}. */
+function tokenizeBatchArgs(
+  args: string[],
+):
+  | { ok: true; values: Map<string, string | undefined>; bools: Set<string> }
+  | { ok: false; message: string } {
+  const values = new Map<string, string | undefined>();
+  const bools = new Set<string>();
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+    if (BATCH_VALUE_FLAGS.has(arg)) {
+      values.set(arg, args[i + 1]);
+      i += 2;
+    } else if (BATCH_BOOL_FLAGS.has(arg)) {
+      bools.add(arg);
+      i += 1;
+    } else {
+      return { ok: false, message: `unknown flag: ${arg}` };
+    }
+  }
+  return { ok: true, values, bools };
+}
+
+/** Validate a required non-empty string flag, returning its trimmed-nonempty
+ *  value or a usage error. */
+function requireFlag(
+  value: string | undefined,
+  message: string,
+): { ok: true; value: string } | { ok: false; message: string } {
+  if (value === undefined || value.trim() === '') return { ok: false, message };
+  return { ok: true, value };
+}
+
+function parseBatchTransitionArgs(
+  args: string[],
+): { ok: true; opts: BatchTransitionOpts } | { ok: false; message: string } {
+  const tokens = tokenizeBatchArgs(args);
+  if (!tokens.ok) return tokens;
+  const { values, bools } = tokens;
+
+  const db = requireFlag(
+    values.get('--db'),
+    'missing required flag: --db <path> (refusing to transition an implicit in-memory store)',
+  );
+  if (!db.ok) return db;
+  const tenant = requireFlag(values.get('--tenant'), 'missing required flag: --tenant <id>');
+  if (!tenant.ok) return tenant;
+
+  const to = values.get('--to');
+  if (to === undefined) return { ok: false, message: 'missing required flag: --to <state>' };
+  if (!(BATCH_TRANSITION_TARGETS as readonly string[]).includes(to)) {
+    return {
+      ok: false,
+      message:
+        to === 'superseded'
+          ? `--to superseded is not batchable: a superseded transition requires a per-memory supersededBy id`
+          : `invalid --to "${to}" (expected one of: ${BATCH_TRANSITION_TARGETS.join(', ')})`,
+    };
+  }
+
+  const reason = requireFlag(values.get('--reason'), 'missing required flag: --reason <text>');
+  if (!reason.ok) return reason;
+  const actor = requireFlag(values.get('--actor'), 'missing required flag: --actor <id>');
+  if (!actor.ok) return actor;
+
+  const source = values.get('--source');
+  const category = values.get('--category');
+  const importedBefore = values.get('--imported-before');
+  const idsFile = values.get('--ids-file');
+
+  const criteria = validateBatchCriteria({ source, category, importedBefore, idsFile });
+  if (!criteria.ok) return criteria;
+
+  return {
+    ok: true,
+    opts: {
+      dbPath: db.value,
+      tenantId: tenant.value,
+      to: to as BatchTransitionTarget,
+      reason: reason.value,
+      actor: actor.value,
+      source,
+      category,
+      importedBefore,
+      idsFile,
+      dryRun: bools.has('--dry-run'),
+      json: bools.has('--json'),
+    },
+  };
+}
+
+/** Validate the four batch-selection criteria: at least one present, and each
+ *  present one well-formed. Split out of the arg parser to keep both functions
+ *  under the complexity gate. */
+function validateBatchCriteria(c: {
+  source?: string;
+  category?: string;
+  importedBefore?: string;
+  idsFile?: string;
+}): { ok: true } | { ok: false; message: string } {
+  if (
+    c.source === undefined &&
+    c.category === undefined &&
+    c.importedBefore === undefined &&
+    c.idsFile === undefined
+  ) {
+    return {
+      ok: false,
+      message:
+        'at least one criterion is required (--source, --category, --imported-before, --ids-file) — ' +
+        'a criterion-less batch would be a tenant-wide mass transition; refusing',
+    };
+  }
+  if (c.source !== undefined && !MemorySource.safeParse(c.source).success) {
+    return {
+      ok: false,
+      message: `invalid --source "${c.source}" (expected one of: ${MemorySource.options.join(', ')})`,
+    };
+  }
+  if (c.category !== undefined && !MemoryCategory.safeParse(c.category).success) {
+    return {
+      ok: false,
+      message: `invalid --category "${c.category}" (expected one of: ${MemoryCategory.options.join(', ')})`,
+    };
+  }
+  if (c.importedBefore !== undefined && Number.isNaN(Date.parse(c.importedBefore))) {
+    return {
+      ok: false,
+      message: `invalid --imported-before "${c.importedBefore}" (expected an ISO-8601 datetime)`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Parse an ids file: one UUID per line, '#' comments and blank lines allowed.
+ *  A malformed line is a hard usage error — silently dropping it could turn a
+ *  targeted sweep into a differently-scoped one. */
+function parseIdsFile(path: string): { ok: true; ids: string[] } | { ok: false; message: string } {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (e) {
+    return {
+      ok: false,
+      message: `cannot read --ids-file ${path}: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  const ids: string[] = [];
+  const lines = text.split('\n');
+  for (let n = 0; n < lines.length; n++) {
+    const line = lines[n]!.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    if (!MEMORY_ID_PATTERN.test(line)) {
+      return {
+        ok: false,
+        message: `--ids-file ${path} line ${n + 1} is not a UUID: "${line}"`,
+      };
+    }
+    ids.push(line.toLowerCase());
+  }
+  if (ids.length === 0) {
+    return { ok: false, message: `--ids-file ${path} contains no memory ids` };
+  }
+  return { ok: true, ids };
+}
+
+/** One skipped row in the batch report — id + why, never content. */
+interface BatchSkip {
+  memoryId: string;
+  from: string;
+  why: string;
+}
+
+/** One applied (or would-apply) transition in the batch report. */
+interface BatchApplied {
+  memoryId: string;
+  from: string;
+  to: string;
+  auditEventId: string | null; // null in dry-run (no receipt was written)
+}
+
+async function cmdBatchTransition(args: string[], deps: CuratorCliDeps): Promise<number> {
+  const parsed = parseBatchTransitionArgs(args);
+  if (!parsed.ok) {
+    process.stderr.write(`curator-cli batch-transition: ${parsed.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const opts = parsed.opts;
+
+  let idsFilter: Set<string> | null = null;
+  if (opts.idsFile !== undefined) {
+    const idsParsed = parseIdsFile(opts.idsFile);
+    if (!idsParsed.ok) {
+      process.stderr.write(`curator-cli batch-transition: ${idsParsed.message}\n\n${USAGE}`);
+      return 2;
+    }
+    idsFilter = new Set(idsParsed.ids);
+  }
+
+  // Dry-run opens READ-ONLY: the preview structurally cannot write.
+  const db = deps.createDb({ dbPath: opts.dbPath, readonly: opts.dryRun });
+  try {
+    const memoryRepo = new MemoryRepository(db);
+    const auditRepo = new AuditRepository(db);
+
+    const tenantRows = memoryRepo.findByTenant(opts.tenantId);
+    const importedBeforeMs =
+      opts.importedBefore !== undefined ? Date.parse(opts.importedBefore) : null;
+
+    const matched: CuratedMemory[] = tenantRows.filter((m) => {
+      if (opts.source !== undefined && m.source !== opts.source) return false;
+      if (opts.category !== undefined && m.category !== opts.category) return false;
+      if (importedBeforeMs !== null && Date.parse(m.promotedAt) >= importedBeforeMs) return false;
+      if (idsFilter !== null && !idsFilter.has(m.id.toLowerCase())) return false;
+      return true;
+    });
+
+    // ids named in the file but absent from the matched tenant rows: reported,
+    // never silently dropped (the id may be another tenant's, already deleted,
+    // or excluded by an AND-criterion).
+    const notFoundIds: string[] =
+      idsFilter !== null
+        ? [...idsFilter].filter((id) => !matched.some((m) => m.id.toLowerCase() === id))
+        : [];
+
+    const applied: BatchApplied[] = [];
+    const skipped: BatchSkip[] = [];
+
+    for (const memory of matched) {
+      if (memory.lifecycle === opts.to) {
+        skipped.push({
+          memoryId: memory.id,
+          from: memory.lifecycle,
+          why: 'already in target state',
+        });
+        continue;
+      }
+      if (!isTransitionAllowed(memory.lifecycle, opts.to as MemoryLifecycleState)) {
+        skipped.push({
+          memoryId: memory.id,
+          from: memory.lifecycle,
+          why: `"${memory.lifecycle}" -> "${opts.to}" is not a legal lifecycle transition`,
+        });
+        continue;
+      }
+
+      if (opts.dryRun) {
+        applied.push({
+          memoryId: memory.id,
+          from: memory.lifecycle,
+          to: opts.to,
+          auditEventId: null,
+        });
+        continue;
+      }
+
+      // ONE transaction per memory: the lifecycle update and THIS memory's
+      // audit receipt commit together (mirrors the single-memory
+      // brain_transition path in apps/mcp-server/src/tools/transition.ts).
+      const now = new Date().toISOString();
+      const auditEventId = randomUUID();
+      const applyOne = db.transaction(() => {
+        memoryRepo.updateLifecycle(memory.id, opts.to as MemoryLifecycleState, now);
+        auditRepo.insert(
+          AuditEventSchema.parse({
+            id: auditEventId,
+            action: batchLifecycleToAction(opts.to),
+            memoryId: memory.id,
+            tenantId: memory.tenantId,
+            actor: { type: 'human', id: opts.actor },
+            reason: opts.reason,
+            details: {
+              from: memory.lifecycle,
+              to: opts.to,
+              batch: true,
+              criteria: {
+                ...(opts.source !== undefined ? { source: opts.source } : {}),
+                ...(opts.category !== undefined ? { category: opts.category } : {}),
+                ...(opts.importedBefore !== undefined
+                  ? { importedBefore: opts.importedBefore }
+                  : {}),
+                ...(opts.idsFile !== undefined ? { idsFile: opts.idsFile } : {}),
+              },
+            },
+            timestamp: now,
+          }),
+        );
+      });
+      applyOne();
+      applied.push({ memoryId: memory.id, from: memory.lifecycle, to: opts.to, auditEventId });
+    }
+
+    const criteria = {
+      ...(opts.source !== undefined ? { source: opts.source } : {}),
+      ...(opts.category !== undefined ? { category: opts.category } : {}),
+      ...(opts.importedBefore !== undefined ? { imported_before: opts.importedBefore } : {}),
+      ...(opts.idsFile !== undefined ? { ids_file: opts.idsFile } : {}),
+    };
+
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          dry_run: opts.dryRun,
+          tenant_id: opts.tenantId,
+          to: opts.to,
+          criteria,
+          tenant_rows: tenantRows.length,
+          matched: matched.length,
+          transitioned: applied.length,
+          transitions: applied.map((a) => ({
+            memory_id: a.memoryId,
+            from: a.from,
+            to: a.to,
+            audit_event_id: a.auditEventId,
+          })),
+          skipped: skipped.map((s) => ({ memory_id: s.memoryId, from: s.from, why: s.why })),
+          not_found_ids: notFoundIds,
+        }) + '\n',
+      );
+      return 0;
+    }
+
+    process.stdout.write(
+      `batch-transition ${opts.dryRun ? '(dry-run — nothing written) ' : ''}complete\n` +
+        `Tenant:       ${opts.tenantId}\n` +
+        `Target state: ${opts.to}\n` +
+        `Criteria:     ${JSON.stringify(criteria)}\n` +
+        `Matched:      ${matched.length} of ${tenantRows.length} tenant row(s)\n` +
+        `${opts.dryRun ? 'Would transition' : 'Transitioned'}: ${applied.length}\n` +
+        `Skipped:      ${skipped.length}\n`,
+    );
+    for (const a of applied) {
+      process.stdout.write(
+        `  ${a.memoryId}  ${a.from} -> ${a.to}` +
+          (a.auditEventId !== null ? `  receipt=${a.auditEventId}` : '') +
+          `\n`,
+      );
+    }
+    for (const s of skipped) {
+      process.stdout.write(`  skipped ${s.memoryId} (${s.from}): ${s.why}\n`);
+    }
+    if (notFoundIds.length > 0) {
+      process.stderr.write(
+        `\nNOT_FOUND: ${notFoundIds.length} id(s) from --ids-file matched no tenant row ` +
+          `(other tenant, deleted, or excluded by another criterion):\n`,
+      );
+      for (const id of notFoundIds) process.stderr.write(`  ${id}\n`);
+    }
+    return 0;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ ok: false, error: msg, code: 'BATCH_TRANSITION_FAILED' }) + '\n',
+      );
+    } else {
+      process.stderr.write(`batch-transition failed: ${msg}\n`);
+    }
+    return 1;
+  } finally {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } catch {
+      // non-fatal
     }
   }
 }

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -18,6 +18,7 @@ import {
 import { promote } from './promotion/promoter.js';
 import { reject } from './rejection/rejector.js';
 import { checkOriginAttestation } from './origin/origin-gate.js';
+import { checkImportExclusion } from './import-exclusion/import-exclusion-gate.js';
 
 /** Repository dependencies required by the Curator */
 export interface CuratorDependencies {
@@ -106,6 +107,29 @@ export class Curator {
         candidateId: candidate.id,
         outcome: 'rejected',
         pipelineResult: originGate.pipelineResult,
+        reason,
+      };
+    }
+
+    // Import exclusion gate (bead 5kw.1) — STRUCTURAL, like the origin gate
+    // above: import-source candidates matching the brainignore ruleset
+    // (vendored paths, lockfiles, boilerplate names, minified/generated/
+    // license-boilerplate content) are rejected deterministically at intake,
+    // with the matched pattern/heuristic on the receipted rejection. Non-import
+    // sources are never checked. Defaults apply when no ruleset is configured,
+    // so no govern path can leave the gate dormant.
+    const importGate = checkImportExclusion(candidate, this.config.importExclusions);
+    if (importGate.verdict === 'rejected') {
+      const reason = reject(
+        candidate,
+        importGate.pipelineResult,
+        this.deps.auditRepo,
+        suppressReject,
+      );
+      return {
+        candidateId: candidate.id,
+        outcome: 'rejected',
+        pipelineResult: importGate.pipelineResult,
         reason,
       };
     }

--- a/apps/curator/src/import-exclusion/brainignore.ts
+++ b/apps/curator/src/import-exclusion/brainignore.ts
@@ -1,0 +1,369 @@
+/**
+ * brainignore — the deterministic import exclusion ruleset (bead
+ * qmd-team-intent-kb-5kw.1).
+ *
+ * The 2026-07-16 whole-machine digestion promoted vendored third-party docs
+ * (node_modules-style package docs, license boilerplate, lockfiles, minified
+ * bundles) into the curated brain because import had no `.gitignore`
+ * equivalent. This module is that equivalent: a committed DEFAULT ruleset of
+ * gitignore-like path patterns plus deterministic content heuristics, with a
+ * per-brain override file (`~/.teamkb/brainignore`) merged on top at intake.
+ *
+ * ## Pattern format (gitignore-like subset — documented deviations)
+ *
+ *  - One pattern per line; `#` starts a comment; blank lines are ignored.
+ *  - `*` matches any run of characters EXCEPT `/`; `**` matches across
+ *    segments (including `/`); `?` matches one non-`/` character.
+ *  - A pattern containing no `/` matches the path BASENAME (like gitignore).
+ *  - A pattern containing `/` matches anywhere in the path unless it starts
+ *    with `/`, which anchors it at the start of the path.
+ *  - `!pattern` NEGATES (re-includes). The LAST matching pattern wins, so an
+ *    override-file `!` line can re-admit something a default excludes.
+ *  - DEVIATION from gitignore: matching is CASE-INSENSITIVE (`LICENSE`,
+ *    `License.txt` and `license` are the same boilerplate), and there are no
+ *    trailing-slash directory semantics (candidate `metadata.filePaths` are
+ *    file paths, not directory listings).
+ *
+ * ## Honesty note — deterministic != perfect
+ *
+ * Every rule here is a pure function of the candidate's bytes: same input,
+ * same verdict, no model, no network, no clock. That makes rejections
+ * receiptable and reproducible — it does NOT make them omniscient. The
+ * heuristics have documented false-positive and false-negative modes (see
+ * each `analyzeContent` check); the escape hatch for a false positive is a
+ * `!pattern` line in the per-brain override file, or hand-promotion through
+ * the admin path after review. A rejection here is "this matched a committed
+ * exclusion rule", never "a model judged this worthless".
+ *
+ * @module import-exclusion/brainignore
+ */
+
+/** One compiled brainignore pattern. */
+export interface BrainignorePattern {
+  /** The raw pattern text as written (without any `!` prefix). */
+  readonly pattern: string;
+  /** True when the line was `!pattern` — a match RE-INCLUDES the path. */
+  readonly negated: boolean;
+  /** Where the pattern came from — the committed defaults or an override file. */
+  readonly source: 'default' | 'override';
+  /** Compiled matcher (case-insensitive). */
+  readonly regex: RegExp;
+  /** True when the pattern contains no `/` and therefore matches basenames. */
+  readonly basenameOnly: boolean;
+}
+
+/** A parsed ruleset: ordered patterns (later entries win) + provenance. */
+export interface BrainignoreRuleset {
+  readonly patterns: readonly BrainignorePattern[];
+  /** Absolute path of the override file merged in, or null when defaults-only. */
+  readonly overridePath: string | null;
+}
+
+/** Verdict for one path / content check. */
+export interface BrainignoreMatch {
+  /** Stable machine-readable code (lands in receipts verbatim). */
+  readonly code:
+    | 'brainignore_path'
+    | 'brainignore_minified_content'
+    | 'brainignore_generated_content'
+    | 'brainignore_license_boilerplate'
+    | 'brainignore_untitled_title';
+  /** Human-readable evidence: the matched pattern + path, or the measured heuristic values. */
+  readonly evidence: string;
+}
+
+/**
+ * The committed default path patterns. Ordered; an override file's patterns
+ * are appended AFTER these, so an operator `!` line always wins (last match
+ * wins). Grouped by junk class from the 2026-07-16 cleanup:
+ */
+export const DEFAULT_BRAINIGNORE_PATTERNS: readonly string[] = [
+  // -- vendored / generated directory trees ---------------------------------
+  '**/node_modules/**',
+  '**/site-packages/**',
+  '**/bower_components/**',
+  '**/vendor/**',
+  '**/.venv/**',
+  '**/venv/**',
+  '**/__pycache__/**',
+  '**/.git/**',
+  '**/.next/**',
+  '**/coverage/**',
+  '**/dist/**',
+  '**/build/**',
+  // -- minified / generated file names --------------------------------------
+  '*.min.js',
+  '*.min.css',
+  '*.map',
+  '*.bundle.js',
+  '*.chunk.js',
+  // -- lockfiles (machine-written dependency state, never knowledge) --------
+  'package-lock.json',
+  'npm-shrinkwrap.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'Cargo.lock',
+  'poetry.lock',
+  'uv.lock',
+  'Pipfile.lock',
+  'Gemfile.lock',
+  'composer.lock',
+  'go.sum',
+  'flake.lock',
+  // -- repo boilerplate templates (CoC / SECURITY / SUPPORT / license) ------
+  'CODE_OF_CONDUCT*',
+  'SECURITY.md',
+  'SUPPORT.md',
+  'PULL_REQUEST_TEMPLATE*',
+  '**/ISSUE_TEMPLATE/**',
+  'LICENSE*',
+  'LICENCE*',
+  'NOTICE*',
+  'PATENTS*',
+];
+
+/**
+ * Compile one gitignore-like pattern into a case-insensitive RegExp.
+ * Deterministic translation, no backtracking traps: only `*`, `**`, `?` are
+ * special; everything else is escaped literally.
+ */
+export function compilePattern(
+  raw: string,
+  source: 'default' | 'override',
+): BrainignorePattern | null {
+  let pattern = raw.trim();
+  if (pattern === '' || pattern.startsWith('#')) return null;
+
+  let negated = false;
+  if (pattern.startsWith('!')) {
+    negated = true;
+    pattern = pattern.slice(1).trim();
+    if (pattern === '') return null;
+  }
+
+  const anchored = pattern.startsWith('/');
+  if (anchored) pattern = pattern.slice(1);
+  const basenameOnly = !pattern.includes('/');
+
+  // Translate glob → regex. `**` first (crosses `/`), then `*` and `?`.
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i]!;
+    if (ch === '*' && pattern[i + 1] === '*') {
+      re += '.*';
+      i += 2;
+      // Collapse a following `/` into the `.*` so `**/x` also matches `x` at
+      // the path root (gitignore semantics).
+      if (pattern[i] === '/') i += 1;
+    } else if (ch === '*') {
+      re += '[^/]*';
+      i += 1;
+    } else if (ch === '?') {
+      re += '[^/]';
+      i += 1;
+    } else {
+      re += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+      i += 1;
+    }
+  }
+
+  // Basename patterns match the final segment; path patterns match the whole
+  // normalized path (optionally anchored at the start).
+  const full = basenameOnly ? `^${re}$` : anchored ? `^${re}$` : `^(?:.*/)?${re}$`;
+  return {
+    pattern: raw.trim().replace(/^!/, '').trim(),
+    negated,
+    source,
+    regex: new RegExp(full, 'i'),
+    basenameOnly,
+  };
+}
+
+/** Parse the text of a brainignore file into compiled patterns (in order). */
+export function parseBrainignore(
+  text: string,
+  source: 'default' | 'override',
+): BrainignorePattern[] {
+  const out: BrainignorePattern[] = [];
+  for (const line of text.split('\n')) {
+    const compiled = compilePattern(line, source);
+    if (compiled !== null) out.push(compiled);
+  }
+  return out;
+}
+
+/** The committed defaults, compiled once at module load. */
+export const DEFAULT_BRAINIGNORE_RULESET: BrainignoreRuleset = {
+  patterns: DEFAULT_BRAINIGNORE_PATTERNS.map((p) => {
+    const compiled = compilePattern(p, 'default');
+    /* istanbul ignore next -- the committed defaults are all valid patterns */
+    if (compiled === null) throw new Error(`invalid default brainignore pattern: ${p}`);
+    return compiled;
+  }),
+  overridePath: null,
+};
+
+/** Normalize a candidate filePath for matching: forward slashes, no `./`. */
+function normalizePath(p: string): string {
+  let n = p.replace(/\\/g, '/');
+  while (n.startsWith('./')) n = n.slice(2);
+  while (n.startsWith('/')) n = n.slice(1);
+  return n;
+}
+
+/**
+ * Match one path against the ruleset. Gitignore semantics: every pattern is
+ * consulted in order and the LAST match decides — a later `!pattern`
+ * (typically from the override file, which is appended after the defaults)
+ * re-includes a path a default excluded.
+ *
+ * @returns the deciding pattern when the path is EXCLUDED, or null.
+ */
+export function matchPath(path: string, ruleset: BrainignoreRuleset): BrainignorePattern | null {
+  const normalized = normalizePath(path);
+  const basename = normalized.split('/').pop() ?? normalized;
+  let decision: BrainignorePattern | null = null;
+  for (const p of ruleset.patterns) {
+    const subject = p.basenameOnly ? basename : normalized;
+    if (p.regex.test(subject)) decision = p;
+  }
+  return decision !== null && !decision.negated ? decision : null;
+}
+
+// ---------------------------------------------------------------------------
+// Content heuristics
+// ---------------------------------------------------------------------------
+
+/** A single line longer than this with almost no whitespace reads as minified. */
+const MINIFIED_LINE_LENGTH = 1000;
+/** Whitespace ratio below this on a long line reads as minified (prose ≈ 0.15–0.20). */
+const MINIFIED_WHITESPACE_RATIO = 0.1;
+/** Content shorter than this is never entropy-classified (too little signal). */
+const ENTROPY_MIN_LENGTH = 1024;
+/** Shannon entropy (bits/char) above this reads as encoded/generated content.
+ *  English prose ≈ 4.2–4.8; base64 ≈ 6.0; source code ≈ 4.5–5.1. */
+const ENTROPY_THRESHOLD = 5.2;
+/** How much of the head of the content is scanned for license boilerplate. */
+const LICENSE_SCAN_WINDOW = 600;
+
+/** Case-insensitive markers that identify license boilerplate text. */
+const LICENSE_MARKERS: readonly string[] = [
+  'apache license',
+  'mit license',
+  'gnu general public license',
+  'gnu lesser general public license',
+  'mozilla public license',
+  'permission is hereby granted, free of charge',
+  'redistribution and use in source and binary forms',
+];
+
+/** Titles that mark a candidate as having no real title. */
+const UNTITLED_TITLES: ReadonlySet<string> = new Set(['untitled', 'untitled document', 'no title']);
+
+/** Shannon entropy in bits per character. Pure and deterministic. */
+export function shannonEntropy(text: string): number {
+  if (text.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const ch of text) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const p = count / text.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+/**
+ * Deterministic content heuristics for machine-written content that path
+ * patterns can miss (a minified bundle imported under an innocent name, a
+ * license pasted into a markdown note). Each check is honest about its
+ * limits:
+ *
+ *  - **minified**: any line > {@link MINIFIED_LINE_LENGTH} chars whose
+ *    whitespace ratio is < {@link MINIFIED_WHITESPACE_RATIO}. Catches minified
+ *    JS/CSS (whitespace ≈ 0.01–0.05). False negative: minified code split
+ *    into short lines. False positive: none known for prose (unwrapped
+ *    markdown paragraphs keep a ≈0.15+ space ratio).
+ *  - **generated/encoded**: content ≥ {@link ENTROPY_MIN_LENGTH} chars with
+ *    Shannon entropy > {@link ENTROPY_THRESHOLD} bits/char — base64 blobs,
+ *    packed sourcemaps. False negative: hex dumps (entropy 4.0). False
+ *    positive: none known for natural-language notes.
+ *  - **license boilerplate**: a known license marker phrase inside the first
+ *    {@link LICENSE_SCAN_WINDOW} chars. Catches vendored LICENSE copies
+ *    imported under any filename. False positive: a genuine note ABOUT
+ *    licensing that opens by quoting a license header — re-admit via review.
+ *  - **untitled**: the normalized title is a known placeholder. Catches the
+ *    empty/untitled documents class from the 2026-07-16 digestion.
+ */
+export function analyzeContent(content: string, title: string): BrainignoreMatch | null {
+  const normalizedTitle = title.trim().toLowerCase();
+  if (UNTITLED_TITLES.has(normalizedTitle)) {
+    return {
+      code: 'brainignore_untitled_title',
+      evidence: `title "${title.trim()}" is a placeholder, not a real title`,
+    };
+  }
+
+  const head = content.slice(0, LICENSE_SCAN_WINDOW).toLowerCase();
+  for (const marker of LICENSE_MARKERS) {
+    if (head.includes(marker)) {
+      return {
+        code: 'brainignore_license_boilerplate',
+        evidence: `license marker "${marker}" found in the first ${LICENSE_SCAN_WINDOW} chars`,
+      };
+    }
+  }
+
+  for (const line of content.split('\n')) {
+    if (line.length > MINIFIED_LINE_LENGTH) {
+      const whitespace = line.length - line.replace(/\s/g, '').length;
+      const ratio = whitespace / line.length;
+      if (ratio < MINIFIED_WHITESPACE_RATIO) {
+        return {
+          code: 'brainignore_minified_content',
+          evidence:
+            `line of ${line.length} chars with whitespace ratio ${ratio.toFixed(3)} ` +
+            `(> ${MINIFIED_LINE_LENGTH} chars and < ${MINIFIED_WHITESPACE_RATIO} reads as minified)`,
+        };
+      }
+    }
+  }
+
+  if (content.length >= ENTROPY_MIN_LENGTH) {
+    const entropy = shannonEntropy(content);
+    if (entropy > ENTROPY_THRESHOLD) {
+      return {
+        code: 'brainignore_generated_content',
+        evidence:
+          `Shannon entropy ${entropy.toFixed(2)} bits/char over ${content.length} chars ` +
+          `(> ${ENTROPY_THRESHOLD} reads as encoded/generated, prose is ≈ 4.2–4.8)`,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Evaluate a candidate's paths + content against the ruleset. Path patterns
+ * first (cheap, and the deciding evidence names the exact path + pattern),
+ * then the content heuristics.
+ */
+export function evaluateBrainignore(
+  filePaths: readonly string[],
+  content: string,
+  title: string,
+  ruleset: BrainignoreRuleset,
+): BrainignoreMatch | null {
+  for (const path of filePaths) {
+    const match = matchPath(path, ruleset);
+    if (match !== null) {
+      return {
+        code: 'brainignore_path',
+        evidence: `path "${path}" matches ${match.source} pattern "${match.pattern}"`,
+      };
+    }
+  }
+  return analyzeContent(content, title);
+}

--- a/apps/curator/src/import-exclusion/import-exclusion-gate.ts
+++ b/apps/curator/src/import-exclusion/import-exclusion-gate.ts
@@ -1,0 +1,94 @@
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import {
+  DEFAULT_BRAINIGNORE_RULESET,
+  evaluateBrainignore,
+  type BrainignoreMatch,
+  type BrainignoreRuleset,
+} from './brainignore.js';
+
+/**
+ * Import exclusion gate (bead qmd-team-intent-kb-5kw.1) — the intake-time
+ * check that an IMPORT-SOURCE candidate does not match the brainignore
+ * exclusion ruleset (vendored paths, lockfiles, boilerplate names, minified /
+ * generated / license-boilerplate content).
+ *
+ * STRUCTURAL, not policy-configured — the same shape as the origin
+ * attestation gate (`origin/origin-gate.ts`, GSB Wave-2 H1 / PR #302): it
+ * runs on every govern path that processes candidates, regardless of tenant
+ * policy. Making it a `governance_policies.rules_json` rule would leave it
+ * dormant on every pre-5kw policy — the exact silent-dormancy failure the
+ * 2026-07-16 digestion exposed (recommended-policy.ts tells that story).
+ * Configurability lives in the RULESET (committed defaults + the per-brain
+ * override file), not in policy plumbing.
+ *
+ * Scope: ONLY candidates with source `import` or `bulk_import`. A
+ * `claude_session` / `manual` / `mcp` candidate is never brainignore-checked —
+ * a human or session deliberately capturing a note about node_modules
+ * internals is knowledge, not vendored junk; only bulk import lacks that
+ * per-item human intent.
+ *
+ * Rejections are POLICY-PIPELINE-SHAPED (`PipelineResult` with
+ * `outcome:'rejected'`) so they flow through the existing receipted rejection
+ * path (`reject()` → audit event), never a crash. The receipt carries the
+ * stable code in `rejectedBy` and the deterministic evidence (matched
+ * pattern + path, or measured heuristic values) in the evaluation reason.
+ */
+
+/** `ruleType` stamped on import-exclusion rule results (a structural pseudo-rule). */
+export const IMPORT_EXCLUSION_RULE_TYPE = 'import_exclusion';
+
+/** Candidate sources the gate applies to. */
+const IMPORT_SOURCES: ReadonlySet<MemoryCandidate['source']> = new Set(['import', 'bulk_import']);
+
+/** Outcome of the import exclusion gate for one candidate. */
+export type ImportExclusionResult =
+  /** Candidate is not import-sourced — the gate does not apply. */
+  | { verdict: 'not_applicable' }
+  /** Import-sourced and matched no exclusion rule. */
+  | { verdict: 'clear' }
+  /** Matched an exclusion rule — receipted rejection. */
+  | { verdict: 'rejected'; match: BrainignoreMatch; pipelineResult: PipelineResult };
+
+/**
+ * Evaluate the import exclusion gate for a candidate. Pure — no I/O; the
+ * caller resolves the ruleset (defaults, or defaults + the per-brain override
+ * file via `loadBrainignoreRuleset`). Omitting `ruleset` applies the
+ * committed defaults, so every govern path is protected without wiring.
+ */
+export function checkImportExclusion(
+  candidate: MemoryCandidate,
+  ruleset: BrainignoreRuleset = DEFAULT_BRAINIGNORE_RULESET,
+): ImportExclusionResult {
+  if (!IMPORT_SOURCES.has(candidate.source)) {
+    return { verdict: 'not_applicable' };
+  }
+
+  const match = evaluateBrainignore(
+    candidate.metadata.filePaths,
+    candidate.content,
+    candidate.title,
+    ruleset,
+  );
+  if (match === null) {
+    return { verdict: 'clear' };
+  }
+
+  return {
+    verdict: 'rejected',
+    match,
+    pipelineResult: {
+      candidateId: candidate.id,
+      outcome: 'rejected',
+      evaluations: [
+        {
+          ruleId: match.code,
+          ruleType: IMPORT_EXCLUSION_RULE_TYPE,
+          outcome: 'fail',
+          reason: `Import exclusion (brainignore): ${match.evidence}`,
+        },
+      ],
+      rejectedBy: match.code,
+    },
+  };
+}

--- a/apps/curator/src/import-exclusion/load-brainignore.ts
+++ b/apps/curator/src/import-exclusion/load-brainignore.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DEFAULT_BRAINIGNORE_PATTERNS,
+  compilePattern,
+  parseBrainignore,
+  type BrainignoreRuleset,
+} from './brainignore.js';
+
+/** Environment variable overriding the per-brain brainignore file location. */
+export const BRAINIGNORE_PATH_ENV = 'TEAMKB_BRAINIGNORE';
+
+/** Default per-brain override file: `~/.teamkb/brainignore`. */
+export function defaultBrainignorePath(): string {
+  return join(homedir(), '.teamkb', 'brainignore');
+}
+
+/** Options for {@link loadBrainignoreRuleset}. */
+export interface LoadBrainignoreOptions {
+  /** Explicit override-file path (wins over the env var and the default). */
+  path?: string;
+  /**
+   * Called when an override file exists but cannot be read/parsed. The loader
+   * NEVER throws — an unreadable override degrades to defaults-only with a
+   * warning, because a broken operator file must not stall the whole govern
+   * pipeline (same containment posture as the origin-secret resolution).
+   */
+  onWarn?: (message: string) => void;
+}
+
+/**
+ * Build the effective brainignore ruleset for this brain: the committed
+ * defaults, plus the per-brain override file appended AFTER them (last match
+ * wins, so an override `!pattern` line re-admits a default exclusion).
+ *
+ * Resolution order for the override file: explicit `path` option → the
+ * `TEAMKB_BRAINIGNORE` env var → `~/.teamkb/brainignore`. A missing file is
+ * normal (defaults-only); an unreadable file warns and degrades to defaults.
+ */
+export function loadBrainignoreRuleset(options: LoadBrainignoreOptions = {}): BrainignoreRuleset {
+  const overridePath =
+    options.path ?? process.env[BRAINIGNORE_PATH_ENV] ?? defaultBrainignorePath();
+
+  const defaults = DEFAULT_BRAINIGNORE_PATTERNS.map((p) => compilePattern(p, 'default')).filter(
+    (p): p is NonNullable<typeof p> => p !== null,
+  );
+
+  let text: string;
+  try {
+    text = readFileSync(overridePath, 'utf8');
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      options.onWarn?.(
+        `brainignore override at ${overridePath} could not be read (${
+          e instanceof Error ? e.message : String(e)
+        }) — continuing with the committed defaults only`,
+      );
+    }
+    return { patterns: defaults, overridePath: null };
+  }
+
+  const overrides = parseBrainignore(text, 'override');
+  return { patterns: [...defaults, ...overrides], overridePath };
+}

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -21,6 +21,32 @@ export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
 export { checkOriginAttestation, ORIGIN_ATTESTATION_RULE_TYPE } from './origin/origin-gate.js';
 export type { OriginGateResult, OriginRejectCode } from './origin/origin-gate.js';
+export {
+  checkImportExclusion,
+  IMPORT_EXCLUSION_RULE_TYPE,
+} from './import-exclusion/import-exclusion-gate.js';
+export type { ImportExclusionResult } from './import-exclusion/import-exclusion-gate.js';
+export {
+  DEFAULT_BRAINIGNORE_PATTERNS,
+  DEFAULT_BRAINIGNORE_RULESET,
+  compilePattern,
+  parseBrainignore,
+  matchPath,
+  analyzeContent,
+  evaluateBrainignore,
+  shannonEntropy,
+} from './import-exclusion/brainignore.js';
+export type {
+  BrainignorePattern,
+  BrainignoreRuleset,
+  BrainignoreMatch,
+} from './import-exclusion/brainignore.js';
+export {
+  loadBrainignoreRuleset,
+  defaultBrainignorePath,
+  BRAINIGNORE_PATH_ENV,
+} from './import-exclusion/load-brainignore.js';
+export type { LoadBrainignoreOptions } from './import-exclusion/load-brainignore.js';
 export { mergeGovern, MergeIdInvariantError } from './merge/merge-gate.js';
 export type {
   MergeGovernResult,

--- a/apps/curator/src/types.ts
+++ b/apps/curator/src/types.ts
@@ -1,4 +1,5 @@
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import type { BrainignoreRuleset } from './import-exclusion/brainignore.js';
 
 /** Result of curating a single candidate */
 export interface CurationResult {
@@ -59,4 +60,12 @@ export interface CuratorConfig {
    * a brain base dir should resolve it via `loadOrCreateOriginSecret()`.
    */
   originSecret?: string;
+  /**
+   * Brainignore ruleset for the import exclusion gate (bead 5kw.1 — see
+   * `import-exclusion/`). When unset, the COMMITTED DEFAULT ruleset applies —
+   * the gate is always on for import-source candidates; wiring is only needed
+   * to honor the per-brain override file (`loadBrainignoreRuleset()`), never
+   * to enable the protection.
+   */
+  importExclusions?: BrainignoreRuleset;
 }

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { ingestFromSpool, Curator } from '@qmd-team-intent-kb/curator';
+import { ingestFromSpool, Curator, loadBrainignoreRuleset } from '@qmd-team-intent-kb/curator';
 import {
   loadOrCreateOriginSecret,
   ORIGIN_SECRET_UNAVAILABLE_WARNING,
@@ -175,6 +175,11 @@ function curateStep(
         // origin-claiming candidates verify; absent/unreadable → they reject
         // fail-closed as unverifiable while unattested candidates flow as before.
         originSecret: resolveOriginSecretSafe(logger),
+        // Import exclusion (5kw.1): merge the per-brain brainignore override
+        // file (~/.teamkb/brainignore or $TEAMKB_BRAINIGNORE) on top of the
+        // committed defaults. An unreadable override warns and degrades to
+        // defaults — the gate itself is always on for import sources.
+        importExclusions: loadBrainignoreRuleset({ onWarn: (m) => logger.warn(m) }),
       },
     );
 

--- a/packages/policy-engine/src/__tests__/pipeline.test.ts
+++ b/packages/policy-engine/src/__tests__/pipeline.test.ts
@@ -352,3 +352,49 @@ describe('PolicyPipeline contradiction_check pre-phase (E1)', () => {
     expect(result.outcome).toBe('approved');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Source-keyed relevance hard reject at the pipeline level (5kw.3)
+// ---------------------------------------------------------------------------
+
+describe('PolicyPipeline — relevance_score source-keyed reject (5kw.3)', () => {
+  /** Junk-shaped: title + category (+0.10 source bonus for import) → far
+   *  below the 0.8 threshold used here. */
+  const junk = {
+    title: 'minimal',
+    content: 'Short.',
+    category: 'reference',
+    trustLevel: 'low',
+    metadata: { filePaths: [], tags: [] },
+  } as const;
+
+  const relevanceReject = () =>
+    makePolicy([
+      makeRule('relevance_score', { action: 'reject', parameters: { minimumScore: 0.8 } }),
+    ]);
+
+  it('REJECTS an import-source junk candidate', () => {
+    const pipeline = new PolicyPipeline(relevanceReject());
+    const result = pipeline.evaluate(makeCandidate({ ...junk, source: 'import' }));
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('rule-relevance_score');
+  });
+
+  it('only FLAGS an identical junk candidate captured over team MCP', () => {
+    const pipeline = new PolicyPipeline(relevanceReject());
+    const result = pipeline.evaluate(makeCandidate({ ...junk, source: 'mcp' }));
+    expect(result.outcome).toBe('flagged');
+    expect(result.rejectedBy).toBeUndefined();
+    expect(result.flaggedBy).toContain('rule-relevance_score');
+  });
+
+  it("keeps flag-only behavior for imports on a pre-5kw policy whose action is 'flag'", () => {
+    const policy = makePolicy([
+      makeRule('relevance_score', { action: 'flag', parameters: { minimumScore: 0.8 } }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const result = pipeline.evaluate(makeCandidate({ ...junk, source: 'import' }));
+    expect(result.outcome).toBe('flagged');
+    expect(result.rejectedBy).toBeUndefined();
+  });
+});

--- a/packages/policy-engine/src/__tests__/recommended-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/recommended-policy.test.ts
@@ -33,14 +33,20 @@ describe('RECOMMENDED_POLICY_RULES', () => {
     for (const r of RECOMMENDED_POLICY_RULES) expect(registeredSet.has(r.type)).toBe(true);
   });
 
-  it('keeps the three hard boundaries as reject and the rest as flag', () => {
+  it('keeps the hard boundaries as reject and the rest as flag', () => {
     const byType = new Map(RECOMMENDED_POLICY_RULES.map((r) => [r.type, r.action]));
     expect(byType.get('secret_detection')).toBe('reject');
     expect(byType.get('content_length')).toBe('reject');
     expect(byType.get('tenant_match')).toBe('reject');
+    // 5kw.3: relevance_score carries action 'reject' but its evaluator is
+    // SOURCE-KEYED — only the sources in rejectSources can return a rejectable
+    // 'fail'; every other source flags at most. The reject surface must stay
+    // scoped to import-class sources.
+    expect(byType.get('relevance_score')).toBe('reject');
+    const relevance = RECOMMENDED_POLICY_RULES.find((r) => r.type === 'relevance_score');
+    expect(relevance?.parameters['rejectSources']).toEqual(['import', 'bulk_import']);
     for (const t of [
       'source_trust',
-      'relevance_score',
       'sensitivity_gate',
       'dedup_check',
       'content_sanitization',

--- a/packages/policy-engine/src/__tests__/relevance-score-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/relevance-score-rule.test.ts
@@ -194,3 +194,72 @@ describe('evaluateRelevanceScore', () => {
     expect(result.reason).toContain('below minimum');
   });
 });
+
+describe('evaluateRelevanceScore — source-keyed hard reject (5kw.3)', () => {
+  /** Junk-shaped overrides: title + category only → score 0.25 (+0.10 when
+   *  source is manual/import). Below the 0.8 threshold used here either way. */
+  const junk = {
+    title: 'minimal',
+    content: 'Short.', // <=50 chars
+    category: 'reference',
+    trustLevel: 'low',
+    metadata: { filePaths: [], tags: [] },
+  } as const;
+
+  it("returns 'fail' (rejectable) for a below-threshold import-source candidate by default", () => {
+    const candidate = makeCandidate({ ...junk, source: 'import' });
+    const rule = makeRule({ minimumScore: 0.8 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain("import-class source 'import'");
+  });
+
+  it("returns 'fail' for a below-threshold bulk_import candidate by default", () => {
+    const candidate = makeCandidate({ ...junk, source: 'bulk_import' });
+    const rule = makeRule({ minimumScore: 0.8 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+  });
+
+  it('still only flags an identical below-threshold candidate from an interactive source', () => {
+    for (const source of ['mcp', 'claude_session', 'manual'] as const) {
+      const candidate = makeCandidate({ ...junk, source });
+      const rule = makeRule({ minimumScore: 0.8 });
+      const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+      expect(result.outcome).toBe('flag');
+    }
+  });
+
+  it('an empty rejectSources parameter restores flag-only behavior for imports', () => {
+    const candidate = makeCandidate({ ...junk, source: 'import' });
+    const rule = makeRule({ minimumScore: 0.8, rejectSources: [] });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('flag');
+  });
+
+  it('ignores rejectSources entries that are not valid MemorySource values', () => {
+    const candidate = makeCandidate({ ...junk, source: 'import' });
+    // A typo can only make the rule SOFTER: 'improt' is dropped, so nothing fails…
+    const softened = evaluateRelevanceScore(
+      candidate,
+      makeRule({ minimumScore: 0.8, rejectSources: ['improt'] }),
+      makeContext(candidate),
+    );
+    expect(softened.outcome).toBe('flag');
+    // …while valid entries alongside garbage still apply.
+    const mixed = evaluateRelevanceScore(
+      candidate,
+      makeRule({ minimumScore: 0.8, rejectSources: ['improt', 'import'] }),
+      makeContext(candidate),
+    );
+    expect(mixed.outcome).toBe('fail');
+  });
+
+  it('an above-threshold import candidate passes untouched', () => {
+    const candidate = makeCandidate({ ...junk, source: 'import' });
+    // import source: title 0.20 + category 0.05 + source 0.10 = 0.35 ≥ 0.3
+    const rule = makeRule({ minimumScore: 0.3 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+  });
+});

--- a/packages/policy-engine/src/recommended-policy.ts
+++ b/packages/policy-engine/src/recommended-policy.ts
@@ -19,10 +19,12 @@
  *     added to the registry with no entry here fails {@link findUncoveredRuleTypes}
  *     (asserted in CI), so the author must make a deliberate enable/waive choice.
  *   - Actions are conservative: the three hard boundaries — `secret_detection`,
- *     `content_length`, `tenant_match` — `reject`; everything else `flag` (records
- *     signal and continues, never blocks a legitimate promotion). This is the
- *     "flag at minimum" the audit recommended; an operator can tighten a flag to a
- *     reject deliberately.
+ *     `content_length`, `tenant_match` — `reject`; `relevance_score` is `reject`
+ *     but SOURCE-KEYED (5kw.3 — its evaluator only returns a rejectable 'fail'
+ *     for import-class sources, so interactive captures still flag at most);
+ *     everything else `flag` (records signal and continues, never blocks a
+ *     legitimate promotion). This is the "flag at minimum" the audit
+ *     recommended; an operator can tighten a flag to a reject deliberately.
  *
  * Applying this to the LIVE brain is a separate, reversible operational step
  * (it changes what gets flagged/rejected on the running store) — this module only
@@ -80,13 +82,21 @@ export const RECOMMENDED_POLICY_RULES: readonly PolicyRule[] = [
     description: 'Flag candidates below the minimum source trust level.',
   },
   {
+    // 5kw.3: action 'reject' + source-keyed evaluator severity. The evaluator
+    // only returns 'fail' (rejectable) for the sources listed in
+    // `rejectSources`; every other source flags at most — so this reject
+    // action hard-rejects below-threshold IMPORT-class candidates while an
+    // identical interactive capture (claude_session / manual / mcp) is only
+    // flagged for review. Both keys (source-keyed 'fail' + action 'reject')
+    // must agree before anything is turned away.
     id: 'rec-relevance-score',
     type: 'relevance_score',
-    action: 'flag',
+    action: 'reject',
     enabled: true,
     priority: 4,
-    parameters: {},
-    description: 'Flag low-relevance candidates for review.',
+    parameters: { rejectSources: ['import', 'bulk_import'] },
+    description:
+      'Reject below-threshold import-source candidates at intake; flag low-relevance interactive captures for review.',
   },
   {
     id: 'rec-sensitivity-gate',

--- a/packages/policy-engine/src/rules/relevance-score-rule.ts
+++ b/packages/policy-engine/src/rules/relevance-score-rule.ts
@@ -1,8 +1,20 @@
-import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import { MemorySource, type MemoryCandidate, type PolicyRule } from '@qmd-team-intent-kb/schema';
 import type { EvaluationContext, RuleResult } from '../types.js';
 import { deterministicScore } from '../deterministic-score.js';
 
 const DEFAULT_MINIMUM_SCORE = 0.3;
+
+/**
+ * Sources whose below-threshold candidates FAIL (hard-rejectable) by default
+ * (bead qmd-team-intent-kb-5kw.3): bulk-imported content has no per-item human
+ * intent behind it, so junk that scores below the relevance floor should be
+ * turned away at spool intake instead of merely flagged — the 2026-07-16
+ * digestion promoted ~15k unfiltered candidates because every rule outcome was
+ * advisory. Interactive sources (`claude_session`, `manual`, `mcp`) keep the
+ * original flag-only behavior by default: a human/session capture that scores
+ * low is a review case, not junk.
+ */
+const DEFAULT_REJECT_SOURCES: readonly string[] = ['import', 'bulk_import'];
 
 /**
  * Deterministic relevance scoring rule. No LLM involvement — purely structural heuristics.
@@ -19,7 +31,22 @@ const DEFAULT_MINIMUM_SCORE = 0.3;
  *   +0.10  unique word count in content > 15
  *   +0.10  source is 'manual' or 'import'
  *
- * Candidates scoring below minimumScore are flagged (not rejected — low relevance is not fatal).
+ * ## Below-threshold outcome is SOURCE-KEYED (5kw.3)
+ *
+ * A candidate scoring below `minimumScore`:
+ *   - source ∈ `rejectSources` (param; default `['import', 'bulk_import']`) →
+ *     outcome **'fail'** — the pipeline REJECTS when the rule's configured
+ *     action is 'reject', flags otherwise. The hard reject is therefore a
+ *     two-key turn: the evaluator marks the candidate rejectable (source-keyed)
+ *     AND the policy names 'reject' as the action. Pre-5kw policies carrying
+ *     action 'flag' keep their exact previous behavior.
+ *   - any other source → outcome **'flag'** — never rejects regardless of the
+ *     configured action (low relevance on an interactive capture is a review
+ *     signal, not fatal).
+ *
+ * `rejectSources` entries are validated against the {@link MemorySource} enum;
+ * unknown values are ignored deterministically (a typo can only make the rule
+ * SOFTER, never widen the reject surface).
  */
 export function evaluateRelevanceScore(
   candidate: MemoryCandidate,
@@ -30,6 +57,13 @@ export function evaluateRelevanceScore(
     typeof rule.parameters['minimumScore'] === 'number'
       ? rule.parameters['minimumScore']
       : DEFAULT_MINIMUM_SCORE;
+
+  const rawRejectSources = rule.parameters['rejectSources'];
+  const rejectSources: readonly string[] = Array.isArray(rawRejectSources)
+    ? rawRejectSources.filter(
+        (s): s is string => typeof s === 'string' && MemorySource.safeParse(s).success,
+      )
+    : DEFAULT_REJECT_SOURCES;
 
   let score = 0;
 
@@ -95,6 +129,20 @@ export function evaluateRelevanceScore(
       ruleType: rule.type,
       outcome: 'pass',
       reason: `Relevance score ${score.toFixed(2)} meets minimum ${minimumScore.toFixed(2)}`,
+      score: deterministicScore(score),
+    };
+  }
+
+  // Source-keyed severity (5kw.3): 'fail' makes the candidate rejectable when
+  // the policy's action is 'reject'; 'flag' can never reject.
+  if (rejectSources.includes(candidate.source)) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'fail',
+      reason:
+        `Relevance score ${score.toFixed(2)} is below minimum ${minimumScore.toFixed(2)} ` +
+        `for import-class source '${candidate.source}' (hard-rejectable per rule parameters)`,
       score: deterministicScore(score),
     };
   }

--- a/scripts/verify-policy-hash.sh
+++ b/scripts/verify-policy-hash.sh
@@ -40,6 +40,11 @@ FILES=(
   "packages/policy-engine/src/rules/contradiction-check-rule.ts"
   "packages/policy-engine/src/rules/index.ts"
   "packages/policy-engine/src/policy-engine.ts"
+  # 5kw.1: the import exclusion gate is a structural deterministic reject
+  # surface (brainignore) — same trust-anchor class as the policy rules, so
+  # its ruleset + gate are pinned too.
+  "apps/curator/src/import-exclusion/brainignore.ts"
+  "apps/curator/src/import-exclusion/import-exclusion-gate.ts"
 )
 
 collect_present_files() {


### PR DESCRIPTION
## What

Closes the two gaps the **2026-07-16 whole-machine digestion** (17,165 candidates) exposed — import had no `.gitignore`-equivalent (vendored/boilerplate docs promoted into the curated brain) and no receipted batch lifecycle-transition path (cleanup drove `brain_transition` one MCP call at a time). Both fixes land in the **deterministic kernel**. Implements epic `qmd-team-intent-kb-5kw` and its three children.

- **5kw.1 — deterministic import exclusion policy ("brainignore").** A committed default ruleset (gitignore-like path patterns: `node_modules`/`site-packages`/vendored trees, lockfiles, minified names, `CODE_OF_CONDUCT`/`SECURITY`/`LICENSE` boilerplate) plus content heuristics (minified-line, Shannon-entropy, license-marker, untitled-title), merged with a per-brain override file. New structural gate `checkImportExclusion` runs on every govern path for `import`/`bulk_import` sources **only**; rejections are policy-pipeline-shaped so they flow through the existing receipted `reject()` path — modelled on the `origin_token_invalid` gate from #302.
- **5kw.2 — `curator-cli batch-transition`.** One lifecycle transition to every memory matching AND-combined criteria (`--source` / `--category` / `--imported-before` / `--ids-file`), each in its **own transaction writing its own hash-chained receipt** (never one giant receipt). `--dry-run` opens the DB READ-ONLY; `--db` mandatory; refuses criterion-less runs and `--to superseded`; reports skipped-illegal transitions and not-found ids.
- **5kw.3 — source-keyed hard reject on `relevance_score`.** Below-threshold candidates from `rejectSources` (default `[import, bulk_import]`) return `'fail'` (rejectable when the policy action is `reject`); every other source flags at most. Recommended policy now sets `action: reject` + `rejectSources`. Combined with 5kw.1, this is designed so a digest-shaped re-run over the 2026-07-16 junk classes would promote **0 junk**, receipted. Evidence is the unit tests below (synthetic candidates shaped like each junk class), not a recorded live re-run over the production brain — no such live run was performed for this PR.

## Why + decision rationale

- **Structural gate over a policy rule** (brainignore): a configurable policy rule would sit **dormant on every pre-5kw policy** — the exact silent-dormancy the digestion exposed. Configurability lives in the **ruleset** (committed defaults + override file), not policy plumbing.
- **Source-keyed `'fail'` over a blanket relevance reject**: a human/session capture scoring low is a **review case, not junk** — only bulk import lacks per-item human intent. Two keys must agree (source-keyed `fail` + policy `action: reject`) before anything is turned away, so pre-5kw `flag` policies are unchanged.
- **One-receipt-per-transition over a batch receipt**: a kill mid-sweep leaves every completed transition fully receipted and none half-written (mirrors the single-memory `brain_transition` path).

## Layers touched + invariants

- `packages/policy-engine`: `relevance-score-rule` (source-keyed severity) + `recommended-policy` (action=reject, rejectSources). `PolicyRuleType` enum unchanged — the reject is source-keyed inside the existing rule, so **no store migration**.
- `apps/curator`: new `import-exclusion/` module (`brainignore.ts`, `import-exclusion-gate.ts`, `load-brainignore.ts`), Curator + CLI wiring, `CuratorConfig.importExclusions`.
- `apps/api`: `PromotionService` mirrors the gate so the single-candidate admin path and the batch path **agree** (the H1 invariant).
- `apps/edge-daemon`: nightly sweep loads the per-brain override (`loadBrainignoreRuleset`).
- **C10**: `.policy-hash` re-pinned — the brainignore ruleset + gate are added to the governance trust anchor (`scripts/verify-policy-hash.sh`), since they are a structural deterministic reject surface.

## How it works

Import-source candidate → `checkImportExclusion` (path patterns then content heuristics) → on match, a `PipelineResult{outcome:'rejected', rejectedBy:<code>}` flows through `reject()`, writing one audit event carrying the matched pattern/heuristic evidence. Non-import sources short-circuit to `not_applicable`. Override-file `!pattern` lines (appended after the committed defaults, last-match-wins) re-admit anything a default excludes.

## Verification & evidence

- `pnpm typecheck` · `pnpm lint` · `pnpm format:check`: clean.
- `pnpm crap`: 0 functions over the 30 threshold (max 27; the batch-arg parser was split into a tokenizer + validators to stay under the gate).
- `pnpm harness-pin --verify` and `verify-policy-hash --verify`: OK.
- `pnpm test`: **2361 passed / 2 skipped**. New/updated tests: `brainignore` (22, incl. the 2026-07-16 junk-class matrix + heuristics + loader override/negation/degrade), `import-exclusion-gate` (9, incl. a Curator integration asserting the receipted audit event + that an identical interactive-source candidate promotes), `cli-batch-transition` (13, file-backed DB proving durable writes + one-receipt-per-memory + dry-run-writes-nothing + refusal patterns), `relevance-score-rule` source-keyed (6 new), `pipeline` reject (3 new), `promote` gate (2 new, incl. the audit-row receipt assertion from the review fix). Review-fix commit adds: the API import-exclusion rejection now writes an audit receipt (asserted in `promote.test.ts`), batch-transition splits unmatched `--ids-file` ids into `not_found` vs `criteria_excluded`, and the API promote path loads the per-brain brainignore override.

## Risk assessment

- New rejects apply to `import`/`bulk_import` **only**; interactive sources (`claude_session`/`manual`/`mcp`) are untouched. Escape hatch for a false positive: a `!pattern` line in `~/.teamkb/brainignore`, or hand-promotion through the admin path after review. Heuristics are documented honestly as deterministic ≠ perfect (each carries its false-positive/negative modes).
- Tamper-evidence/receipts posture preserved: every rejection and transition writes to the append-only hash-chained audit log.

## Operational impact

- No schema migration, no new dependencies, no secrets, no deploy-order constraint. `batch-transition` is opt-in tooling. Applying the recommended policy to the **live** brain remains a separate, reversible ops step (unchanged by this PR).

## Follow-up & deferred

None for the epic scope.

## Governance

Epic `qmd-team-intent-kb-5kw` (children .1 / .2 / .3). Do not merge — review-gated per house workflow.

- Jeremy Longshore
intentsolutions.io

**Refs:** bead qmd-team-intent-kb-5kw (bulk-import hardening epic)

