### PR TITLE
feat(ontology): bulk-import scoping, receipted policy-upgrade path, hardened contradiction lookup (5bm)

### DIFF
--- a/.policy-hash
+++ b/.policy-hash
@@ -6,5 +6,5 @@ f4f35a03da263da51085841eb71fb33df83f1a1c34e1bccb5963cf965de1ce05   packages/poli
 c7d87405ca41bc1848bc31a9177d7b53e9e7c082567d28d700dc4268072eeeb7   packages/policy-engine/src/rules/tenant-match-rule.ts
 b28f01e57900b09e33eafad6ac3bfe9e360b81216efafc63e70cbb7625876eea   packages/policy-engine/src/rules/sensitivity-gate-rule.ts
 b596ca83e40ebefd2dcbf8df62987b5d14039643ff1ff4e4f1c96ea370200a46   packages/policy-engine/src/rules/content-sanitization-rule.ts
-fbdd22b83ce4c0793bb41613e89e8d67a427fc14d0ec8c18fe039eec62705fa9   packages/policy-engine/src/rules/contradiction-check-rule.ts
+38a4993fe4bf180e930be4751cc3ba9d2fc625d0fcf0ff067470003346d76631   packages/policy-engine/src/rules/contradiction-check-rule.ts
 9dcaced9c7eb0d61d1bd4c258796861f420fc50ac5b519e53e237cb7090a1359   packages/policy-engine/src/rules/index.ts

--- a/.policy-hash
+++ b/.policy-hash
@@ -6,5 +6,5 @@ f4f35a03da263da51085841eb71fb33df83f1a1c34e1bccb5963cf965de1ce05   packages/poli
 c7d87405ca41bc1848bc31a9177d7b53e9e7c082567d28d700dc4268072eeeb7   packages/policy-engine/src/rules/tenant-match-rule.ts
 b28f01e57900b09e33eafad6ac3bfe9e360b81216efafc63e70cbb7625876eea   packages/policy-engine/src/rules/sensitivity-gate-rule.ts
 b596ca83e40ebefd2dcbf8df62987b5d14039643ff1ff4e4f1c96ea370200a46   packages/policy-engine/src/rules/content-sanitization-rule.ts
-38a4993fe4bf180e930be4751cc3ba9d2fc625d0fcf0ff067470003346d76631   packages/policy-engine/src/rules/contradiction-check-rule.ts
+51a3a1f526e8c550b9ec4c59129a62fc55ceeb83fb7e94ce54ed7176fe54bebc   packages/policy-engine/src/rules/contradiction-check-rule.ts
 9dcaced9c7eb0d61d1bd4c258796861f420fc50ac5b519e53e237cb7090a1359   packages/policy-engine/src/rules/index.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,35 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Ontology axes carry signal — enforcement, persistence, and a receipted policy-migration path
-  (epic `qmd-team-intent-kb-5bm`).** Follow-through on the 2026-07-17 ontology audit, which found
-  three of four axes carrying zero bits in production.
-  - **Receipted policy upgrade (`5bm.2`).** New `curator-cli upgrade-policy --tenant <id>` brings a
-    store's live governance policy up to the recommended anti-dormancy shape
-    (`RECOMMENDED_POLICY_RULES` — every registered rule enabled) and writes a `policy_upgraded`
-    audit receipt carrying the previous rules verbatim, so the change is reversible from the chain
-    alone. Three explicit outcomes (`upgraded` / `created` / `already-complete`); `--dry-run` previews
-    without writing. This is the operator-safe migration path — it never edits the live brain
-    directly. (The recommended-policy + dormancy doctor tooling shipped earlier under `5bm.10`.)
-  - **Bulk-digestion scoping (`5bm.8`).** The `bulk_import` memory source is now stamped low-trust at
-    the schema boundary (a `bulk_import` candidate cannot claim curated-grade trust), and bulk memories
-    export to a new non-default `kb-bulk` collection (`bulk/` subdir) instead of flooding the
-    default-searched category collections. New `bulk` search scope is the deliberate way into that
-    corpus; the default `curated` scope excludes it on both the qmd and SQLite-fallback paths.
-  - **Category-scoped contradiction lookup (E1 review follow-up).** `MemoryRepository` gains
-    `findByTenantAndLifecycleAndCategory`, so the contradiction-check rule filters same-category
-    actives at the store query instead of loading and deserializing the whole active set per
-    candidate.
-  - **Unicode contradiction tokenizer (E1 review follow-up).** The token-overlap heuristic now
-    tokenizes on `\p{L}\p{N}` (Unicode letters/digits) instead of ASCII-only `[a-z0-9]`, so
-    non-Latin text (Cyrillic, CJK, accented) no longer collapses to empty token sets.
-  - Verified-only (already delivered on `main` by prior Wave-1/2 work, confirmed against current code
-    with tests cited in the PR): sensitivity persistence + read-time enforcement (`5bm.3`/`5bm.11`),
-    repository-layer lifecycle-transition guard + lifecycle `CHECK` constraint (`5bm.4`), fail-closed
-    export directory mapper (`5bm.5`), candidate `schemaVersion` v2-rejection (`5bm.6`), governed
-    recategorization tool (`5bm.7`).
+- **Receipted governance-policy upgrade (`curator-cli upgrade-policy`, epic
+  `qmd-team-intent-kb-5bm.2`).** New `curator-cli upgrade-policy --tenant <id> [--db] [--dry-run]
+  [--json]` brings a store's live governance policy up to the recommended anti-dormancy shape
+  (`RECOMMENDED_POLICY_RULES` — every registered rule enabled) and writes a `policy_upgraded` audit
+  receipt carrying the previous rules verbatim, so the change is reversible from the chain alone.
+  Three explicit outcomes (`upgraded` / `created` / `already-complete`); `--dry-run` previews without
+  writing. This is the operator-safe migration path — it never edits the live brain directly. (The
+  recommended-policy + dormancy doctor tooling itself shipped earlier under `5bm.10`; this is the
+  previously-missing command that applies it to a store.)
+- **Bulk-digestion scoping (`5bm.8`).** A new non-default `kb-bulk` collection (`bulk/` export
+  subdir): memories whose source is `bulk_import` (whole-machine digestions) now route there via
+  `getActiveDirectory` instead of flooding the default-searched category collections (the 2026-07-16
+  flood put ~9.7k bulk `reference` files in `kb-guides`). A new `bulk` search scope is the deliberate
+  way into that corpus; the default `curated` scope excludes it on both the qmd (collection-level)
+  and SQLite-fallback (source-level) paths.
 
 ### Changed
+
+- **`bulk_import` candidates are stamped low-trust at the schema boundary (`5bm.8`).** A
+  `bulk_import` candidate must now carry `trustLevel` `low` or `untrusted` (the default `medium` is
+  refused by `MemoryCandidate`), so a whole-machine digestion can never claim curated-grade trust and
+  the `source_trust` rule can gate it. **Migration note:** any pre-PR `bulk_import` candidate stamped
+  `medium` under the old emitter convention now **fails closed** at re-validation — this is intended
+  (it surfaces mis-stamped digestions rather than admitting them silently), and such a row is
+  corrected via the governed recategorization/curation tooling (or a one-shot re-stamp), not dropped.
+  Depends on the deferred coordination to have ICO's emitter stamp `bulk_import` low at capture time
+  (flagged in PR #310); until then, bulk digestions must carry an explicit low/untrusted stamp.
+- **Contradiction-check tokenizer is Unicode-aware (E1 review follow-up).** The token-overlap
+  heuristic now tokenizes whole words for space-delimited scripts and per-character for space-less
+  CJK (`\p{sc=Han|Hiragana|Katakana|Hangul}` unigrams), replacing the ASCII-only `[a-z0-9]` that
+  collapsed all non-Latin text to empty token sets.
+- **Contradiction-check lookup is category-scoped at the store (E1 review follow-up).**
+  `MemoryRepository.findByTenantAndLifecycleAndCategory` lets the rule filter same-category actives in
+  SQL instead of loading and deserializing the whole active set per candidate.
 
 - **Repository renamed** from `jeremylongshore/qmd-team-intent-kb` to
   `jeremylongshore/bobs-big-brain-registrar` on 2026-07-19 (public product name: **Bob's Big Brain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Ontology axes carry signal — enforcement, persistence, and a receipted policy-migration path
+  (epic `qmd-team-intent-kb-5bm`).** Follow-through on the 2026-07-17 ontology audit, which found
+  three of four axes carrying zero bits in production.
+  - **Receipted policy upgrade (`5bm.2`).** New `curator-cli upgrade-policy --tenant <id>` brings a
+    store's live governance policy up to the recommended anti-dormancy shape
+    (`RECOMMENDED_POLICY_RULES` — every registered rule enabled) and writes a `policy_upgraded`
+    audit receipt carrying the previous rules verbatim, so the change is reversible from the chain
+    alone. Three explicit outcomes (`upgraded` / `created` / `already-complete`); `--dry-run` previews
+    without writing. This is the operator-safe migration path — it never edits the live brain
+    directly. (The recommended-policy + dormancy doctor tooling shipped earlier under `5bm.10`.)
+  - **Bulk-digestion scoping (`5bm.8`).** The `bulk_import` memory source is now stamped low-trust at
+    the schema boundary (a `bulk_import` candidate cannot claim curated-grade trust), and bulk memories
+    export to a new non-default `kb-bulk` collection (`bulk/` subdir) instead of flooding the
+    default-searched category collections. New `bulk` search scope is the deliberate way into that
+    corpus; the default `curated` scope excludes it on both the qmd and SQLite-fallback paths.
+  - **Category-scoped contradiction lookup (E1 review follow-up).** `MemoryRepository` gains
+    `findByTenantAndLifecycleAndCategory`, so the contradiction-check rule filters same-category
+    actives at the store query instead of loading and deserializing the whole active set per
+    candidate.
+  - **Unicode contradiction tokenizer (E1 review follow-up).** The token-overlap heuristic now
+    tokenizes on `\p{L}\p{N}` (Unicode letters/digits) instead of ASCII-only `[a-z0-9]`, so
+    non-Latin text (Cyrillic, CJK, accented) no longer collapses to empty token sets.
+  - Verified-only (already delivered on `main` by prior Wave-1/2 work, confirmed against current code
+    with tests cited in the PR): sensitivity persistence + read-time enforcement (`5bm.3`/`5bm.11`),
+    repository-layer lifecycle-transition guard + lifecycle `CHECK` constraint (`5bm.4`), fail-closed
+    export directory mapper (`5bm.5`), candidate `schemaVersion` v2-rejection (`5bm.6`), governed
+    recategorization tool (`5bm.7`).
+
 ### Changed
 
 - **Repository renamed** from `jeremylongshore/qmd-team-intent-kb` to

--- a/apps/api/src/__tests__/search.test.ts
+++ b/apps/api/src/__tests__/search.test.ts
@@ -207,4 +207,55 @@ describe('POST /api/search', () => {
         expect(ids).not.toContain(restricted.id);
       });
   });
+
+  it('excludes bulk_import memories from the default curated scope (5bm.8)', async () => {
+    const curatedRow = makeMemory({ title: 'Indexing strategy curated', source: 'import' });
+    const bulkRow = makeMemory({
+      title: 'Indexing strategy bulk',
+      source: 'bulk_import',
+      trustLevel: 'low',
+      contentHash: 'e'.repeat(64),
+    });
+    memoryRepo.insert(curatedRow);
+    memoryRepo.insert(bulkRow);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { query: 'indexing', scope: 'curated' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.totalCount).toBe(1);
+    expect(body.hits[0].memoryId).toBe(curatedRow.id);
+  });
+
+  it("scope 'bulk' returns only bulk_import memories; 'all' returns both (5bm.8)", async () => {
+    const curatedRow = makeMemory({ title: 'Indexing strategy curated', source: 'import' });
+    const bulkRow = makeMemory({
+      title: 'Indexing strategy bulk',
+      source: 'bulk_import',
+      trustLevel: 'low',
+      contentHash: 'e'.repeat(64),
+    });
+    memoryRepo.insert(curatedRow);
+    memoryRepo.insert(bulkRow);
+
+    const bulkRes = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { query: 'indexing', scope: 'bulk' },
+    });
+    expect(bulkRes.statusCode).toBe(200);
+    expect(bulkRes.json().totalCount).toBe(1);
+    expect(bulkRes.json().hits[0].memoryId).toBe(bulkRow.id);
+
+    const allRes = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: { query: 'indexing', scope: 'all' },
+    });
+    expect(allRes.statusCode).toBe(200);
+    expect(allRes.json().totalCount).toBe(2);
+  });
 });

--- a/apps/api/src/services/search-service.ts
+++ b/apps/api/src/services/search-service.ts
@@ -158,13 +158,19 @@ export class SearchService {
     // Read-time sensitivity enforcement (5bm.11): the SQLite path returns rows
     // directly, so drop confidential/restricted here — the leak the audit found.
     // Bulk-digestion scoping (5bm.8): the qmd path excludes the kb-bulk
-    // collection from the default scope at the collection level; this path has
-    // no collections, so mirror the contract on the row's source — bulk_import
-    // rows only surface when the caller deliberately asks ('bulk' or 'all').
+    // collection from the DEFAULT (curated) scope at the collection level; this
+    // path has no collections, so mirror that contract on the row's source.
+    // Only two scopes constrain bulk membership here: `curated` (the default)
+    // excludes bulk; `bulk` returns ONLY bulk. Every other scope is left to its
+    // own semantics and must NOT bulk-filter — notably `archived`, where a bulk
+    // memory exports to kb-archive (lifecycle wins in getDirectory), so on the
+    // qmd path an archived bulk hit IS returned under `archived`; excluding it
+    // here would diverge. (Moot in practice — searchByText is active-only — but
+    // kept correct so the two paths never disagree.)
     const bulkVisible = (m: { source: string }): boolean => {
-      if (query.scope === 'all') return true;
+      if (query.scope === 'curated') return m.source !== 'bulk_import';
       if (query.scope === 'bulk') return m.source === 'bulk_import';
-      return m.source !== 'bulk_import';
+      return true;
     };
     const memories = allMemories.filter(
       (m) => isSearchVisibleSensitivity(m.sensitivity) && bulkVisible(m),

--- a/apps/api/src/services/search-service.ts
+++ b/apps/api/src/services/search-service.ts
@@ -157,7 +157,18 @@ export class SearchService {
     const allMemories = this.memoryRepo.searchByText(query.query, query.tenantId, query.categories);
     // Read-time sensitivity enforcement (5bm.11): the SQLite path returns rows
     // directly, so drop confidential/restricted here — the leak the audit found.
-    const memories = allMemories.filter((m) => isSearchVisibleSensitivity(m.sensitivity));
+    // Bulk-digestion scoping (5bm.8): the qmd path excludes the kb-bulk
+    // collection from the default scope at the collection level; this path has
+    // no collections, so mirror the contract on the row's source — bulk_import
+    // rows only surface when the caller deliberately asks ('bulk' or 'all').
+    const bulkVisible = (m: { source: string }): boolean => {
+      if (query.scope === 'all') return true;
+      if (query.scope === 'bulk') return m.source === 'bulk_import';
+      return m.source !== 'bulk_import';
+    };
+    const memories = allMemories.filter(
+      (m) => isSearchVisibleSensitivity(m.sensitivity) && bulkVisible(m),
+    );
 
     const nowIso = new Date().toISOString();
     const queryLower = query.query.toLowerCase();

--- a/apps/curator/src/__tests__/cli.test.ts
+++ b/apps/curator/src/__tests__/cli.test.ts
@@ -14,7 +14,17 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { AuditRepository, createTestDatabase } from '@qmd-team-intent-kb/store';
+import {
+  AuditRepository,
+  PolicyRepository,
+  createDatabase,
+  createTestDatabase,
+} from '@qmd-team-intent-kb/store';
+import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import {
+  RECOMMENDED_POLICY_RULES,
+  findUncoveredRuleTypes,
+} from '@qmd-team-intent-kb/policy-engine';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dispatch, type CuratorCliDeps } from '../cli.js';
@@ -506,5 +516,229 @@ describe('dispatch generate-exception-manifest', () => {
     expect(parsed['ok']).toBe(true);
     expect(parsed['entryCount']).toBe(1);
     db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upgrade-policy (5bm.2 — receipted migration to the recommended policy)
+// ---------------------------------------------------------------------------
+
+describe('dispatch upgrade-policy', () => {
+  const TENANT = 'demo-e2e';
+
+  /** The audited 2-rule live shape (secret_detection + content_length only). */
+  function seedTwoRulePolicy(db: ReturnType<typeof createTestDatabase>): GovernancePolicy {
+    const policy = GovernancePolicy.parse({
+      id: '22222222-2222-4222-8222-222222222222',
+      name: 'local-default',
+      tenantId: TENANT,
+      rules: [
+        {
+          id: 'r-secret',
+          type: 'secret_detection',
+          action: 'reject',
+          enabled: true,
+          priority: 0,
+          parameters: {},
+        },
+        {
+          id: 'r-length',
+          type: 'content_length',
+          action: 'reject',
+          enabled: true,
+          priority: 1,
+          parameters: { min: 25 },
+        },
+      ],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-05-29T08:00:00.000Z',
+      updatedAt: '2026-05-29T08:00:00.000Z',
+    });
+    new PolicyRepository(db).insert(policy);
+    return policy;
+  }
+
+  /** File-backed db so state survives dispatch's connection close. */
+  let dbDir: string;
+  let dbPath: string;
+  const fileDeps: CuratorCliDeps = {
+    createDb: ({ dbPath: p, readonly }) =>
+      p !== undefined
+        ? createDatabase({ path: p, readonly: readonly ?? false })
+        : createTestDatabase(),
+  };
+
+  beforeEach(async () => {
+    dbDir = await mkdtemp(join(tmpdir(), 'curator-upgrade-policy-'));
+    dbPath = join(dbDir, 'teamkb.db');
+  });
+
+  afterEach(async () => {
+    await rm(dbDir, { recursive: true, force: true });
+  });
+
+  it('exits 2 without --tenant', async () => {
+    const rc = await dispatch(['upgrade-policy'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/missing required flag: --tenant/);
+  });
+
+  it('exits 2 on an unknown flag', async () => {
+    const rc = await dispatch(['upgrade-policy', '--tenant', TENANT, '--bogus'], testDeps);
+    expect(rc).toBe(2);
+    expect(stderrText()).toMatch(/unknown argument: --bogus/);
+  });
+
+  it('upgrades a dormant 2-rule policy to the recommended set with a policy_upgraded receipt', async () => {
+    {
+      const seedDb = createDatabase({ path: dbPath });
+      seedTwoRulePolicy(seedDb);
+      seedDb.close();
+    }
+
+    const rc = await dispatch(
+      ['upgrade-policy', '--tenant', TENANT, '--db', dbPath, '--json'],
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(true);
+    expect(parsed['outcome']).toBe('upgraded');
+    expect(parsed['written']).toBe(true);
+    // The 7 previously-dormant registered rules are named.
+    expect(parsed['dormantRules']).toEqual([
+      'content_sanitization',
+      'contradiction_check',
+      'dedup_check',
+      'relevance_score',
+      'sensitivity_gate',
+      'source_trust',
+      'tenant_match',
+    ]);
+
+    // Durable state: rules replaced, version bumped, nothing dormant anymore.
+    const verifyDb = createDatabase({ path: dbPath });
+    try {
+      const upgraded = new PolicyRepository(verifyDb).findByTenant(TENANT).find((p) => p.enabled)!;
+      expect(upgraded.rules).toHaveLength(RECOMMENDED_POLICY_RULES.length);
+      expect(upgraded.version).toBe(2);
+      expect(findUncoveredRuleTypes(upgraded)).toEqual([]);
+
+      // The receipt: policy_upgraded, anchored to the policy id, carrying the
+      // previous rules verbatim (the rollback), on an intact hash chain.
+      const events = new AuditRepository(verifyDb).findByMemory(upgraded.id);
+      expect(events).toHaveLength(1);
+      const receipt = events[0]!;
+      expect(receipt.action).toBe('policy_upgraded');
+      expect(receipt.tenantId).toBe(TENANT);
+      const details = receipt.details as {
+        previousRules: Array<{ type: string }>;
+        previouslyDormant: string[];
+        fromVersion: number;
+        toVersion: number;
+      };
+      expect(details.previousRules.map((r) => r.type).sort()).toEqual([
+        'content_length',
+        'secret_detection',
+      ]);
+      expect(details.previouslyDormant).toHaveLength(7);
+      expect(details.fromVersion).toBe(1);
+      expect(details.toVersion).toBe(2);
+    } finally {
+      verifyDb.close();
+    }
+
+    // The chain still verifies after the receipt append.
+    stdoutSpy.mockClear();
+    const verifyRc = await dispatch(['verify-audit-chain', '--db', dbPath, '--json'], fileDeps);
+    expect(verifyRc).toBe(0);
+  });
+
+  it('creates the recommended policy when the tenant has no enabled policy', async () => {
+    const rc = await dispatch(
+      ['upgrade-policy', '--tenant', TENANT, '--db', dbPath, '--json'],
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['outcome']).toBe('created');
+    expect(parsed['written']).toBe(true);
+
+    const verifyDb = createDatabase({ path: dbPath });
+    try {
+      const created = new PolicyRepository(verifyDb).findByTenant(TENANT).find((p) => p.enabled)!;
+      expect(created.rules).toHaveLength(RECOMMENDED_POLICY_RULES.length);
+      expect(findUncoveredRuleTypes(created)).toEqual([]);
+      const events = new AuditRepository(verifyDb).findByMemory(created.id);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.action).toBe('policy_upgraded');
+    } finally {
+      verifyDb.close();
+    }
+  });
+
+  it('is a no-op on a policy that already enables every registered rule', async () => {
+    // First run creates the complete policy; second run must write nothing.
+    await dispatch(['upgrade-policy', '--tenant', TENANT, '--db', dbPath], fileDeps);
+    stdoutSpy.mockClear();
+
+    const rc = await dispatch(
+      ['upgrade-policy', '--tenant', TENANT, '--db', dbPath, '--json'],
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['outcome']).toBe('already-complete');
+    expect(parsed['written']).toBe(false);
+
+    // Still exactly ONE receipt (from the create) — the no-op left no row.
+    const verifyDb = createDatabase({ path: dbPath });
+    try {
+      const rows = verifyDb
+        .prepare(`SELECT COUNT(*) AS cnt FROM audit_events WHERE action = 'policy_upgraded'`)
+        .get() as { cnt: number };
+      expect(rows.cnt).toBe(1);
+    } finally {
+      verifyDb.close();
+    }
+  });
+
+  it('--dry-run reports the dormant rules without writing anything', async () => {
+    {
+      const seedDb = createDatabase({ path: dbPath });
+      seedTwoRulePolicy(seedDb);
+      seedDb.close();
+    }
+
+    const rc = await dispatch(
+      ['upgrade-policy', '--tenant', TENANT, '--db', dbPath, '--dry-run', '--json'],
+      fileDeps,
+    );
+    expect(rc).toBe(0);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['dry_run']).toBe(true);
+    expect(parsed['outcome']).toBe('upgraded');
+    expect(parsed['written']).toBe(false);
+    expect((parsed['dormantRules'] as string[]).length).toBe(7);
+
+    const verifyDb = createDatabase({ path: dbPath });
+    try {
+      const policy = new PolicyRepository(verifyDb).findByTenant(TENANT).find((p) => p.enabled)!;
+      expect(policy.version).toBe(1);
+      expect(policy.rules).toHaveLength(2);
+      const rows = verifyDb.prepare('SELECT COUNT(*) AS cnt FROM audit_events').get() as {
+        cnt: number;
+      };
+      expect(rows.cnt).toBe(0);
+    } finally {
+      verifyDb.close();
+    }
+  });
+
+  it('lists the upgrade-policy subcommand in the help text', async () => {
+    const rc = await dispatch(['help'], testDeps);
+    expect(rc).toBe(0);
+    expect(stdoutText()).toMatch(/upgrade-policy --tenant <id>/);
   });
 });

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -21,7 +21,7 @@
  * @module cli
  */
 
-import { createPublicKey, createPrivateKey } from 'node:crypto';
+import { createPublicKey, createPrivateKey, randomUUID } from 'node:crypto';
 import {
   closeSync,
   existsSync,
@@ -56,6 +56,13 @@ import {
   loadOrCreateOriginSecret,
   ORIGIN_SECRET_UNAVAILABLE_WARNING,
 } from '@qmd-team-intent-kb/common';
+
+import {
+  buildRecommendedPolicy,
+  findUncoveredRuleTypes,
+  RECOMMENDED_POLICY_RULES,
+} from '@qmd-team-intent-kb/policy-engine';
+import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
 
 import { Curator } from './curator.js';
 import { ingestFromSpoolDetailed } from './intake/spool-intake.js';
@@ -121,6 +128,14 @@ Subcommands:
     two pre-merge clone heads (requires MERGE_ANCHOR_PRIVATE_KEY_HEX in the
     environment, sourced from the SOPS-encrypted key file — never plaintext).
 
+  upgrade-policy --tenant <id> [--db <path>] [--dry-run] [--json]
+    Upgrade the tenant's enabled governance policy to the RECOMMENDED rule set
+    (every registered rule enabled — the anti-dormancy shape, 5bm.2). Writes a
+    'policy_upgraded' audit receipt carrying the PREVIOUS rules, so the change
+    is reversible from the receipt alone. No enabled policy → creates the
+    recommended policy. Policy already complete → no-op, nothing written.
+    --dry-run reports the dormant rules and the planned change without writing.
+
   help | --help | -h
     Print this message.
 
@@ -168,6 +183,13 @@ Options for 'merge-govern':
                   merge. Signing key comes from MERGE_ANCHOR_PRIVATE_KEY_HEX.
   --commit <sha>  Optional Dolt/git commit SHA recorded in the anchor.
   --json          Emit a structured JSON envelope in place of the summary.
+
+Options for 'upgrade-policy':
+  --tenant <id>   Tenant whose enabled policy is upgraded (required).
+  --db <path>     Persistent SQLite path. Default: in-memory (tests only —
+                  a real upgrade needs the store on disk).
+  --dry-run       Report the dormant rules + planned change, write nothing.
+  --json          Emit a structured JSON envelope in place of the summary.
 `;
 
 // ---------------------------------------------------------------------------
@@ -193,6 +215,8 @@ export async function dispatch(argv: string[], deps: CuratorCliDeps): Promise<nu
       return cmdProvenanceWalk(argv.slice(1), deps);
     case 'merge-govern':
       return cmdMergeGovern(argv.slice(1), deps);
+    case 'upgrade-policy':
+      return cmdUpgradePolicy(argv.slice(1), deps);
     case 'help':
     case '--help':
     case '-h':
@@ -1425,5 +1449,264 @@ async function cmdMergeGovern(args: string[], deps: CuratorCliDeps): Promise<num
         // non-fatal
       }
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// upgrade-policy
+// ---------------------------------------------------------------------------
+
+interface UpgradePolicyOpts {
+  tenantId: string;
+  dbPath?: string;
+  dryRun: boolean;
+  json: boolean;
+}
+
+function parseUpgradePolicyArgs(
+  args: string[],
+): { ok: true; opts: UpgradePolicyOpts } | { ok: false; message: string } {
+  let tenantId: string | undefined;
+  let dbPath: string | undefined;
+  let dryRun = false;
+  let json = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i]!;
+    switch (arg) {
+      case '--tenant':
+        tenantId = args[i + 1];
+        i += 2;
+        break;
+      case '--db':
+        dbPath = args[i + 1];
+        i += 2;
+        break;
+      case '--dry-run':
+        dryRun = true;
+        i += 1;
+        break;
+      case '--json':
+        json = true;
+        i += 1;
+        break;
+      default:
+        return { ok: false, message: `unknown argument: ${arg}` };
+    }
+  }
+
+  if (tenantId === undefined || tenantId.trim() === '') {
+    return { ok: false, message: 'missing required flag: --tenant <id>' };
+  }
+
+  return { ok: true, opts: { tenantId, dbPath, dryRun, json } };
+}
+
+/**
+ * The receipted migration path for 5bm.2: bring a store's LIVE governance
+ * policy up to the recommended anti-dormancy shape ({@link RECOMMENDED_POLICY_RULES}
+ * — every registered rule enabled; secret/length/tenant reject, the rest flag).
+ *
+ * Three outcomes, all explicit:
+ *   - `upgraded`         — the tenant's enabled policy left rules dormant; its
+ *                          rules are replaced with the recommended set (version
+ *                          bumped) and a `policy_upgraded` audit receipt is
+ *                          appended IN THE SAME SQLite transaction. The receipt's
+ *                          details carry the PREVIOUS rules verbatim, so the
+ *                          change is reversible from the chain alone.
+ *   - `created`          — no enabled policy existed; the recommended policy is
+ *                          inserted (same transactional receipt).
+ *   - `already-complete` — no registered rule is dormant; nothing is written.
+ *
+ * `--dry-run` reports which outcome WOULD apply (and the dormant rules) without
+ * touching the store — the operator preview 5bm.10 did by hand.
+ */
+async function cmdUpgradePolicy(args: string[], deps: CuratorCliDeps): Promise<number> {
+  const parsed = parseUpgradePolicyArgs(args);
+  if (!parsed.ok) {
+    process.stderr.write(`curator-cli upgrade-policy: ${parsed.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const opts = parsed.opts;
+
+  const db = deps.createDb(opts.dbPath !== undefined ? { dbPath: opts.dbPath } : {});
+  try {
+    const policyRepo = new PolicyRepository(db);
+    const auditRepo = new AuditRepository(db);
+    const now = new Date().toISOString();
+
+    const enabled = policyRepo.findByTenant(opts.tenantId).find((p) => p.enabled);
+    const dormant = enabled !== undefined ? findUncoveredRuleTypes(enabled) : [];
+
+    // Outcome: already-complete — nothing to do, nothing written.
+    if (enabled !== undefined && dormant.length === 0) {
+      emitUpgradePolicyReport(opts, {
+        outcome: 'already-complete',
+        policyId: enabled.id,
+        policyName: enabled.name,
+        dormantRules: [],
+        written: false,
+      });
+      return 0;
+    }
+
+    const outcome = enabled === undefined ? 'created' : 'upgraded';
+
+    if (opts.dryRun) {
+      emitUpgradePolicyReport(opts, {
+        outcome,
+        policyId: enabled?.id ?? null,
+        policyName: enabled?.name ?? null,
+        dormantRules: dormant,
+        written: false,
+      });
+      return 0;
+    }
+
+    if (enabled === undefined) {
+      // No enabled policy: create the recommended one, with a receipt.
+      const policy = buildRecommendedPolicy(opts.tenantId, now);
+      const applyFn = (db as unknown as BetterSqliteLike).transaction(() => {
+        policyRepo.insert(policy);
+        auditRepo.insert({
+          id: randomUUID(),
+          action: 'policy_upgraded',
+          memoryId: policy.id,
+          tenantId: opts.tenantId,
+          actor: { type: 'system', id: 'curator-cli' },
+          reason:
+            'Created the recommended governance policy (no enabled policy existed for this tenant)',
+          details: {
+            outcome: 'created',
+            policyName: policy.name,
+            toRuleCount: policy.rules.length,
+            previousRules: null,
+          },
+          timestamp: now,
+        });
+      });
+      applyFn();
+      emitUpgradePolicyReport(opts, {
+        outcome: 'created',
+        policyId: policy.id,
+        policyName: policy.name,
+        dormantRules: [],
+        written: true,
+      });
+      return 0;
+    }
+
+    // Enabled policy with dormant rules: replace its rule set, with a receipt
+    // carrying the previous rules (reversibility) in ONE transaction.
+    const previousRules = enabled.rules;
+    const upgraded = GovernancePolicy.parse({
+      ...enabled,
+      rules: RECOMMENDED_POLICY_RULES,
+      version: enabled.version + 1,
+      updatedAt: now,
+    });
+    const applyFn = (db as unknown as BetterSqliteLike).transaction(() => {
+      policyRepo.update(upgraded);
+      auditRepo.insert({
+        id: randomUUID(),
+        action: 'policy_upgraded',
+        memoryId: enabled.id,
+        tenantId: opts.tenantId,
+        actor: { type: 'system', id: 'curator-cli' },
+        reason:
+          `Upgraded policy "${enabled.name}" to the recommended rule set — ` +
+          `${dormant.length} dormant rule(s) activated: ${dormant.join(', ')}`,
+        details: {
+          outcome: 'upgraded',
+          policyName: enabled.name,
+          fromVersion: enabled.version,
+          toVersion: upgraded.version,
+          fromRuleCount: previousRules.length,
+          toRuleCount: upgraded.rules.length,
+          previouslyDormant: dormant,
+          // The full previous rule set — restoring it is the rollback.
+          previousRules,
+        },
+        timestamp: now,
+      });
+    });
+    applyFn();
+    emitUpgradePolicyReport(opts, {
+      outcome: 'upgraded',
+      policyId: enabled.id,
+      policyName: enabled.name,
+      dormantRules: dormant,
+      written: true,
+    });
+    return 0;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ ok: false, error: msg, code: 'UPGRADE_POLICY_FAILED' }) + '\n',
+      );
+    } else {
+      process.stderr.write(`upgrade-policy failed: ${msg}\n`);
+    }
+    return 1;
+  } finally {
+    try {
+      (db as unknown as { close?: () => void }).close?.();
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+/** Minimal structural view of better-sqlite3's transaction API (test doubles included). */
+interface BetterSqliteLike {
+  transaction(fn: () => void): () => void;
+}
+
+interface UpgradePolicyReport {
+  outcome: 'upgraded' | 'created' | 'already-complete';
+  policyId: string | null;
+  policyName: string | null;
+  dormantRules: string[];
+  written: boolean;
+}
+
+function emitUpgradePolicyReport(opts: UpgradePolicyOpts, report: UpgradePolicyReport): void {
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        dry_run: opts.dryRun,
+        tenant_id: opts.tenantId,
+        ...report,
+      }) + '\n',
+    );
+    return;
+  }
+  const header = opts.dryRun ? '[dry-run] ' : '';
+  switch (report.outcome) {
+    case 'already-complete':
+      process.stdout.write(
+        `${header}Policy "${report.policyName}" already enables every registered rule — nothing to do.\n`,
+      );
+      break;
+    case 'created':
+      process.stdout.write(
+        `${header}No enabled policy for tenant ${opts.tenantId} — ` +
+          (report.written
+            ? `created "Recommended Governance Policy" (${RECOMMENDED_POLICY_RULES.length} rules) with a policy_upgraded receipt.\n`
+            : `would create the recommended policy (${RECOMMENDED_POLICY_RULES.length} rules).\n`),
+      );
+      break;
+    case 'upgraded':
+      process.stdout.write(
+        `${header}Policy "${report.policyName}" leaves ${report.dormantRules.length} rule(s) dormant: ` +
+          `${report.dormantRules.join(', ')}\n` +
+          (report.written
+            ? `Upgraded to the recommended rule set (${RECOMMENDED_POLICY_RULES.length} rules) with a policy_upgraded receipt (previous rules preserved in the receipt).\n`
+            : `Would upgrade to the recommended rule set (${RECOMMENDED_POLICY_RULES.length} rules).\n`),
+      );
+      break;
   }
 }

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -144,12 +144,13 @@ export class Curator {
       existingHashes: hashSet,
       tenantId: this.config.tenantId,
       // contradiction_check lookup (E1): tenant-scoped ACTIVE memories filtered
-      // to the requested category. Queried lazily — the store is only hit when
-      // a contradiction rule actually runs.
+      // to the requested category AT THE STORE QUERY — loading the whole active
+      // set and filtering in JS deserialized a 17k-row corpus per candidate to
+      // keep ~6%. Queried lazily — the store is only hit when a contradiction
+      // rule actually runs.
       getActiveMemoriesInCategory: (category) =>
         this.deps.memoryRepo
-          .findByTenantAndLifecycle(this.config.tenantId, 'active')
-          .filter((m) => m.category === category)
+          .findByTenantAndLifecycleAndCategory(this.config.tenantId, 'active', category)
           .map((m) => ({ id: m.id, content: m.content })),
     });
 

--- a/apps/git-exporter/src/__tests__/directory-mapper.test.ts
+++ b/apps/git-exporter/src/__tests__/directory-mapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   getDirectory,
+  getActiveDirectory,
   getCategoryDirectory,
   getRelativePath,
   UnknownCategoryError,
@@ -81,6 +82,43 @@ describe('getDirectory', () => {
   it('active reference → guides', () => {
     const memory = makeCuratedMemory({ category: 'reference', lifecycle: 'active' });
     expect(getDirectory(memory)).toBe('guides');
+  });
+});
+
+describe('bulk_import routing (5bm.8)', () => {
+  it('active bulk_import → bulk/ regardless of category', () => {
+    // A whole-machine digestion routes to the non-default kb-bulk collection —
+    // even a 'reference' category (the 07-16 flood shape) stays out of guides/.
+    const memory = makeCuratedMemory({ source: 'bulk_import', category: 'reference' });
+    expect(getDirectory(memory)).toBe('bulk');
+  });
+
+  it('deprecated bulk_import → bulk/', () => {
+    const memory = makeCuratedMemory({
+      source: 'bulk_import',
+      category: 'decision',
+      lifecycle: 'deprecated',
+    });
+    expect(getDirectory(memory)).toBe('bulk');
+  });
+
+  it('archived bulk_import → archive/ (lifecycle still wins)', () => {
+    const memory = makeCuratedMemory({
+      source: 'bulk_import',
+      category: 'reference',
+      lifecycle: 'archived',
+    });
+    expect(getDirectory(memory)).toBe('archive');
+  });
+
+  it('getActiveDirectory: bulk_import → bulk, others → category dir', () => {
+    expect(getActiveDirectory({ source: 'bulk_import', category: 'reference' })).toBe('bulk');
+    expect(getActiveDirectory({ source: 'import', category: 'reference' })).toBe('guides');
+  });
+
+  it('bulk memory relative path is bulk/{id}.md', () => {
+    const memory = makeCuratedMemory({ source: 'bulk_import', category: 'reference' });
+    expect(getRelativePath(memory)).toBe(`bulk/${memory.id}.md`);
   });
 });
 

--- a/apps/git-exporter/src/diff/change-detector.ts
+++ b/apps/git-exporter/src/diff/change-detector.ts
@@ -1,7 +1,7 @@
 import type { MemoryRepository, ExportStateRepository } from '@qmd-team-intent-kb/store';
 import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
 import type { ExportChangeset, ExportConfig } from '../types.js';
-import { getRelativePath, getCategoryDirectory } from '../formatter/directory-mapper.js';
+import { getRelativePath, getActiveDirectory } from '../formatter/directory-mapper.js';
 import { join } from 'node:path';
 
 /**
@@ -60,9 +60,10 @@ export function detectChanges(
     // curated/; the operator fixes it at source (recategorize, 5bm.7).
     try {
       if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
-        // File may currently live in its category directory (from when it was active).
-        const categoryDir = getCategoryDirectory(memory.category);
-        const fromPath = join(config.outputDir, categoryDir, `${memory.id}.md`);
+        // File may currently live in its active-time directory (category dir,
+        // or bulk/ for a bulk_import memory — 5bm.8).
+        const activeDir = getActiveDirectory(memory);
+        const fromPath = join(config.outputDir, activeDir, `${memory.id}.md`);
         const toPath = join(config.outputDir, getRelativePath(memory));
         toArchive.push({ memory, fromPath, toPath });
       } else {

--- a/apps/git-exporter/src/formatter/directory-mapper.ts
+++ b/apps/git-exporter/src/formatter/directory-mapper.ts
@@ -17,10 +17,15 @@ export class UnknownCategoryError extends Error {
 /**
  * Resolve the export subdirectory for a memory.
  *
- * Lifecycle takes precedence over category:
+ * Lifecycle takes precedence over everything:
  * - `archived` or `superseded` → `archive/`
  *
- * Category mapping (active / deprecated):
+ * Source takes precedence over category (active / deprecated):
+ * - `bulk_import` → `bulk/` (5bm.8 — a whole-machine digestion routes to the
+ *   non-default `kb-bulk` collection so it cannot flood the default search
+ *   surface, regardless of what category the compiler assigned it)
+ *
+ * Category mapping (active / deprecated, non-bulk):
  * - `decision`                                → `decisions/`
  * - `pattern`, `convention`, `architecture`  → `curated/`
  * - `troubleshooting`, `reference`, `onboarding` → `guides/`
@@ -29,6 +34,20 @@ export class UnknownCategoryError extends Error {
 export function getDirectory(memory: CuratedMemory): string {
   if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
     return 'archive';
+  }
+  return getActiveDirectory(memory);
+}
+
+/**
+ * The directory a memory occupies while active/deprecated — i.e. ignoring the
+ * lifecycle→archive override. Bulk-imported memories live in `bulk/` (5bm.8);
+ * everything else lives in its category directory. The change-detector also
+ * uses this to compute the FROM path when archiving, so a bulk memory is moved
+ * out of `bulk/`, not looked for in its category directory.
+ */
+export function getActiveDirectory(memory: Pick<CuratedMemory, 'source' | 'category'>): string {
+  if (memory.source === 'bulk_import') {
+    return 'bulk';
   }
   return getCategoryDirectory(memory.category);
 }

--- a/apps/git-exporter/src/index.ts
+++ b/apps/git-exporter/src/index.ts
@@ -3,6 +3,7 @@ export { extractFrontmatter, renderFrontmatter } from './formatter/frontmatter.j
 export { formatMemoryAsMarkdown, getFilename } from './formatter/markdown-formatter.js';
 export {
   getDirectory,
+  getActiveDirectory,
   getCategoryDirectory,
   UnknownCategoryError,
   getRelativePath,

--- a/apps/mcp-server/src/remote-client.ts
+++ b/apps/mcp-server/src/remote-client.ts
@@ -82,9 +82,11 @@ server.tool(
   {
     query: z.string().min(1).describe('Natural-language search query'),
     scope: z
-      .enum(['curated', 'all', 'inbox', 'archived'])
+      .enum(['curated', 'all', 'inbox', 'archived', 'bulk'])
       .optional()
-      .describe('Search scope: curated (default), all, inbox, or archived'),
+      .describe(
+        'Search scope: curated (default), all, inbox, archived, or bulk (bulk-digestion corpus)',
+      ),
     limit: z
       .number()
       .int()

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -45,7 +45,7 @@ export function createServer(
     {
       query: z.string().min(1).describe('Natural-language search query'),
       scope: SearchScope.optional().describe(
-        'Search scope: curated (default, governed memories), all, inbox, or archived',
+        'Search scope: curated (default, governed memories), all, inbox, archived, or bulk (bulk-digestion corpus)',
       ),
       limit: z
         .number()

--- a/packages/eval-surface/src/govern-decision/decision-eval.ts
+++ b/packages/eval-surface/src/govern-decision/decision-eval.ts
@@ -189,8 +189,7 @@ function firedChecks(def: DecisionCase): ReadonlySet<DecisionCheck> {
       tenantId: DECISION_TENANT,
       getActiveMemoriesInCategory: (category) =>
         repo
-          .findByTenantAndLifecycle(DECISION_TENANT, 'active')
-          .filter((m) => m.category === category)
+          .findByTenantAndLifecycleAndCategory(DECISION_TENANT, 'active', category)
           .map((m) => ({ id: m.id, content: m.content })),
     });
 

--- a/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
@@ -141,4 +141,36 @@ describe('evaluateContradictionCheck', () => {
     const result = evaluateContradictionCheck(candidate, makeRule(), context);
     expect(result.outcome).toBe('pass');
   });
+
+  // E1 review follow-up: the tokenizer is Unicode-aware. Under the old
+  // ASCII-only [a-z0-9]+ pattern, both of these texts tokenized to the empty
+  // set (Cyrillic has no ASCII letters), Jaccard returned 0 for BOTH empty
+  // sets, and heavy non-Latin overlap was invisible.
+  it('flags heavy overlap between non-Latin (Cyrillic) texts', () => {
+    const original =
+      'Всегда развертывайте сервисы через синие зеленые переключения на балансировщике нагрузки';
+    const contradicting =
+      'Никогда развертывайте сервисы через синие зеленые переключения на балансировщике нагрузки';
+    const candidate = makeCandidate({ content: original, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-cyr', content: contradicting }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('flag');
+    expect(result.reason).toContain('mem-cyr');
+  });
+
+  it('does not flag disjoint non-Latin texts (no empty-token-set collapse)', () => {
+    const candidate = makeCandidate({
+      content: 'Всегда проверяйте целостность резервных копий после каждого запуска',
+      category: 'convention',
+    });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [
+        { id: 'mem-other', content: '部署服務時必須先執行資料庫遷移然後重新啟動應用程式' },
+      ],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
 });

--- a/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/contradiction-check-rule.test.ts
@@ -173,4 +173,32 @@ describe('evaluateContradictionCheck', () => {
     const result = evaluateContradictionCheck(candidate, makeRule(), context);
     expect(result.outcome).toBe('pass');
   });
+
+  // CJK carries no word spaces, so the whole-word Unicode pattern would make a
+  // sentence one token and never overlap. Per-character CJK segmentation
+  // (TOKEN_PATTERN) lets two near-identical Chinese sentences (one negated)
+  // share almost every character token and flag — the v1 target shape.
+  it('flags heavy overlap between near-identical CJK (Chinese) texts', () => {
+    const original = '部署服務時必須先執行資料庫遷移然後重新啟動應用程式並通知團隊成員';
+    const negated = '部署服務時禁止先執行資料庫遷移然後重新啟動應用程式並通知團隊成員';
+    const candidate = makeCandidate({ content: original, category: 'convention' });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-cjk', content: negated }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('flag');
+    expect(result.reason).toContain('mem-cjk');
+  });
+
+  it('does not flag two unrelated CJK sentences (per-char tokens still discriminate)', () => {
+    const candidate = makeCandidate({
+      content: '每次啟動後務必檢查備份資料的完整性與雜湊值',
+      category: 'convention',
+    });
+    const context = withActiveMemories(makeContext(candidate), {
+      convention: [{ id: 'mem-unrelated', content: '前端元件應使用嚴格型別並避免任意字串輸入' }],
+    });
+    const result = evaluateContradictionCheck(candidate, makeRule(), context);
+    expect(result.outcome).toBe('pass');
+  });
 });

--- a/packages/policy-engine/src/rules/contradiction-check-rule.ts
+++ b/packages/policy-engine/src/rules/contradiction-check-rule.ts
@@ -21,9 +21,16 @@ function parseThreshold(params: Record<string, unknown> | undefined): number {
   return Math.min(1, Math.max(0, raw));
 }
 
-/** Lowercased alphanumeric token set of a text. */
+/**
+ * Lowercased token set of a text — Unicode letters and digits (E1 review
+ * follow-up). The prior ASCII-only `[a-z0-9]+` collapsed any non-Latin text
+ * (Cyrillic, CJK, accented words) to an empty/tiny token set, making two
+ * unrelated non-English memories look either identical-topic or invisible to
+ * the overlap heuristic. `\p{L}\p{N}` with the `u` flag tokenizes every script
+ * the same way.
+ */
 function tokenSet(text: string): Set<string> {
-  return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+  return new Set(text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []);
 }
 
 /** Jaccard similarity of two token sets: |A ∩ B| / |A ∪ B| (0 when both empty). */
@@ -44,7 +51,7 @@ function jaccard(a: Set<string>, b: Set<string>): number {
  *
  * ## v1 heuristic — token overlap, honestly stated
  *
- * Detection is Jaccard similarity over lowercased alphanumeric token sets.
+ * Detection is Jaccard similarity over lowercased Unicode letter/digit token sets.
  * Token overlap is NOT semantic contradiction — "deploy on Fridays" and "never
  * deploy on Fridays" score high, but so do two compatible restatements of the
  * same convention. What high overlap reliably means is *same topic, different

--- a/packages/policy-engine/src/rules/contradiction-check-rule.ts
+++ b/packages/policy-engine/src/rules/contradiction-check-rule.ts
@@ -22,15 +22,27 @@ function parseThreshold(params: Record<string, unknown> | undefined): number {
 }
 
 /**
- * Lowercased token set of a text — Unicode letters and digits (E1 review
- * follow-up). The prior ASCII-only `[a-z0-9]+` collapsed any non-Latin text
- * (Cyrillic, CJK, accented words) to an empty/tiny token set, making two
- * unrelated non-English memories look either identical-topic or invisible to
- * the overlap heuristic. `\p{L}\p{N}` with the `u` flag tokenizes every script
- * the same way.
+ * Word/character-segmenting Unicode token pattern (E1 review follow-up).
+ *
+ * The prior ASCII-only `[a-z0-9]+` collapsed any non-Latin text (Cyrillic, CJK,
+ * accented words) to an empty token set. The Unicode swap fixes space-delimited
+ * scripts (Cyrillic, Greek, accented Latin), but a run of CJK ideographs carries
+ * NO word spaces, so `[\p{L}\p{N}]+` alone would make one long sentence a single
+ * token — two near-identical CJK sentences would then share zero tokens and never
+ * flag. So CJK scripts (Han / Hiragana / Katakana / Hangul) are segmented per
+ * character (the standard unigram approximation for space-less scripts), while
+ * every other script keeps whole-word runs. Alternation order matters: a single
+ * CJK char is matched before the general letter/digit run so it is never glued
+ * into a longer token.
+ */
+const TOKEN_PATTERN = /[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}]|[\p{L}\p{N}]+/gu;
+
+/**
+ * Lowercased token set of a text — whole words for space-delimited scripts,
+ * per-character tokens for space-less CJK. See {@link TOKEN_PATTERN}.
  */
 function tokenSet(text: string): Set<string> {
-  return new Set(text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []);
+  return new Set(text.toLowerCase().match(TOKEN_PATTERN) ?? []);
 }
 
 /** Jaccard similarity of two token sets: |A ∩ B| / |A ∪ B| (0 when both empty). */
@@ -51,7 +63,8 @@ function jaccard(a: Set<string>, b: Set<string>): number {
  *
  * ## v1 heuristic — token overlap, honestly stated
  *
- * Detection is Jaccard similarity over lowercased Unicode letter/digit token sets.
+ * Detection is Jaccard similarity over lowercased Unicode token sets (whole words
+ * for space-delimited scripts, per-character for space-less CJK).
  * Token overlap is NOT semantic contradiction — "deploy on Fridays" and "never
  * deploy on Fridays" score high, but so do two compatible restatements of the
  * same convention. What high overlap reliably means is *same topic, different

--- a/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
@@ -88,7 +88,13 @@ describe.skipIf(!HAS_QMD)('QmdAdapter ↔ real qmd (production index path)', () 
     expect(ensured.ok).toBe(true);
     if (ensured.ok) {
       // kb-inbox has no exported source, so it is NOT registered
-      expect(ensured.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
+      expect(ensured.value).toEqual([
+        'kb-curated',
+        'kb-decisions',
+        'kb-guides',
+        'kb-archive',
+        'kb-bulk',
+      ]);
     }
 
     const updated = await adapter.update();

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -49,13 +49,19 @@ describe('QmdAdapter', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('delegates ensureCollections to collection manager (4 exportable collections)', async () => {
+  it('delegates ensureCollections to collection manager (5 exportable collections)', async () => {
     mock.queueSuccess(''); // list
-    for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
+    for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
     const result = await adapter.ensureCollections();
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
+      expect(result.value).toEqual([
+        'kb-curated',
+        'kb-decisions',
+        'kb-guides',
+        'kb-archive',
+        'kb-bulk',
+      ]);
     }
     // Sources point at the export tree, not a per-tenant index dir
     const firstAdd = mock.commands.find((c) => c[0] === 'collection' && c[1] === 'add');

--- a/packages/qmd-adapter/src/__tests__/cli.test.ts
+++ b/packages/qmd-adapter/src/__tests__/cli.test.ts
@@ -65,7 +65,7 @@ describe('run', () => {
   it('reindex returns 0 and reports created collections', async () => {
     const { mock, makeAdapter } = makeInjected();
     mock.queueSuccess(''); // list
-    for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
+    for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
     mock.queueSuccess('Updated'); // update
     const logs: string[] = [];
 
@@ -120,9 +120,9 @@ describe('run', () => {
     for (let i = 0; i < DEFAULT_CANARY_CONTROLS.length; i++) {
       mock.queueSuccess(hitsJson(i === 0 ? 0 : 2));
     }
-    // heal reindex: list + 4 adds + update
+    // heal reindex: list + 5 adds + update
     mock.queueSuccess('');
-    for (let i = 0; i < 4; i++) mock.queueSuccess('');
+    for (let i = 0; i < 5; i++) mock.queueSuccess('');
     mock.queueSuccess('Updated');
     // Pass 2: all healthy
     for (const _ of DEFAULT_CANARY_CONTROLS) mock.queueSuccess(hitsJson(4));

--- a/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
+++ b/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
@@ -65,17 +65,23 @@ describe('CollectionManager', () => {
   });
 
   describe('ensureCollections', () => {
-    it('creates the 4 exportable collections, sourced from export subdirs', async () => {
+    it('creates the 5 exportable collections, sourced from export subdirs', async () => {
       // listCollections returns empty
       mock.queueSuccess('');
-      // 4 addCollection calls (kb-inbox has no exported source)
-      for (let i = 0; i < 4; i++) {
+      // 5 addCollection calls (kb-inbox has no exported source)
+      for (let i = 0; i < 5; i++) {
         mock.queueSuccess('');
       }
       const result = await manager.ensureCollections('/exports');
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
+        expect(result.value).toEqual([
+          'kb-curated',
+          'kb-decisions',
+          'kb-guides',
+          'kb-archive',
+          'kb-bulk',
+        ]);
       }
       // Each collection sources from its git-exporter subdir, not <base>/<name>
       const addCommands = mock.commands.filter((c) => c[0] === 'collection' && c[1] === 'add');
@@ -97,7 +103,7 @@ describe('CollectionManager', () => {
 
     it('does not register kb-inbox (no exported source)', async () => {
       mock.queueSuccess(''); // list
-      for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
+      for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
       const result = await manager.ensureCollections('/exports');
       expect(result.ok).toBe(true);
       const addedNames = mock.commands
@@ -108,7 +114,7 @@ describe('CollectionManager', () => {
 
     it('skips existing collections', async () => {
       // listCollections returns all exportable collections already present
-      mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive');
+      mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive\nkb-bulk');
       const result = await manager.ensureCollections('/exports');
       expect(result.ok).toBe(true);
       if (result.ok) {

--- a/packages/qmd-adapter/src/__tests__/collection-registry.test.ts
+++ b/packages/qmd-adapter/src/__tests__/collection-registry.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../collections/collection-registry.js';
 
 describe('KNOWN_COLLECTIONS', () => {
-  it('has 5 collections', () => {
-    expect(KNOWN_COLLECTIONS).toHaveLength(5);
+  it('has 6 collections', () => {
+    expect(KNOWN_COLLECTIONS).toHaveLength(6);
   });
 
   it('all have required fields', () => {
@@ -29,10 +29,12 @@ describe('getDefaultSearchCollections', () => {
     expect(defaults).toContain('kb-guides');
   });
 
-  it('excludes kb-inbox and kb-archive', () => {
+  it('excludes kb-inbox, kb-archive, and kb-bulk', () => {
     const defaults = getDefaultSearchCollections();
     expect(defaults).not.toContain('kb-inbox');
     expect(defaults).not.toContain('kb-archive');
+    // 5bm.8: the bulk-digestion corpus never rides the default surface.
+    expect(defaults).not.toContain('kb-bulk');
   });
 
   it('returns 3 collections', () => {
@@ -41,11 +43,12 @@ describe('getDefaultSearchCollections', () => {
 });
 
 describe('getAllCollectionNames', () => {
-  it('returns all 5 names', () => {
+  it('returns all 6 names', () => {
     const names = getAllCollectionNames();
-    expect(names).toHaveLength(5);
+    expect(names).toHaveLength(6);
     expect(names).toContain('kb-inbox');
     expect(names).toContain('kb-archive');
+    expect(names).toContain('kb-bulk');
   });
 });
 
@@ -70,5 +73,6 @@ describe('isDefaultSearchCollection', () => {
   it('returns false for non-default collections', () => {
     expect(isDefaultSearchCollection('kb-inbox')).toBe(false);
     expect(isDefaultSearchCollection('kb-archive')).toBe(false);
+    expect(isDefaultSearchCollection('kb-bulk')).toBe(false);
   });
 });

--- a/packages/qmd-adapter/src/__tests__/reindex.test.ts
+++ b/packages/qmd-adapter/src/__tests__/reindex.test.ts
@@ -26,7 +26,7 @@ describe('reindex', () => {
 
   it('registers missing collections then updates the index', async () => {
     mock.queueSuccess(''); // collection list -> none registered
-    for (let i = 0; i < 4; i++) mock.queueSuccess(''); // 4 collection adds
+    for (let i = 0; i < 5; i++) mock.queueSuccess(''); // 5 collection adds
     mock.queueSuccess('Updated'); // qmd update
 
     const result = await reindex(adapter);
@@ -38,6 +38,7 @@ describe('reindex', () => {
         'kb-decisions',
         'kb-guides',
         'kb-archive',
+        'kb-bulk',
       ]);
       expect(result.value.indexUpdated).toBe(true);
     }
@@ -46,8 +47,8 @@ describe('reindex', () => {
   });
 
   it('is idempotent — a re-run against already-registered collections creates none', async () => {
-    // list returns all 4 already present → ensureCollections adds nothing
-    mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive');
+    // list returns all 5 already present → ensureCollections adds nothing
+    mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive\nkb-bulk');
     mock.queueSuccess('Updated'); // qmd update still runs (re-index)
 
     const result = await reindex(adapter);
@@ -74,7 +75,7 @@ describe('reindex', () => {
   });
 
   it('surfaces an update failure', async () => {
-    mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive'); // all present
+    mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive\nkb-bulk'); // all present
     mock.queueFailure('qmd update crashed');
 
     const result = await reindex(adapter);

--- a/packages/qmd-adapter/src/__tests__/search-canary.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-canary.test.ts
@@ -108,9 +108,9 @@ describe('runSearchCanary', () => {
 
       // Pass 1: empty index -> 0 hits (degraded).
       mock.queueSuccess(hitsJson(0));
-      // Heal: reindex = ensureCollections (list + 4 adds) + update.
+      // Heal: reindex = ensureCollections (list + 5 adds) + update.
       mock.queueSuccess(''); // collection list
-      for (let i = 0; i < 4; i++) mock.queueSuccess(''); // 4 adds
+      for (let i = 0; i < 5; i++) mock.queueSuccess(''); // 5 adds
       mock.queueSuccess('Updated'); // update
       // Pass 2 (re-check): now returns hits.
       mock.queueSuccess(hitsJson(5));
@@ -127,7 +127,7 @@ describe('runSearchCanary', () => {
 
       mock.queueSuccess(hitsJson(0)); // pass 1: degraded
       mock.queueSuccess(''); // heal: list
-      for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
+      for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
       mock.queueSuccess('Updated'); // update
       mock.queueSuccess(hitsJson(0)); // pass 2: STILL 0 hits (e.g. empty kb-export)
 

--- a/packages/qmd-adapter/src/__tests__/search-client.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-client.test.ts
@@ -97,6 +97,30 @@ describe('SearchClient', () => {
     }
   });
 
+  it('scope "bulk" only returns bulk results (5bm.8)', async () => {
+    mock.queueSuccess(
+      jsonHits([{ file: 'qmd://kb-curated/a.md' }, { file: 'qmd://kb-bulk/b.md' }]),
+    );
+    const result = await client.search('test', 'bulk');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.collection).toBe('kb-bulk');
+    }
+  });
+
+  it('default curated scope excludes kb-bulk hits (5bm.8)', async () => {
+    mock.queueSuccess(
+      jsonHits([{ file: 'qmd://kb-curated/a.md' }, { file: 'qmd://kb-bulk/b.md' }]),
+    );
+    const result = await client.search('test');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.collection).toBe('kb-curated');
+    }
+  });
+
   it('returns error on command failure', async () => {
     mock.queueFailure('search error', 1);
     const result = await client.search('test');

--- a/packages/qmd-adapter/src/collections/collection-registry.ts
+++ b/packages/qmd-adapter/src/collections/collection-registry.ts
@@ -19,7 +19,7 @@ export interface CollectionDef {
   sourceSubdir: string | null;
 }
 
-/** The 5 known collections with their default search inclusion */
+/** The 6 known collections with their default search inclusion */
 export const KNOWN_COLLECTIONS: CollectionDef[] = [
   {
     name: 'kb-curated',
@@ -50,6 +50,20 @@ export const KNOWN_COLLECTIONS: CollectionDef[] = [
     description: 'Deprecated, superseded, or archived memories',
     includeInDefaultSearch: false,
     sourceSubdir: 'archive',
+  },
+  {
+    // 5bm.8 — bulk-digestion quarantine collection. Memories whose source is
+    // `bulk_import` (whole-machine digestions, stamped low-trust at the schema
+    // boundary) export to `bulk/` instead of their category directory, so a
+    // 10k-file digestion can never flood the default `curated` search scope
+    // again (the 2026-07-16 flood put ~9.7k bulk reference files in kb-guides).
+    // Deliberately searchable via scope `bulk` or `all` — quarantined from the
+    // DEFAULT surface, not hidden.
+    name: 'kb-bulk',
+    description:
+      'Bulk-imported low-trust memories (whole-machine digestions), excluded from default search',
+    includeInDefaultSearch: false,
+    sourceSubdir: 'bulk',
   },
 ];
 

--- a/packages/qmd-adapter/src/search/result-parser.ts
+++ b/packages/qmd-adapter/src/search/result-parser.ts
@@ -56,7 +56,14 @@ export function parseQueryOutput(stdout: string): QmdSearchResult[] {
 
 /** Derive collection name from a file path (qmd:// URI or filesystem path) */
 export function deriveCollectionFromPath(filePath: string): string {
-  const knownCollections = ['kb-curated', 'kb-decisions', 'kb-guides', 'kb-inbox', 'kb-archive'];
+  const knownCollections = [
+    'kb-curated',
+    'kb-decisions',
+    'kb-guides',
+    'kb-inbox',
+    'kb-archive',
+    'kb-bulk',
+  ];
   for (const name of knownCollections) {
     if (filePath.includes(name)) return name;
   }

--- a/packages/qmd-adapter/src/search/search-client.ts
+++ b/packages/qmd-adapter/src/search/search-client.ts
@@ -61,6 +61,10 @@ export function resolveScopeCollections(scope: SearchScope): string[] {
       return ['kb-inbox'];
     case 'archived':
       return ['kb-archive'];
+    case 'bulk':
+      // The deliberate way into the bulk-digestion corpus (5bm.8) — excluded
+      // from the default scope, reachable here or via 'all'.
+      return ['kb-bulk'];
     case 'all':
       return []; // No filtering
     default:

--- a/packages/schema/src/__tests__/enums.test.ts
+++ b/packages/schema/src/__tests__/enums.test.ts
@@ -72,7 +72,7 @@ describe('CandidateStatus', () => {
 });
 
 describe('SearchScope', () => {
-  it.each(['curated', 'all', 'inbox', 'archived'])('accepts "%s"', (val) => {
+  it.each(['curated', 'all', 'inbox', 'archived', 'bulk'])('accepts "%s"', (val) => {
     expect(SearchScope.parse(val)).toBe(val);
   });
   it('defaults to "curated"', () => {
@@ -145,6 +145,9 @@ describe('AuditAction', () => {
     'exported',
     'eval-result',
     'proposed',
+    'recategorized',
+    'governed',
+    'policy_upgraded',
   ];
   it.each(actions)('accepts "%s"', (val) => {
     expect(AuditAction.parse(val)).toBe(val);

--- a/packages/schema/src/__tests__/memory-candidate.test.ts
+++ b/packages/schema/src/__tests__/memory-candidate.test.ts
@@ -92,6 +92,47 @@ describe('MemoryCandidate', () => {
     }
   });
 
+  // 5bm.8 — the low-trust stamp on bulk digestions is a schema-boundary
+  // invariant, not an emitter convention: a bulk_import candidate can never
+  // claim curated-grade trust past this parse.
+  describe('bulk_import low-trust stamp (5bm.8)', () => {
+    it("accepts bulk_import with trustLevel 'low'", () => {
+      const c = MemoryCandidate.parse(
+        makeMemoryCandidate({ source: 'bulk_import', trustLevel: 'low' }),
+      );
+      expect(c.source).toBe('bulk_import');
+      expect(c.trustLevel).toBe('low');
+    });
+
+    it("accepts bulk_import with trustLevel 'untrusted'", () => {
+      const c = MemoryCandidate.parse(
+        makeMemoryCandidate({ source: 'bulk_import', trustLevel: 'untrusted' }),
+      );
+      expect(c.trustLevel).toBe('untrusted');
+    });
+
+    it.each(['medium', 'high'] as const)('rejects bulk_import claiming trustLevel %s', (trust) => {
+      const result = MemoryCandidate.safeParse(
+        makeMemoryCandidate({ source: 'bulk_import', trustLevel: trust }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a bulk_import line that omits trustLevel (default medium is not a valid stamp)', () => {
+      const input = makeMemoryCandidate({ source: 'bulk_import' }) as Record<string, unknown>;
+      delete input['trustLevel'];
+      const result = MemoryCandidate.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('leaves non-bulk sources free to carry medium/high trust', () => {
+      const c = MemoryCandidate.parse(
+        makeMemoryCandidate({ source: 'import', trustLevel: 'high' }),
+      );
+      expect(c.trustLevel).toBe('high');
+    });
+  });
+
   it('accepts all valid categories', () => {
     const categories = [
       'decision',

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -64,7 +64,13 @@ export const CandidateStatus = z.enum([
 ]);
 export type CandidateStatus = z.infer<typeof CandidateStatus>;
 
-export const SearchScope = z.enum(['curated', 'all', 'inbox', 'archived']).default('curated');
+// `bulk` (5bm.8) addresses the default-search flood: bulk-digestion reference
+// memories route to the non-default `kb-bulk` collection at export, so the
+// `curated` default scope no longer surfaces a whole-machine digestion. The
+// `bulk` scope is the deliberate way IN to that corpus ('all' also includes it).
+export const SearchScope = z
+  .enum(['curated', 'all', 'inbox', 'archived', 'bulk'])
+  .default('curated');
 export type SearchScope = z.infer<typeof SearchScope>;
 
 // `contradiction_check` (GSB blueprint Track E1) surfaces candidates whose
@@ -120,6 +126,13 @@ export const AuditAction = z.enum([
   // re-fire every night for a candidate left in the inbox → unbounded chain bloat).
   // `memoryId` is a fixed sweep sentinel UUID (the sweep is not tied to one memory).
   'governed',
+  // Receipt for a governed-policy upgrade (5bm.2's migration path): the curator
+  // `upgrade-policy` command replaces a store's dormant-rule policy shape with
+  // RECOMMENDED_POLICY_RULES. `memoryId` on this row is the POLICY's UUID (the
+  // policy row is the mutated durable state); `details` carries the previous
+  // rules so the change is reversible from the receipt alone. The audit_events
+  // `action` column has no CHECK constraint, so this member needs no migration.
+  'policy_upgraded',
 ]);
 export type AuditAction = z.infer<typeof AuditAction>;
 

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -112,6 +112,15 @@ export const MemoryCandidate = z
   // bulk candidate. NOTE: `trustLevel` defaults to 'medium', so a bulk_import
   // line MUST stamp its trust explicitly — an unstamped one is refused, which
   // is the fail-closed reading of "ICO stamps it with low trust".
+  //
+  // MIGRATION STORY: any pre-5bm.8 `bulk_import` candidate stamped `medium`
+  // under the old emitter convention FAILS this refine at re-validation. That is
+  // intended — it surfaces a mis-stamped digestion loudly instead of admitting
+  // it — and is NOT silent dropping: such a row is corrected via the governed
+  // recategorization/curation tooling (or a one-shot re-stamp to low), then
+  // re-ingested. The durable fix is the deferred coordination to have ICO's
+  // emitter stamp `bulk_import` low at capture time (flagged in PR #310); until
+  // then, callers of bulk digestions must supply an explicit low/untrusted stamp.
   .refine(
     (c) => c.source !== 'bulk_import' || c.trustLevel === 'low' || c.trustLevel === 'untrusted',
     {

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -78,27 +78,46 @@ export const CandidateOrigin = z
 export type CandidateOrigin = z.infer<typeof CandidateOrigin>;
 
 /** A raw memory proposal captured from a Claude Code session, before governance */
-export const MemoryCandidate = z.object({
-  schemaVersion: z
-    .literal(MEMORY_CANDIDATE_SCHEMA_VERSION)
-    .default(MEMORY_CANDIDATE_SCHEMA_VERSION),
-  id: Uuid,
-  status: CandidateStatus,
-  source: MemorySource,
-  content: NonEmptyString,
-  title: NonEmptyString,
-  category: MemoryCategory,
-  trustLevel: TrustLevel.default('medium'),
-  author: Author,
-  tenantId: TenantId,
-  metadata: ContentMetadata.default({ filePaths: [], tags: [] }),
-  prePolicyFlags: PrePolicyFlags.default({
-    potentialSecret: false,
-    lowConfidence: false,
-    duplicateSuspect: false,
-  }),
-  capturedAt: IsoDatetime,
-  /** Optional write-time provenance attestation (H1) — verified before promotion when present. */
-  origin: CandidateOrigin.optional(),
-});
+export const MemoryCandidate = z
+  .object({
+    schemaVersion: z
+      .literal(MEMORY_CANDIDATE_SCHEMA_VERSION)
+      .default(MEMORY_CANDIDATE_SCHEMA_VERSION),
+    id: Uuid,
+    status: CandidateStatus,
+    source: MemorySource,
+    content: NonEmptyString,
+    title: NonEmptyString,
+    category: MemoryCategory,
+    trustLevel: TrustLevel.default('medium'),
+    author: Author,
+    tenantId: TenantId,
+    metadata: ContentMetadata.default({ filePaths: [], tags: [] }),
+    prePolicyFlags: PrePolicyFlags.default({
+      potentialSecret: false,
+      lowConfidence: false,
+      duplicateSuspect: false,
+    }),
+    capturedAt: IsoDatetime,
+    /** Optional write-time provenance attestation (H1) — verified before promotion when present. */
+    origin: CandidateOrigin.optional(),
+  })
+  // Enforced low-trust stamp for bulk digestions (5bm.8): `bulk_import` exists
+  // so a whole-machine digestion is distinguishable from a deliberate `import`
+  // and gateable by the source-trust rule. That only works if the stamp cannot
+  // be inflated — a bulk_import candidate CLAIMING medium/high trust would walk
+  // straight past a `minimumTrust: 'low'` gate, exactly the 2026-07-16 flood
+  // shape. Enforcing `low`/`untrusted` at the schema boundary (not by emitter
+  // convention) means no client, spool line, or API caller can mint a trusted
+  // bulk candidate. NOTE: `trustLevel` defaults to 'medium', so a bulk_import
+  // line MUST stamp its trust explicitly — an unstamped one is refused, which
+  // is the fail-closed reading of "ICO stamps it with low trust".
+  .refine(
+    (c) => c.source !== 'bulk_import' || c.trustLevel === 'low' || c.trustLevel === 'untrusted',
+    {
+      message:
+        "source 'bulk_import' requires trustLevel 'low' or 'untrusted' — a bulk digestion cannot claim curated-grade trust",
+      path: ['trustLevel'],
+    },
+  );
 export type MemoryCandidate = z.infer<typeof MemoryCandidate>;

--- a/packages/store/src/__tests__/memory-repository.test.ts
+++ b/packages/store/src/__tests__/memory-repository.test.ts
@@ -305,6 +305,55 @@ describe('MemoryRepository — aggregation queries', () => {
     expect(results[0]?.lifecycle).toBe('active');
   });
 
+  // findByTenantAndLifecycleAndCategory (E1 contradiction-lookup follow-up)
+  it('findByTenantAndLifecycleAndCategory filters on tenant, lifecycle, AND category at the store', () => {
+    const fresh = () => randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '');
+    repo.insert(
+      makeMemory({
+        tenantId: 'team-alpha',
+        lifecycle: 'active',
+        category: 'convention',
+        contentHash: fresh(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        tenantId: 'team-alpha',
+        lifecycle: 'active',
+        category: 'reference',
+        contentHash: fresh(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        tenantId: 'team-alpha',
+        lifecycle: 'deprecated',
+        category: 'convention',
+        contentHash: fresh(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        tenantId: 'team-beta',
+        lifecycle: 'active',
+        category: 'convention',
+        contentHash: fresh(),
+      }),
+    );
+    const results = repo.findByTenantAndLifecycleAndCategory('team-alpha', 'active', 'convention');
+    expect(results).toHaveLength(1);
+    expect(results[0]?.tenantId).toBe('team-alpha');
+    expect(results[0]?.lifecycle).toBe('active');
+    expect(results[0]?.category).toBe('convention');
+  });
+
+  it('findByTenantAndLifecycleAndCategory returns empty array when no category match', () => {
+    repo.insert(makeMemory({ tenantId: 'team-alpha', lifecycle: 'active', category: 'reference' }));
+    expect(repo.findByTenantAndLifecycleAndCategory('team-alpha', 'active', 'decision')).toEqual(
+      [],
+    );
+  });
+
   it('findByTenantAndLifecycle returns empty array when no match', () => {
     repo.insert(
       makeMemory({

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type Database from 'better-sqlite3';
 import { CuratedMemory, isTransitionAllowed } from '@qmd-team-intent-kb/schema';
-import type { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import type { MemoryCategory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 import { assertMemoryEnumMembership } from './enum-membership.js';
 
 /**
@@ -229,6 +229,7 @@ export class MemoryRepository {
   private readonly stmtCountByTenant: Database.Statement;
   private readonly stmtFindStale: Database.Statement;
   private readonly stmtFindByTenantAndLifecycle: Database.Statement;
+  private readonly stmtFindByTenantAndLifecycleAndCategory: Database.Statement;
 
   constructor(db: Database.Database) {
     this.db = db;
@@ -345,6 +346,10 @@ export class MemoryRepository {
 
     this.stmtFindByTenantAndLifecycle = db.prepare(`
       SELECT * FROM curated_memories WHERE tenant_id = ? AND lifecycle = ?
+    `);
+
+    this.stmtFindByTenantAndLifecycleAndCategory = db.prepare(`
+      SELECT * FROM curated_memories WHERE tenant_id = ? AND lifecycle = ? AND category = ?
     `);
   }
 
@@ -564,6 +569,24 @@ export class MemoryRepository {
   /** Find memories by tenant and lifecycle state */
   findByTenantAndLifecycle(tenantId: string, lifecycle: MemoryLifecycleState): CuratedMemory[] {
     const rows = this.stmtFindByTenantAndLifecycle.all(tenantId, lifecycle);
+    return rows.map(rowToMemory);
+  }
+
+  /**
+   * Find memories by tenant, lifecycle state, AND category — the
+   * contradiction-check lookup (E1 review follow-up). The rule only ever
+   * compares against same-category actives, so filtering at the store keeps a
+   * 17k-row corpus from being loaded and deserialized per candidate just to
+   * discard the ~94% in other categories. Narrowed by
+   * `idx_memories_tenant_lifecycle`; the residual category filter runs in SQL,
+   * not on materialized domain objects.
+   */
+  findByTenantAndLifecycleAndCategory(
+    tenantId: string,
+    lifecycle: MemoryLifecycleState,
+    category: MemoryCategory,
+  ): CuratedMemory[] {
+    const rows = this.stmtFindByTenantAndLifecycleAndCategory.all(tenantId, lifecycle, category);
     return rows.map(rowToMemory);
   }
 


### PR DESCRIPTION
## What

Implements the still-open children of the ontology-axes epic (`qmd-team-intent-kb-5bm`, GH #259) plus two hygiene fixes from the E1 review. The 2026-07-17 five-auditor ontology audit found the enum vocabulary healthy but the axes carrying no signal in production, and no receipted, operator-safe way to bring a store's dormant governance policy up to the recommended shape.

Per-bead status:

| Bead | Title | Status |
|---|---|---|
| `5bm.2` | Enable source-trust/sensitivity/relevance in the live policy + doctor check | **Built** — the missing receipted migration path (`curator upgrade-policy`). Recommended-policy + dormancy-doctor tooling pre-shipped under `5bm.10`. |
| `5bm.3` | Persist sensitivity at promotion; enforce at read time | **Verify-only** — promoter persists `classifyContent(...).sensitivityLevel` (`promoter.ts:156`); read-time enforcement via `5bm.11` (`search-service.ts`, mcp `search.ts`, `isSearchVisibleSensitivity`). |
| `5bm.4` | Lifecycle validation in the repo layer + CHECK constraint | **Verify-only** — `updateLifecycle` guards via `isTransitionAllowed`/`InvalidLifecycleTransitionError` (`memory-repository.ts`); lifecycle `CHECK` in fresh DDL **and** the v9 rebuild migration; guard test `memory-repository-lifecycle-guard.test.ts`. |
| `5bm.5` | Export mapper fails on unknown category | **Verify-only** — `getCategoryDirectory` throws `UnknownCategoryError` (`directory-mapper.ts:54`); tests in `directory-mapper.test.ts`. Secondary "back/remove dead `inbox` scope" deferred (see Unfinished). |
| `5bm.6` | `schemaVersion` on the candidate schema | **Verify-only** — `MemoryCandidate.schemaVersion = z.literal('1')`; v2-rejection proven by `spool-intake-ico-contract.test.ts` ("rejects a v2 spool line instead of ingesting it as v1"). |
| `5bm.7` | Governed recategorization tool | **Verify-only** — MCP `recategorize.ts` + API `memory-service.recategorize` + `recategorized` AuditAction; re-export flows via the existing change-detector on `updatedAt`. |
| `5bm.8` | Split/tag bulk-digestion so default search isn't flooded | **Built** — low-trust `bulk_import` stamp + `kb-bulk` non-default collection + `bulk` scope. |
| E1(a) | Category-scoped contradiction lookup | **Built** — `findByTenantAndLifecycleAndCategory` + rewired call sites. |
| E1(b) | Unicode contradiction tokenizer | **Built** — `\p{L}\p{N}` with the `u` flag. |

(`5bm.1` closed; `5bm.9`/`5bm.10`/`5bm.11`/`5bm.12` already closed on main.)

## Why + decision rationale

- **Bulk low-trust stamp enforced in the Zod schema**, not by ICO emitter convention — fail-closed: no client, spool line, or API caller can mint a trusted whole-machine digestion, the exact shape a source-trust gate must catch. `bulk_import` is a new source with no existing rows → zero blast radius on the live corpus.
- **Route bulk to a non-default collection** chosen over "drop the guides slice from default search": keeps the corpus reachable via `bulk`/`all` (quarantined from the default surface, not hidden) and survives the `5kw` intake drain.
- **Upgrade receipt stores the full previous rule set** (not a diff) so rollback is a single restore with no reconstruction.
- **One PR, not two:** the schema `enums.ts` edits (SearchScope, AuditAction) serve both the `5bm.2` migration path and `5bm.8` — splitting would create an artificial cross-PR schema dependency.

## Layers touched + invariant changes

- **schema** — `SearchScope` gains `bulk`; `AuditAction` gains `policy_upgraded`; `MemoryCandidate` gains a refine forcing `bulk_import` → low/untrusted trust (**new invariant**, fail-closed).
- **store** — `findByTenantAndLifecycleAndCategory` + prepared statement.
- **policy-engine** — Unicode tokenizer (a **C10 policy-hash-pinned file**; re-pinned in-commit).
- **qmd-adapter** — `kb-bulk` collection, `bulk` scope resolver, parser known-collection list.
- **git-exporter** — source-aware `getActiveDirectory` routing (`bulk_import` → `bulk/`).
- **curator** — `upgrade-policy` subcommand + contradiction-lookup rewire.
- **api / mcp-server** — `bulk` scope surface + SQLite-fallback source scoping.
- **eval-surface** — contradiction-lookup rewire.

## How it works

`upgrade-policy` reads the tenant's enabled policy, computes `findUncoveredRuleTypes`, and — unless already complete — replaces the rules with `RECOMMENDED_POLICY_RULES` (version bumped) while appending a `policy_upgraded` receipt carrying the previous rules, both in one SQLite transaction. Bulk memories carry `source: bulk_import` from candidate through promotion into `CuratedMemory`; the exporter's `getActiveDirectory` sends them to `bulk/`, which the qmd-adapter registers as the non-default `kb-bulk` collection, excluded from the `curated` default scope.

## Verification & evidence

- `pnpm -r build` — pass; `pnpm -r typecheck` — pass; `pnpm -r test` — **all green** (api 25, curator 23, store 26, qmd-adapter 30+1 skipped, policy-engine 12, schema 8, git-exporter 9, edge-daemon 12, eval-surface 4, reporting 7, common 9, claude-runtime 15, repo-resolver 5 test files).
- `pnpm format` clean · `eslint` clean · `depcruise` **0 errors** (4 pre-existing orphan-source warnings).
- New tests: `upgrade-policy` (5 cases — upgrade/create/no-op/dry-run + receipt shape + reversible previous rules + chain re-verifies), bulk routing (`directory-mapper.test.ts`, `search.test.ts` scope cases), Unicode contradiction (Cyrillic match / CJK non-match), `findByTenantAndLifecycleAndCategory`, bulk low-trust schema refusal, `kb-bulk` registry counts.
- **C10 tripwire:** `scripts/verify-policy-hash.sh --verify` → `OK` after in-commit `--init`.

## Risk assessment

- The bulk low-trust refine **rejects** a `bulk_import` candidate lacking an explicit low/untrusted stamp — intended fail-closed; requires ICO's emitter to stamp bulk digestions. No live rows affected (new source).
- `upgrade-policy` mutates a store's governance policy — reversible (receipt carries previous rules), gated behind an explicit CLI call + `--dry-run`, runs only when invoked, and does **not** touch `~/.teamkb` here.

## Operational impact

None automatic. `upgrade-policy` is an operator command; applying it to the live brain is a separate, deliberate step (out of scope for this PR).

## Follow-up & deferred

- `5bm.5` secondary: the dead `inbox` SearchScope value is left in place (kb-inbox is a documented scope surface; removing it is out of scope).
- Coordinate ICO emitter to stamp `bulk_import` with low trust before any bulk digestion is spooled.

## Governance links

Epic `qmd-team-intent-kb-5bm` · GH #259.

- Jeremy Longshore
intentsolutions.io

**Refs:** bead qmd-team-intent-kb-5bm (ontology-axes epic)

---

**Update (owner ruling on the adversarial NEEDS-OWNER-DECISION):** the CHANGELOG's `Added` section now lists only what is genuinely new in this PR — the `curator upgrade-policy` command (`5bm.2`) and the `kb-bulk` collection + `bulk` scope (`5bm.8`). The bulk low-trust schema stamp, the Unicode tokenizer, and the category-scoped lookup are under `Changed`. The verify-only children (`5bm.3`/`.4`/`.5`/`.6`/`.7`) were **removed from the changelog** — they were delivered by prior PRs and are not this PR's additions; their verify-only status stays documented in the status table above, not framed as changelog additions here.

**Migration story for the `bulk_import` low-trust refine:** any pre-PR `bulk_import` candidate stamped `medium` under the old emitter convention now **fails closed** at re-validation. This is intended — it surfaces a mis-stamped digestion loudly rather than admitting it — and is **not** silent dropping: such a row is corrected via the governed recategorization/curation tooling (or a one-shot re-stamp to low), then re-ingested. The durable fix is the deferred coordination to have ICO's emitter stamp `bulk_import` low at capture time (Follow-up above); until then, bulk digestions must carry an explicit low/untrusted stamp. Documented at the refine site (`packages/schema/src/memory-candidate.ts`) and in the CHANGELOG `Changed` bullet.