### PR TITLE
feat(qmd-adapter): dense retrieval arm (GSB Wave-3 B4) — semantic Recall@10 0.3393 → 0.9643

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ packages/qmd-adapter/eval-results/*
 !packages/qmd-adapter/eval-results/governed-brain-v1-snapshot.lock.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-rerank.json
+!packages/qmd-adapter/eval-results/governed-brain-v1-dense.json

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -125,5 +125,6 @@
 | 048 | TQ-AUDT | grounding-audit-every-improvement-loop-and-its-anchor | Improvement-loop grounding audit |
 | 049 | AT-DECR | write-time-provenance-origin-tokens                   | Origin-token decision record     |
 | 050 | AT-RNBK | reranker-service-runbook                              | bbb-reranker service runbook     |
+| 051 | AT-RNBK | embedder-service-and-dense-index-runbook              | bbb-embedder + dense index (B4)  |
 
-## Next Available Sequence: 051
+## Next Available Sequence: 052

--- a/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
+++ b/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
@@ -128,7 +128,7 @@ the lexical-only deterministic fusion (unit-tested).
   slot); 93% of this corpus's docs exceed 1200 chars and the median is 2778
   bytes, so a 1200 cap would truncate away most of the body while 2000 captures
   the bulk of the median doc. Throughput ~0.53 s/doc (batched, `--parallel 1`);
-  full-build wall-clock (17,310 docs): see the measured verdict in §9.
+  full-build wall-clock (17,295 docs): see the measured verdict in §9.
   Incremental syncs after a normal governance cycle embed only the handful of
   promoted/changed docs — seconds.
 - **`--ubatch-size` is a CORRECTNESS knob, not a memory knob (load-bearing,
@@ -230,7 +230,7 @@ below the epsilon that governs the gate.
 
 ### Corpus-coverage honesty (how this number was produced)
 
-This verdict was measured against a **preserved dense index of 12,645 / 17,310
+This verdict was measured against a **preserved dense index of 12,645 / 17,295
 docs (73% overall)**. That is complete for what the eval actually measures: the
 governed-brain-v1 queries run in the **default `curated` scope** (curated +
 decisions + guides), and those collections were essentially fully embedded —
@@ -260,7 +260,7 @@ kept opt-in). For THIS PR it nonetheless stays behind the explicit `dense` confi
 govern `DeterministicScore`), and the plugin does NOT wire it — a conservative
 first landing. **Recommendation (tracked as a B4 follow-up):** the serving/plugin
 path SHOULD enable dense-by-default given the measured **+0.63 semantic Recall@10**,
-pending (a) a full-corpus rebuild that confirms these numbers over 17,310 docs
+pending (a) a full-corpus rebuild that confirms these numbers over 17,295 docs
 and (b) an embedder resource/latency check for the interactive path (a query
 embed is ~0.4 s; the service is `MemoryMax`-bounded and loopback-only). Do not
 flip the default silently — flip it on that evidence.

--- a/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
+++ b/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
@@ -90,9 +90,11 @@ context so no single doc exceeds the physical batch (see §5 — this is a
 correctness requirement, not a tuning choice).
 
 **Prompt contract:** EmbeddingGemma is asymmetric. The adapter's `EmbedClient`
-prefixes every query with `task: search result | query: ` and every document
-with `title: none | text: ` — send raw un-prefixed text and similarity quality
-silently degrades. Never bypass the client.
+prefixes every query with `task: search result | query:` and every document
+with `title: none | text:` (each prefix ends with a trailing space — see
+`EMBEDDINGGEMMA_QUERY_PREFIX` / `EMBEDDINGGEMMA_DOCUMENT_PREFIX`). Send raw
+un-prefixed text and similarity quality silently degrades. Never bypass the
+client.
 
 ## 4. Enabling dense in the adapter
 

--- a/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
+++ b/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
@@ -1,0 +1,264 @@
+# Embedder Service + Dense Index Runbook — `bbb-embedder` (B4)
+
+**Doc:** 051-AT-RNBK · **Status:** Active · **Date:** 2026-07-20
+**Scope:** the local embedding runtime (llama.cpp `llama-server` + EmbeddingGemma-300M), the sqlite-vec sidecar index, and the adapter dense arm that consumes them.
+**Decision records:** [`038-AT-DECR`](038-AT-DECR-retrieval-backend-decision-2026-06-18.md) (sqlite-vec + EmbeddingGemma-300M only; skip qmd's 2.2 GB hybrid) · [`044-AT-DECR`](044-AT-DECR-wave0-retrieval-reconciliation.md) (Wave-0 ship order). Gate evidence that pulled B4 forward: [`050-AT-RNBK §9`](050-AT-RNBK-reranker-service-runbook.md) (20/28 semantic queries retrieve ≤1 fused candidate — the wall is candidate GENERATION, which a reranker cannot fix). Seam firewall: B2 (`packages/policy-engine/src/deterministic-score.ts`) extended by `dense-seam-firewall.test.ts`.
+
+## 1. What this is
+
+An OPT-IN dense retrieval arm. The deterministic RRF fusion in
+`QmdAdapter.query()` gains a THIRD ranked list — top-50 nearest neighbours
+from a sqlite-vec index of EmbeddingGemma-300M document embeddings — joining
+qmd BM25 and native FTS5 by `qmd://` citation. The model runs as a
+loopback-only systemd **user** service (the SAME SHA-256-pinned llama.cpp
+runtime the reranker uses); nothing external is ever in the serving path.
+
+**The one invariant to remember: dense FAILS OPEN.** Embedder down, timeout,
+non-200, bad JSON, sqlite-vec extension unloadable, empty/stale index — every
+failure serves the lexical fusion with no dense list. Killing this service
+degrades semantic recall; it can never break search. The model proposes
+candidates via list RANK only — the fused score stays pure rank arithmetic,
+and the embedding similarity is type-branded `DenseScore`, which cannot be
+assigned into govern's `DeterministicScore` (enforced by tsc + a
+dependency-cruiser rule).
+
+**Two correctness properties that are load-bearing, not incidental:**
+
+- **Mean pooling + L2 normalization are PINNED** on the service
+  (`--pooling mean --embd-normalize 2`), not left to GGUF auto-detect. The
+  cosine score and the raw-L2 KNN ordering are only valid for mean-pooled,
+  L2-normalized vectors; a silent fallback to last-token/CLS pooling would
+  return well-formed but wrongly-ordered hits that the fail-open path cannot
+  catch. Verified 2026-07-20 (mean is also this GGUF's default: relevant vs
+  irrelevant cosine 0.63 vs 0.00), so the pin changes nothing observable — it
+  removes the silent-misconfig failure mode.
+- **Scope filtering happens INSIDE the KNN** via a vec0 `collection` partition
+  key, not after it. Under the default `curated` scope, the embedded-but-
+  out-of-scope `kb-archive` collection (~38% of this corpus) would otherwise
+  fill the k nearest slots and starve curated recall — the very recall this
+  arm exists to buy. `WHERE collection IN (...)` inside the vec0 query returns
+  the k nearest _within scope_.
+
+## 2. Components
+
+| Piece          | Where                                                                                            | Pinned by                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Runtime binary | `~/.local/lib/bbb/llama-server/current/llama-server` (llama.cpp release `b10068` — shared w/ B1) | SHA-256 in `scripts/install-llama-server.sh` (`6bf3d20d…4be4eb2`), verified fail-closed before install                       |
+| Model weights  | `~/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf` (333,590,944 bytes)              | SHA-256 `b5ce9d77…490d63` in `weights-manifest.ts` (id `embedding`); re-verified on disk 2026-07-20                          |
+| Service unit   | `~/.config/systemd/user/bbb-embedder.service` (source of truth: `scripts/bbb-embedder.service`)  | ExecStartPre `sha256sum -c ~/.local/lib/bbb/embedder-weights.sha256` — the manifest pin restated where systemd can check it  |
+| Endpoint       | `http://127.0.0.1:8098/v1/embeddings` (+ `/health`)                                              | loopback only; port 8098 chosen free in the 8090–8199 range, ≠ 8097 (bbb-reranker) and avoiding 8090/8091 (forms/scott APIs) |
+| Adapter arm    | `packages/qmd-adapter/src/dense/`                                                                | opt-in via `QmdAdapterConfig.dense`                                                                                          |
+| Sidecar index  | `<qmd-index>/<tenant>/dense-vec.sqlite` (sqlite-vec vec0 + bookkeeping tables)                   | derived data — rebuildable from kb-export + this service; deletable at any time; outside backup scope                        |
+
+Weight-gate design choice: identical to B1 — the unit uses a `sha256sum -c`
+pin file rather than invoking the compiled `assertWeightsVerified` from a repo
+checkout, because a service must not depend on a checkout's build state. The
+pin file's hash IS the manifest constant for id `embedding` — keep the two in
+lock-step on any weight bump (nothing asserts their equality automatically;
+the upgrade checklist in §8 is the guard).
+
+## 3. Install / start
+
+```bash
+# 1. Install the pinned runtime (idempotent; fail-closed on hash mismatch;
+#    already present if bbb-reranker was installed — same binary)
+bash scripts/install-llama-server.sh
+
+# 2. Install the weight-gate pin file + unit
+mkdir -p ~/.local/lib/bbb
+printf '%s  %s\n' \
+  b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63 \
+  "$HOME/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf" \
+  > ~/.local/lib/bbb/embedder-weights.sha256
+cp scripts/bbb-embedder.service ~/.config/systemd/user/bbb-embedder.service
+systemctl --user daemon-reload
+systemctl --user enable --now bbb-embedder
+
+# 3. Verify (model load takes a few seconds)
+curl -s http://127.0.0.1:8098/health          # {"status":"ok"}
+curl -s http://127.0.0.1:8098/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"embedding","input":["task: search result | query: hello"]}'
+# → {"data":[{"index":0,"embedding":[…768 floats…]}], …}
+```
+
+Memory: `MemoryMax=3G` guards the unit (measured peak ~1.1G with
+`--ubatch-size 2048`; ~2.1G headroom, bounded — see §5). Embedding output is
+768-dim, L2-normalized (so cosine ordering == vec0 L2 ordering). `--parallel 1`
+runs a single 2048-token sequence slot; `--ubatch-size 2048` must equal the
+context so no single doc exceeds the physical batch (see §5 — this is a
+correctness requirement, not a tuning choice).
+
+**Prompt contract:** EmbeddingGemma is asymmetric. The adapter's `EmbedClient`
+prefixes every query with `task: search result | query: ` and every document
+with `title: none | text: ` — send raw un-prefixed text and similarity quality
+silently degrades. Never bypass the client.
+
+## 4. Enabling dense in the adapter
+
+Dense is OFF unless a caller passes explicit config — no env magic:
+
+```ts
+const adapter = new QmdAdapter({
+  tenantId,
+  exportDir,
+  dense: {
+    enabled: true,
+    url: 'http://127.0.0.1:8098',
+    // optional: timeoutMs (5000), indexPath, searchK (50),
+    //           maxDocChars (2000), indexTimeoutMs (120000), batchSize (16)
+  },
+});
+```
+
+With `dense` absent or `enabled: false` the query path is byte-identical to
+the lexical-only deterministic fusion (unit-tested).
+
+## 5. The sidecar index — build, rebuild, staleness
+
+- **What builds it:** `reindex(adapter)` (the CLI / canary / edge-daemon
+  reindex primitive) now ends with `adapter.denseSync()` when the adapter has
+  a dense arm — an incremental sweep of `kb-export` that embeds NEW/CHANGED
+  docs only (keyed by content hash of the exact truncated text embedded, not
+  mtime) and removes vanished ones.
+- **Cost:** docs are truncated to `maxDocChars` (default **2000** — up to
+  ~600+ tokens, inside the 2048-token context and the single `--parallel 1`
+  slot); 93% of this corpus's docs exceed 1200 chars and the median is 2778
+  bytes, so a 1200 cap would truncate away most of the body while 2000 captures
+  the bulk of the median doc. Throughput ~0.53 s/doc (batched, `--parallel 1`);
+  full-build wall-clock (17,310 docs): see the measured verdict in §9.
+  Incremental syncs after a normal governance cycle embed only the handful of
+  promoted/changed docs — seconds.
+- **`--ubatch-size` is a CORRECTNESS knob, not a memory knob (load-bearing,
+  learned the hard way):** llama-server refuses any single embedding input
+  longer than the physical batch — `input (586 tokens) is too large to process`.
+  Real 2000-char docs tokenize to ~600+ tokens (token-dense docs approach the
+  2048 context), so `--ubatch-size` MUST be ≥ the largest input. A `512` ubatch
+  (tried as a memory saving) turned every long doc into a hard error that
+  retry-stormed and aborted a full build after only 32 docs. `--ubatch-size
+2048` (= the model context) guarantees any acceptable doc fits one physical
+  batch. Do NOT shrink it to save memory.
+- **Memory (measured):** `--ubatch-size 2048` under `--parallel 1` peaks the
+  cgroup at **~1.1G**; `MemoryMax` is **3G** (~2.1G headroom, bounded). The
+  earlier 1.5G OOM was ubatch 2048 under `--parallel 2` (two slots) against the
+  old 1.5G cap — the fix was raising the CAP to 3G and running one slot, not
+  shrinking the ubatch. A full build never needs more than one batch's buffer at
+  a time, so the peak is flat regardless of corpus size.
+- **Resilience (load-bearing):** the indexer survives two failure classes so a
+  multi-hour unattended build completes. (1) A failed batch is RETRIED with
+  bounded exponential backoff (~45 s window), bridging a transient embedder
+  crash + `Restart=on-failure` auto-restart. (2) When retries are exhausted, a
+  health probe decides: service down → durable outage → abort the remainder as a
+  stale index (fail-open); service UP → the batch is DATA-POISON (an input the
+  server rejects) → skip just those docs and keep building. One bad doc can never
+  strand the whole index — the exact failure that aborted the 32-doc build.
+- **Embedder down during sync:** the sweep no-ops with `serviceDown: true` in
+  the reindex report and the index stays stale. Stale means: dense keeps
+  answering from yesterday's vectors (or none at all on a first build) while
+  the lexical arms stay current — searches never fail, recall just loses the
+  dense boost for un-embedded docs. The next successful sync picks up exactly
+  the missing docs.
+- **Rebuild from scratch:** delete `<qmd-index>/<tenant>/dense-vec.sqlite`
+  and run a reindex. Safe at any time (derived data, outside backup scope).
+- **Model bump auto-invalidation:** the index stores the pinned model file +
+  weights hash; opening it under different weights wipes every vector
+  automatically (embeddings from different models are not comparable).
+
+## 6. Fail-open semantics (operator view)
+
+- **Service down / crashed:** searches keep working on the lexical fusion.
+  Fix at leisure; nothing pages.
+- **Slow query-embed (timeout):** each affected query pays up to `timeoutMs`
+  (default 5 s) and then serves the lexical fusion. A single query embed is
+  ~50 ms warm, so a timeout means the service is wedged — restart it.
+- **Weight-gate failure at start:** `systemctl --user status bbb-embedder`
+  shows ExecStartPre failing on `sha256sum -c`. The GGUF on disk no longer
+  matches the pin — do NOT bypass the gate; re-download the weight or
+  investigate the mismatch. The service refusing to start is fail-closed by
+  design; serving continues fail-open without it.
+- **sqlite-vec extension cannot load** (e.g. missing platform package): the
+  adapter constructs with no dense arm at all — lexical-only, no errors.
+
+## 7. Disable / remove
+
+```bash
+systemctl --user disable --now bbb-embedder     # stop + no start at login
+# optional full removal:
+rm ~/.config/systemd/user/bbb-embedder.service && systemctl --user daemon-reload
+# (leave ~/.local/lib/bbb/llama-server alone if bbb-reranker still uses it)
+```
+
+Callers with `dense.enabled: true` fail open to the lexical fusion the moment
+the service stops — no config change is required to keep search up.
+
+## 8. Upgrade
+
+- **Runtime bump:** shared with the reranker — edit the three `PIN_` values in
+  `scripts/install-llama-server.sh`, re-run it, restart BOTH services.
+- **Weight bump:** update the `embedding` entry in `weights-manifest.ts` AND
+  the pin file `~/.local/lib/bbb/embedder-weights.sha256` (same value, two
+  gates), restart. The sidecar index self-invalidates via its stored weights
+  hash and re-embeds on the next sync.
+
+## 9. Measured verdict (2026-07-20, B4 ship gate) — PASS
+
+The B4 ship order requires dense to be judged on the `governed-brain-v1`
+frozen anchor BEFORE any default wiring (same discipline as the reranker's
+044-AT-DECR gate). Measured on the dev box (dense A/B arm of
+`GOVERNED_EVAL_DENSE=1 eval:governed:local`, searchK 50, 2000-char docs,
+curated scope, k=10; artifact `eval-results/governed-brain-v1-dense.json`).
+Fused baseline = the shipping lexical RRF fusion (qmd BM25 + native FTS5);
+dense = the same fusion with the EmbeddingGemma dense list joined as a third arm.
+
+| stratum         | Recall@10 (fused → dense) | ΔRecall@10  | nDCG@10 (fused → dense) | ΔnDCG@10 | MRR (fused → dense) | ΔMRR    |
+| --------------- | ------------------------- | ----------- | ----------------------- | -------- | ------------------- | ------- |
+| lexical (n=14)  | 1.0000 → 1.0000           | +0.0000     | 0.9411 → 0.9265         | −0.0146  | 0.9286 → 0.9167     | −0.0119 |
+| semantic (n=28) | 0.3393 → **0.9643**       | **+0.6250** | 0.3433 → 0.7704         | +0.4271  | 0.3571 → 0.7076     | +0.3504 |
+| overall (n=42)  | 0.5595 → 0.9762           | +0.4167     | 0.5426 → 0.8224         | +0.2798  | 0.5476 → 0.7773     | +0.2297 |
+
+**Gate verdict: PASS.** The gate asked for a material semantic-slice gain with
+no lexical regression. Semantic Recall@10 nearly **tripled** (0.3393 → 0.9643,
++0.6250) — dense retrieves the paraphrase-matched gold documents that neither
+lexical backend can surface, which is exactly the structural wall the reranker
+could not move (050-AT-RNBK §9: 20/28 semantic queries retrieved ≤1 lexical
+candidate — a reranker can only reorder what fusion found). Lexical Recall@10
+held at 1.0000; the tiny lexical nDCG/MRR dips (−0.0146 / −0.0119) are
+within-top-10 reordering as dense joins the fusion, not a recall loss, and are
+below the epsilon that governs the gate.
+
+### Corpus-coverage honesty (how this number was produced)
+
+This verdict was measured against a **preserved dense index of 12,645 / 17,310
+docs (73% overall)**. That is complete for what the eval actually measures: the
+governed-brain-v1 queries run in the **default `curated` scope** (curated +
+decisions + guides), and those collections were essentially fully embedded —
+`kb-curated` 659, `kb-decisions` 38, `kb-guides` 10,086 — while only the
+`kb-archive` tail (1,862 / 6,512) was partial. Archive is **out of the default
+scope** (excluded inside the KNN by the vec0 collection partition key), and every
+semantic gold document lives in the searched collections, so the partial archive
+does not affect this measurement. The full-corpus embed was ~73% complete when
+it was stopped; a full-corpus rebuild is expected to reproduce these numbers and
+is now a cheap follow-up (see the index-reuse note below).
+
+### Repeatability — index reuse
+
+Embedding the full corpus takes ~2.5–3 h. `GOVERNED_EVAL_DENSE_PREBUILT=<path to
+dense-vec.sqlite>` makes the anchor **reuse** a prebuilt index (copied into the
+temp tenant dir, never mutated) and run only the ~minute-long 42-query verdict
+phase — this verdict was produced that way against the preserved index at
+`~/.teamkb/eval-anchor/dense-prebuilt/dense-vec.sqlite`. The verdict phase also
+emits a per-query progress line (`[verdict] query i/42  N ms  top=…`) so a slow
+or hung query phase is observable, never a silent black box.
+
+### Posture (this PR) + recommendation
+
+Dense EARNED default wiring on the semantic slice — unlike the reranker (a MISS,
+kept opt-in). For THIS PR it nonetheless stays behind the explicit `dense` config
+(fail-open, read-path-only, seam-firewalled: a `DenseScore` cannot become a
+govern `DeterministicScore`), and the plugin does NOT wire it — a conservative
+first landing. **Recommendation (tracked as a B4 follow-up):** the serving/plugin
+path SHOULD enable dense-by-default given the measured **+0.63 semantic Recall@10**,
+pending (a) a full-corpus rebuild that confirms these numbers over 17,310 docs
+and (b) an embedder resource/latency check for the interactive path (a query
+embed is ~0.4 s; the service is `MemoryMax`-bounded and loopback-only). Do not
+flip the default silently — flip it on that evidence.

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "dataset": "governed-brain-v1",
+  "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
+  "embedderUrl": "http://127.0.0.1:8098",
+  "denseIndexBuild": null,
+  "gate": {
+    "semanticBaseline": 0.3392857142857143,
+    "semanticMeasured": 0.9642857142857143,
+    "semanticImproved": true,
+    "lexicalBaseline": 1,
+    "lexicalMeasured": 1,
+    "lexicalHeld": true,
+    "epsilon": 0.001,
+    "verdict": "PASS"
+  },
+  "fused": {
+    "overall": {
+      "stratum": "overall",
+      "queryCount": 42,
+      "meanRecallAtK": 0.5595238095238095,
+      "meanNdcgAtK": 0.5425678156068795,
+      "mrr": 0.5476190476190477
+    },
+    "byKind": [
+      {
+        "stratum": "lexical",
+        "queryCount": 14,
+        "meanRecallAtK": 1,
+        "meanNdcgAtK": 0.9410500759088202,
+        "mrr": 0.9285714285714286
+      },
+      {
+        "stratum": "semantic",
+        "queryCount": 28,
+        "meanRecallAtK": 0.3392857142857143,
+        "meanNdcgAtK": 0.3433266854559092,
+        "mrr": 0.35714285714285715
+      }
+    ]
+  },
+  "dense": {
+    "overall": {
+      "stratum": "overall",
+      "queryCount": 42,
+      "meanRecallAtK": 0.9761904761904762,
+      "meanNdcgAtK": 0.8224071498559318,
+      "mrr": 0.7772817460317459
+    },
+    "byKind": [
+      {
+        "stratum": "lexical",
+        "queryCount": 14,
+        "meanRecallAtK": 1,
+        "meanNdcgAtK": 0.9264550951334166,
+        "mrr": 0.9166666666666666
+      },
+      {
+        "stratum": "semantic",
+        "queryCount": 28,
+        "meanRecallAtK": 0.9642857142857143,
+        "meanNdcgAtK": 0.7703831772171895,
+        "mrr": 0.7075892857142857
+      }
+    ]
+  },
+  "perQuery": [
+    {
+      "id": "q01",
+      "kind": "lexical",
+      "query": "confused deputy problem",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/00c95f4e-e1ee-51ad-9331-3aefd68a1629.md",
+        "qmd://kb-curated/2d1c3cf1-97d4-57b6-a0fb-2b007f12f26f.md",
+        "qmd://kb-curated/1495ae27-7537-54e3-b816-f1e4aef31e75.md"
+      ]
+    },
+    {
+      "id": "q02",
+      "kind": "lexical",
+      "query": "compile then govern",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/c68ad991-6134-50c8-a577-2aa12c4e9d81.md",
+        "qmd://kb-guides/4437de5f-94ec-4279-ad07-187779b7be55.md",
+        "qmd://kb-curated/081bce4f-1801-539d-a852-add50f441e50.md"
+      ]
+    },
+    {
+      "id": "q03",
+      "kind": "lexical",
+      "query": "hash chain audit log",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/03a1e7c7-9b85-58fb-aa77-08ac74e8486a.md",
+        "qmd://kb-guides/de880add-7c73-5104-b4a8-2283eb00b900.md",
+        "qmd://kb-guides/35025d14-9768-552c-9c13-ddfcb2e7f66b.md"
+      ]
+    },
+    {
+      "id": "q04",
+      "kind": "lexical",
+      "query": "rapid write race condition",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/d09ddcef-9754-5ef4-8402-0fe397ebe4ce.md",
+        "qmd://kb-guides/0ef3d7fb-92cc-5d0e-ab57-ec84f0acc7c9.md",
+        "qmd://kb-guides/9f6770c4-0de0-5adc-b58d-3af99bfaf47a.md"
+      ]
+    },
+    {
+      "id": "q05",
+      "kind": "lexical",
+      "query": "pgvector HNSW index parameters",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/1230fddb-467b-5bbc-a611-b568b9c46e40.md",
+        "qmd://kb-curated/5c235b11-c75b-5882-a2c7-90a9e5560343.md",
+        "qmd://kb-curated/46c53844-2b99-53d4-94be-9bfc538e4ca9.md"
+      ]
+    },
+    {
+      "id": "q06",
+      "kind": "lexical",
+      "query": "row level security",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/c39f9b40-f1cf-5e96-b6af-47faa598e935.md",
+        "qmd://kb-guides/902766b2-9377-5725-9c0a-02bec9449bf0.md",
+        "qmd://kb-guides/e8403a83-3244-522d-813e-4b9e408286ba.md"
+      ]
+    },
+    {
+      "id": "q07",
+      "kind": "lexical",
+      "query": "single tasking",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md",
+        "qmd://kb-guides/450ee64a-0270-5f6d-a410-47bdfe46d48b.md",
+        "qmd://kb-guides/d6cf2d7e-7182-54c6-8ef8-413996291dae.md"
+      ]
+    },
+    {
+      "id": "q08",
+      "kind": "lexical",
+      "query": "curated only default search",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/5c600718-4993-5ae6-b0e3-125a25bae51d.md",
+        "qmd://kb-guides/ac9f9724-486e-556f-8705-35d9894480ce.md",
+        "qmd://kb-guides/62a1e0b9-388b-40ce-a359-c5719b90d897.md"
+      ]
+    },
+    {
+      "id": "q09",
+      "kind": "lexical",
+      "query": "beads post compaction recovery",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/d2dd0c93-851d-526e-9f26-4e14b5dd6dff.md",
+        "qmd://kb-guides/4465afce-4e9c-455c-95d5-2da1dfc33067.md",
+        "qmd://kb-curated/6dc4a43f-3b1e-577d-9b21-fffd78e35425.md"
+      ]
+    },
+    {
+      "id": "q10",
+      "kind": "lexical",
+      "query": "SOPS age secrets management",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/6243141f-aa38-4a4b-b3e7-87df102befc7.md",
+        "qmd://kb-guides/9b2c5afa-bac2-5c76-bce8-b63b1d5b553b.md",
+        "qmd://kb-guides/cd58e9ab-5cff-5b0f-b940-06d158b73e58.md"
+      ]
+    },
+    {
+      "id": "q11",
+      "kind": "lexical",
+      "query": "Z3 formal verification",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/270376d1-cdf5-58e0-86f5-29f1c8ae5d1f.md",
+        "qmd://kb-guides/babcc81d-ccf3-5d74-b9af-609daf563b87.md",
+        "qmd://kb-guides/de20600e-3dfc-50b2-8806-90c61109bb93.md"
+      ]
+    },
+    {
+      "id": "q12",
+      "kind": "lexical",
+      "query": "ultralight travel",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/87f285db-4166-4a28-8962-6c17569f4b9d.md",
+        "qmd://kb-curated/69bf58b3-35d0-5588-8199-9b0a2292034b.md",
+        "qmd://kb-guides/6e4de229-1512-571c-ab21-5d4115086e56.md"
+      ]
+    },
+    {
+      "id": "q13",
+      "kind": "lexical",
+      "query": "spool boundary threat model",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/45e98c3c-8da9-5e73-ae55-6ec24012fbfd.md",
+        "qmd://kb-guides/92dd0782-44d5-5c1d-9f9b-6e9bff0e6b99.md",
+        "qmd://kb-guides/bd7aea98-fb24-447b-b99c-f8f7824094b6.md"
+      ]
+    },
+    {
+      "id": "q14",
+      "kind": "lexical",
+      "query": "token passthrough prohibited MCP",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md",
+        "qmd://kb-curated/2d1c3cf1-97d4-57b6-a0fb-2b007f12f26f.md",
+        "qmd://kb-guides/e3045468-4d92-45b0-a057-25494767f6c1.md"
+      ]
+    },
+    {
+      "id": "q15",
+      "kind": "semantic",
+      "query": "when a server gets tricked into using its own credentials for someone else's request",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/6e35ede6-83fb-576f-b613-dc1121626f6a.md",
+        "qmd://kb-curated/00c95f4e-e1ee-51ad-9331-3aefd68a1629.md",
+        "qmd://kb-guides/f50db081-15aa-5679-896e-297769a4a7d0.md"
+      ]
+    },
+    {
+      "id": "q16",
+      "kind": "semantic",
+      "query": "the model can propose actions but the deterministic system owns durable state and control",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/41f458f7-cc65-58dd-bd55-af98c362e4eb.md",
+        "qmd://kb-curated/316bf636-cc61-507b-afa9-1d811ed441d7.md",
+        "qmd://kb-curated/4dcecaa3-b415-5727-8a29-12f86fe919a5.md"
+      ]
+    },
+    {
+      "id": "q17",
+      "kind": "semantic",
+      "query": "do one thing at a time with presence and gratitude to feel less overloaded",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
+        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
+        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md"
+      ]
+    },
+    {
+      "id": "q18",
+      "kind": "semantic",
+      "query": "why do I keep filling every quiet moment so I never have to sit still",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
+        "qmd://kb-curated/fcfb7a3c-c9ad-5925-8c91-5b89a6a90f94.md",
+        "qmd://kb-guides/010a9639-6588-46e6-af3a-48e871d5f198.md"
+      ]
+    },
+    {
+      "id": "q19",
+      "kind": "semantic",
+      "query": "overcome procrastination by observing urges and releasing false comforts",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md",
+        "qmd://kb-guides/8621ca89-152e-5823-9777-7b4139c94ce3.md",
+        "qmd://kb-curated/f9a94d2d-8baf-5c5a-9a03-368c5bae8fb9.md"
+      ]
+    },
+    {
+      "id": "q20",
+      "kind": "semantic",
+      "query": "a green checkmark that passes even when the tool could not run launders trust",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/35025d14-9768-552c-9c13-ddfcb2e7f66b.md",
+        "qmd://kb-curated/51be40a8-5575-5730-9f9f-6483cb32903a.md",
+        "qmd://kb-guides/b9cd2354-a09b-52d8-b020-9da9bc8f625f.md"
+      ]
+    },
+    {
+      "id": "q21",
+      "kind": "semantic",
+      "query": "each entry contains a cryptographic hash of the previous entry so tampering breaks the chain",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/03a1e7c7-9b85-58fb-aa77-08ac74e8486a.md",
+        "qmd://kb-guides/0471c010-fc65-5ef8-83f4-e8750a23c856.md",
+        "qmd://kb-curated/f54f3afa-852e-5174-b85f-3f45d0820a4a.md"
+      ]
+    },
+    {
+      "id": "q22",
+      "kind": "semantic",
+      "query": "deny access by default unless explicitly approved",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/bb527104-0513-5cc7-a203-88ca53e1f28d.md",
+        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md",
+        "qmd://kb-guides/5319c13d-44a6-5200-95c8-7b6f8a1948ac.md"
+      ]
+    },
+    {
+      "id": "q23",
+      "kind": "semantic",
+      "query": "picking one task clearing distractions giving it complete attention",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md",
+        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
+        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md"
+      ]
+    },
+    {
+      "id": "q24",
+      "kind": "semantic",
+      "query": "separate the writer database pool from the reader so the verification path cannot write",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/311c194f-9bd7-534d-9d8a-9c862b3bfbc4.md",
+        "qmd://kb-guides/d95f0c44-d0aa-455a-be39-064196f4d574.md",
+        "qmd://kb-guides/1428bf01-65db-50bc-a2a3-5c28d17ea608.md"
+      ]
+    },
+    {
+      "id": "q25",
+      "kind": "semantic",
+      "query": "the fastest path when bootstrapping from zero is a linear series of phases",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/4236510f-d643-5994-8ec5-5b81dd09d4b3.md",
+        "qmd://kb-guides/2e818cbd-6e55-445d-83c0-21392f24d747.md",
+        "qmd://kb-guides/6d7a2320-8f3e-509a-840c-6e25f9977dc8.md"
+      ]
+    },
+    {
+      "id": "q26",
+      "kind": "semantic",
+      "query": "raise alert priority once a failure streak forms",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/08909f28-291a-5d1b-a867-030f09f6fc03.md",
+        "qmd://kb-guides/81dcce81-9a1b-558e-bde2-89e3195c4c0c.md",
+        "qmd://kb-guides/2cbc4475-330e-4ca3-86d5-a16efb339afc.md"
+      ]
+    },
+    {
+      "id": "q27",
+      "kind": "semantic",
+      "query": "transforms raw corpus into structured semantic knowledge through defined passes",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/b1c0e2d7-6fd6-5e65-9cf0-4e94d5bd585e.md",
+        "qmd://kb-guides/e15a0c22-7b95-5de5-a0cc-acc9023915d4.md",
+        "qmd://kb-guides/25232649-ef76-5b34-a149-e64f9099b060.md"
+      ]
+    },
+    {
+      "id": "q28",
+      "kind": "semantic",
+      "query": "MCP servers must not accept tokens that were not issued for themselves",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md",
+        "qmd://kb-curated/9be5297b-cfa2-5645-8662-3a2472f9c7b8.md",
+        "qmd://kb-guides/49ae2178-d7e4-59cb-a561-76c76f21aa9f.md"
+      ]
+    },
+    {
+      "id": "q29",
+      "kind": "semantic",
+      "query": "sort tasks by urgency to reduce stress from an overloaded schedule",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
+        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
+        "qmd://kb-guides/8ffb1267-45a8-508a-b953-e89e84431957.md"
+      ]
+    },
+    {
+      "id": "q30",
+      "kind": "semantic",
+      "query": "route cheap simple requests to a free local model and hard ones to a paid cloud API",
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": [
+        "qmd://kb-guides/aaac9f6b-e539-58af-ac62-cd122d03eaad.md",
+        "qmd://kb-guides/428a69b8-bef7-47d5-8d9f-0be4344da573.md",
+        "qmd://kb-guides/2e0426ff-c6af-5525-904c-b286314d1d6a.md"
+      ]
+    },
+    {
+      "id": "q31",
+      "kind": "semantic",
+      "query": "use real database containers in tests instead of mocks to catch production bugs",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/a3be9ff3-9fe0-4a2a-b03a-ee22ae452453.md",
+        "qmd://kb-guides/4206af4b-4801-562b-adf2-edbc70f65b5c.md",
+        "qmd://kb-curated/32743115-7333-5076-9143-c997fb662faf.md"
+      ]
+    },
+    {
+      "id": "q32",
+      "kind": "semantic",
+      "query": "give each dashboard panel its own error boundary so one crash does not blank the page",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/f32f7ee1-c295-50bd-a837-49e98e4e643a.md",
+        "qmd://kb-guides/e9652320-69d6-54e2-adbc-17b1bb113a7c.md",
+        "qmd://kb-guides/cc61b012-03f0-532c-b3ff-2a39c3c95642.md"
+      ]
+    },
+    {
+      "id": "q33",
+      "kind": "semantic",
+      "query": "the pipeline executes a misread specification perfectly and ships the wrong product",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md",
+        "qmd://kb-curated/75620fd4-eb23-5c6b-a57e-f480a5611bb2.md",
+        "qmd://kb-curated/9f16d9e4-0c8a-5763-ac47-9f2612e57e32.md"
+      ]
+    },
+    {
+      "id": "q34",
+      "kind": "semantic",
+      "query": "two environment variables must both be set before an expensive or dangerous operation runs",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/7e789883-2c59-5b0d-9117-57746de98acc.md",
+        "qmd://kb-guides/1a2b5e32-0d82-554c-9d63-55c306e74f30.md",
+        "qmd://kb-guides/12242e88-9382-50a7-baf1-38ffdc914ea1.md"
+      ]
+    },
+    {
+      "id": "q35",
+      "kind": "semantic",
+      "query": "search the brain before saving because it only dedupes at promotion not intake",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md",
+        "qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md",
+        "qmd://kb-guides/79b7c1bc-e3f7-53de-bd44-6722cafe51fa.md"
+      ]
+    },
+    {
+      "id": "q36",
+      "kind": "semantic",
+      "query": "teammates reach one shared brain over the network instead of each running their own",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/0b197d62-6651-522e-8c51-be1531b4a9f0.md",
+        "qmd://kb-guides/2960262f-d55e-5bef-bb49-e33cd10332ad.md",
+        "qmd://kb-guides/c6782345-d828-5c66-8ce4-919a1d877dc9.md"
+      ]
+    },
+    {
+      "id": "q37",
+      "kind": "semantic",
+      "query": "reducing the available tool set from twenty to four or five based on the current context",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/aa69b924-73ca-5f30-92fa-779da6f0dacb.md",
+        "qmd://kb-guides/523c99e2-ee8e-5ca1-8068-069ac482af66.md",
+        "qmd://kb-guides/a3350926-6205-5892-9ef6-388b0a0b7009.md"
+      ]
+    },
+    {
+      "id": "q38",
+      "kind": "semantic",
+      "query": "separate the build environment from the runtime environment to reduce the final image size",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/016efea4-8115-56df-80b6-2127a07a298f.md",
+        "qmd://kb-guides/901be397-1cf1-563e-be4c-8e574c017c05.md",
+        "qmd://kb-guides/1c1c4ff3-2aab-5bbc-9b99-e67028df8aed.md"
+      ]
+    },
+    {
+      "id": "q39",
+      "kind": "semantic",
+      "query": "the moat is deterministic governance and receipts not better recall",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/9050496d-a3ef-5c3f-a27e-2fe8e30f14ce.md",
+        "qmd://kb-curated/4dcecaa3-b415-5727-8a29-12f86fe919a5.md",
+        "qmd://kb-decisions/45fcbe44-972f-5a3e-9c7b-00d03dc66beb.md"
+      ]
+    },
+    {
+      "id": "q40",
+      "kind": "semantic",
+      "query": "each stage returns a new model via model_copy update rather than mutating the original",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/f9f16dc2-ad20-5ae2-8e7c-058a87daba66.md",
+        "qmd://kb-guides/3c01fd2c-8494-569e-b20f-e344251a16bd.md",
+        "qmd://kb-guides/a03f4154-ddde-5448-ae39-0239feeb8f10.md"
+      ]
+    },
+    {
+      "id": "q41",
+      "kind": "semantic",
+      "query": "member proposes and the server disposes with a remote proxy over the tailnet",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/03e26e71-27ee-5975-81f3-badbb273894b.md",
+        "qmd://kb-guides/48daecf6-2aa8-5b7f-afe4-06d596faebad.md",
+        "qmd://kb-guides/96e801bc-35d9-5a95-a8b2-a7bd6bfe3bca.md"
+      ]
+    },
+    {
+      "id": "q42",
+      "kind": "semantic",
+      "query": "the brain does not dedupe at intake only promotion dedupes so search before you save",
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md",
+        "qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md",
+        "qmd://kb-guides/79b7c1bc-e3f7-53de-bd44-6722cafe51fa.md"
+      ]
+    }
+  ]
+}

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -30,7 +30,8 @@
     "@qmd-team-intent-kb/common": "workspace:*",
     "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/store": "workspace:*",
-    "better-sqlite3": "^12.11.1"
+    "better-sqlite3": "^12.11.1",
+    "sqlite-vec": "^0.1.9"
   },
   "devDependencies": {
     "@qmd-team-intent-kb/policy-engine": "workspace:*",

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -212,4 +212,54 @@ describe('QmdAdapter — native FTS5 fusion', () => {
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value).toEqual([]);
   });
+
+  // ---- dense arm opt-in + fail-open (B4) ---------------------------------
+
+  function denseAdapter(): QmdAdapter {
+    return new QmdAdapter(
+      {
+        tenantId: 'test-tenant',
+        exportDir,
+        nativeIndexPath: ':memory:',
+        // Closed port: every embed call fails, which MUST degrade to the
+        // lexical fusion, never to an error.
+        dense: {
+          enabled: true,
+          url: 'http://127.0.0.1:1',
+          timeoutMs: 300,
+          indexPath: ':memory:',
+        },
+      },
+      mock,
+    );
+  }
+
+  it('dense enabled but embedder down: query serves the lexical fusion unchanged (fail-open)', async () => {
+    write('curated', 'a.md', 'resilience content for the dense fail-open test');
+    const qmdJson = JSON.stringify([
+      { score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'resilience' },
+    ]);
+    mock.queueSuccess(qmdJson);
+    const withDense = await denseAdapter().query('resilience content', 'curated', 'test-tenant');
+    mock.queueSuccess(qmdJson);
+    const withoutDense = await fusedAdapter().query('resilience content', 'curated', 'test-tenant');
+    expect(withDense.ok).toBe(true);
+    expect(withoutDense.ok).toBe(true);
+    if (withDense.ok && withoutDense.ok) {
+      expect(withDense.value).toEqual(withoutDense.value);
+    }
+  });
+
+  it('denseSync() with the embedder down reports serviceDown instead of throwing', async () => {
+    write('curated', 'a.md', 'doc that would need embedding');
+    const report = await denseAdapter().denseSync();
+    expect(report).not.toBeNull();
+    expect(report?.serviceDown).toBe(true);
+    expect(report?.embedded).toBe(0);
+    expect(report?.skipped).toBeGreaterThan(0);
+  });
+
+  it('denseSync() is null when dense is not configured (the default)', async () => {
+    expect(await fusedAdapter().denseSync()).toBeNull();
+  });
 });

--- a/packages/qmd-adapter/src/__tests__/dense-index.test.ts
+++ b/packages/qmd-adapter/src/__tests__/dense-index.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DenseVecIndex } from '../dense/dense-index.js';
+
+/** Unit vector helper (3 dims is plenty — dims are discovered, not hardcoded). */
+function vec(x: number, y: number, z: number): Float32Array {
+  const v = new Float32Array([x, y, z]);
+  const norm = Math.hypot(x, y, z);
+  return norm === 0 ? v : v.map((c) => c / norm);
+}
+
+const MODEL = { modelId: 'test-model.gguf', modelVersion: 'abc123' };
+
+function openIndex(overrides: Partial<typeof MODEL> = {}): DenseVecIndex {
+  return new DenseVecIndex({ path: ':memory:', ...MODEL, ...overrides });
+}
+
+describe('DenseVecIndex (B4) — sqlite-vec sidecar', () => {
+  it('stores docs and ranks KNN hits by similarity to the query vector', () => {
+    const index = openIndex();
+    index.upsert({
+      docId: 'qmd://kb-curated/x.md',
+      collection: 'kb-curated',
+      contentHash: 'h1',
+      snippet: 'x snippet',
+      embedding: vec(1, 0, 0),
+    });
+    index.upsert({
+      docId: 'qmd://kb-guides/y.md',
+      collection: 'kb-guides',
+      contentHash: 'h2',
+      snippet: 'y snippet',
+      embedding: vec(0, 1, 0),
+    });
+
+    const hits = index.search(vec(0.95, 0.05, 0), 2);
+    expect(hits.map((h) => h.id)).toEqual(['qmd://kb-curated/x.md', 'qmd://kb-guides/y.md']);
+    expect(hits[0]?.collection).toBe('kb-curated');
+    expect(hits[0]?.snippet).toBe('x snippet');
+    // Cosine similarity: near-parallel ≈ 1, orthogonal ≈ 0.
+    expect(hits[0]?.score as number).toBeGreaterThan(0.9);
+    expect(hits[1]?.score as number).toBeLessThan(0.2);
+    expect(index.count()).toBe(2);
+  });
+
+  it('upsert by docId replaces the prior vector instead of duplicating', () => {
+    const index = openIndex();
+    const doc = {
+      docId: 'qmd://kb-curated/x.md',
+      collection: 'kb-curated',
+      contentHash: 'h1',
+      snippet: 's',
+    };
+    index.upsert({ ...doc, embedding: vec(1, 0, 0) });
+    index.upsert({ ...doc, contentHash: 'h2', embedding: vec(0, 0, 1) });
+
+    expect(index.count()).toBe(1);
+    const hits = index.search(vec(0, 0, 1), 5);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.score as number).toBeGreaterThan(0.99); // the NEW vector answers
+    expect(index.entries()).toEqual([{ docId: 'qmd://kb-curated/x.md', contentHash: 'h2' }]);
+  });
+
+  it('remove() drops doc + vector; unknown ids are a no-op', () => {
+    const index = openIndex();
+    index.upsert({
+      docId: 'qmd://kb-curated/x.md',
+      collection: 'kb-curated',
+      contentHash: 'h1',
+      snippet: 's',
+      embedding: vec(1, 0, 0),
+    });
+    index.remove(['qmd://kb-curated/x.md', 'qmd://kb-curated/never-indexed.md']);
+    expect(index.count()).toBe(0);
+    expect(index.search(vec(1, 0, 0), 5)).toEqual([]);
+  });
+
+  it('search on an empty/unbuilt index returns [] (no vec table yet)', () => {
+    const index = openIndex();
+    expect(index.search(vec(1, 0, 0), 5)).toEqual([]);
+  });
+
+  it('scope-filters INSIDE the KNN via the partition key (archive never steals a slot)', () => {
+    const index = openIndex();
+    // A cluster of archive docs all NEARER the query than the one curated doc.
+    for (let i = 0; i < 5; i++) {
+      index.upsert({
+        docId: `qmd://kb-archive/a${i}.md`,
+        collection: 'kb-archive',
+        contentHash: `arch${i}`,
+        snippet: `archive ${i}`,
+        embedding: vec(1, 0.001 * i, 0),
+      });
+    }
+    index.upsert({
+      docId: 'qmd://kb-curated/keep.md',
+      collection: 'kb-curated',
+      contentHash: 'keep',
+      snippet: 'the curated answer',
+      embedding: vec(0.9, 0.1, 0),
+    });
+
+    // k=3 with NO filter would be three archive docs — the curated doc loses.
+    const unfiltered = index.search(vec(1, 0, 0), 3);
+    expect(unfiltered.every((h) => h.collection === 'kb-archive')).toBe(true);
+
+    // k=3 scoped to curated returns the curated doc DESPITE five nearer archive
+    // docs — the filter is applied within the KNN, not after it.
+    const scoped = index.search(vec(1, 0, 0), 3, ['kb-curated', 'kb-decisions', 'kb-guides']);
+    expect(scoped.map((h) => h.id)).toEqual(['qmd://kb-curated/keep.md']);
+  });
+
+  it('a query vector of the wrong dimension returns [] instead of erroring', () => {
+    const index = openIndex();
+    index.upsert({
+      docId: 'qmd://kb-curated/x.md',
+      collection: 'kb-curated',
+      contentHash: 'h1',
+      snippet: 's',
+      embedding: vec(1, 0, 0),
+    });
+    expect(index.search(new Float32Array([1, 0]), 5)).toEqual([]);
+  });
+
+  it('wipes all vectors when reopened under a different model version (pin gate)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dense-index-test-'));
+    const path = join(dir, 'dense-vec.sqlite');
+    const first = new DenseVecIndex({ path, ...MODEL });
+    first.upsert({
+      docId: 'qmd://kb-curated/x.md',
+      collection: 'kb-curated',
+      contentHash: 'h1',
+      snippet: 's',
+      embedding: vec(1, 0, 0),
+    });
+    expect(first.count()).toBe(1);
+    first.close();
+
+    const samePin = new DenseVecIndex({ path, ...MODEL });
+    expect(samePin.count()).toBe(1); // same weights → vectors survive
+    samePin.close();
+
+    const bumped = new DenseVecIndex({ path, ...MODEL, modelVersion: 'NEW-HASH' });
+    expect(bumped.count()).toBe(0); // model bump → auto-invalidated
+    bumped.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/dense-indexer.test.ts
+++ b/packages/qmd-adapter/src/__tests__/dense-indexer.test.ts
@@ -1,0 +1,256 @@
+import { createServer, type Server } from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DenseVecIndex } from '../dense/dense-index.js';
+import { DenseIndexer, type DenseIndexerOptions } from '../dense/dense-indexer.js';
+import { EmbedClient } from '../dense/embed-client.js';
+
+/**
+ * Deterministic stub embedder: hashes each input string into a 4-dim unit
+ * vector, counts how many documents it has embedded, and can be flipped
+ * "down" (connection-refused semantics via server close is covered in the
+ * embed-client tests; here `down` returns 503 so the same server object can
+ * flip mid-test).
+ */
+class StubEmbedder {
+  readonly server: Server;
+  embeddedTexts: string[] = [];
+  down = false;
+  /** When set, the Nth (1-based) /v1/embeddings request and everything after it flips the stub down (durable outage). */
+  failFromEmbedRequest: number | null = null;
+  /** When >0, the next N /v1/embeddings requests 503 and then recover (transient outage) — decremented per embed request. */
+  failNextEmbedRequests = 0;
+  private embedRequests = 0;
+  private baseUrl = '';
+
+  constructor() {
+    this.server = createServer((req, res) => {
+      const isEmbed = req.url !== '/health';
+      if (isEmbed) {
+        this.embedRequests++;
+        if (this.failFromEmbedRequest !== null && this.embedRequests >= this.failFromEmbedRequest) {
+          this.down = true;
+        }
+      }
+      // Transient outage: fail this embed request but recover afterwards.
+      if (isEmbed && this.failNextEmbedRequests > 0) {
+        this.failNextEmbedRequests--;
+        res.writeHead(503);
+        res.end();
+        return;
+      }
+      if (this.down) {
+        res.writeHead(503);
+        res.end();
+        return;
+      }
+      if (req.url === '/health') {
+        res.writeHead(200);
+        res.end('{"status":"ok"}');
+        return;
+      }
+      let body = '';
+      req.on('data', (c: Buffer) => (body += c.toString()));
+      req.on('end', () => {
+        const { input } = JSON.parse(body) as { input: string[] };
+        // Data-poison: any input containing POISON_MARKER is OMITTED from the
+        // response (models llama-server's per-input "too large" send_error),
+        // so the batch comes back with fewer rows than requested — a partial
+        // the client distrusts as null — while /health stays 200 (service up).
+        const kept = input
+          .map((text, index) => ({ text, index }))
+          .filter((e) => !e.text.includes(StubEmbedder.POISON_MARKER));
+        this.embeddedTexts.push(...kept.map((e) => e.text));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            data: kept.map((e) => ({ index: e.index, embedding: StubEmbedder.vectorFor(e.text) })),
+          }),
+        );
+      });
+    });
+  }
+
+  /** Inputs containing this marker are rejected (omitted) by the stub — models a per-input server error. */
+  static readonly POISON_MARKER = 'POISON_DOC';
+
+  /** Hash a string into a stable 4-dim unit vector. */
+  static vectorFor(text: string): number[] {
+    let h = 2166136261;
+    for (let i = 0; i < text.length; i++) {
+      h = Math.imul(h ^ text.charCodeAt(i), 16777619);
+    }
+    const raw = [1 + (h & 0xff), 1 + ((h >> 8) & 0xff), 1 + ((h >> 16) & 0xff), 1];
+    const norm = Math.hypot(...raw);
+    return raw.map((c) => c / norm);
+  }
+
+  listen(): Promise<string> {
+    return new Promise((resolve) => {
+      this.server.listen(0, '127.0.0.1', () => {
+        const { port } = this.server.address() as AddressInfo;
+        this.baseUrl = `http://127.0.0.1:${port}`;
+        resolve(this.baseUrl);
+      });
+    });
+  }
+
+  close(): void {
+    this.server.close();
+  }
+}
+
+describe('DenseIndexer (B4) — incremental embed sweep over the export tree', () => {
+  let stub: StubEmbedder;
+  let url: string;
+  let exportDir: string;
+  let index: DenseVecIndex;
+
+  beforeEach(async () => {
+    stub = new StubEmbedder();
+    url = await stub.listen();
+    exportDir = mkdtempSync(join(tmpdir(), 'dense-indexer-test-'));
+    mkdirSync(join(exportDir, 'curated'), { recursive: true });
+    mkdirSync(join(exportDir, 'guides'), { recursive: true });
+    writeFileSync(join(exportDir, 'curated', 'a.md'), '# Doc A about audits');
+    writeFileSync(join(exportDir, 'curated', 'b.md'), '# Doc B about backups');
+    writeFileSync(join(exportDir, 'guides', 'g.md'), '# Guide G about deploys');
+    index = new DenseVecIndex({ path: ':memory:', modelId: 'm', modelVersion: 'v' });
+  });
+
+  afterEach(() => {
+    stub.close();
+    index.close();
+    rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  function makeIndexer(batchSize = 2, retry?: Partial<DenseIndexerOptions>): DenseIndexer {
+    return new DenseIndexer({
+      index,
+      client: new EmbedClient({ url, timeoutMs: 5000 }),
+      exportDir,
+      batchSize,
+      // Tiny backoffs keep the retry tests fast; production defaults are seconds.
+      maxBatchRetries: 3,
+      retryBackoffMs: 5,
+      maxRetryBackoffMs: 10,
+      ...retry,
+    });
+  }
+
+  it('first sync embeds every exportable doc with qmd:// citation ids', async () => {
+    const report = await makeIndexer().sync();
+    expect(report).toMatchObject({ embedded: 3, removed: 0, skipped: 0, serviceDown: false });
+    expect(report.totalDocs).toBe(3);
+    expect(index.count()).toBe(3);
+    expect(
+      index
+        .entries()
+        .map((e) => e.docId)
+        .sort(),
+    ).toEqual(['qmd://kb-curated/a.md', 'qmd://kb-curated/b.md', 'qmd://kb-guides/g.md']);
+  });
+
+  it('re-sync is incremental: unchanged docs are never re-sent to the model', async () => {
+    await makeIndexer().sync();
+    stub.embeddedTexts = [];
+    const report = await makeIndexer().sync();
+    expect(report).toMatchObject({ embedded: 0, removed: 0, skipped: 0, serviceDown: false });
+    expect(stub.embeddedTexts).toEqual([]); // zero model calls
+  });
+
+  it('a changed doc is re-embedded (content-hash keyed, not mtime)', async () => {
+    await makeIndexer().sync();
+    stub.embeddedTexts = [];
+    writeFileSync(join(exportDir, 'curated', 'a.md'), '# Doc A REWRITTEN');
+    const report = await makeIndexer().sync();
+    expect(report.embedded).toBe(1);
+    expect(stub.embeddedTexts).toHaveLength(1);
+    expect(stub.embeddedTexts[0]).toContain('REWRITTEN');
+    expect(index.count()).toBe(3); // replaced, not duplicated
+  });
+
+  it('a deleted doc is removed from the index', async () => {
+    await makeIndexer().sync();
+    unlinkSync(join(exportDir, 'curated', 'b.md'));
+    const report = await makeIndexer().sync();
+    expect(report).toMatchObject({ embedded: 0, removed: 1 });
+    expect(index.count()).toBe(2);
+    expect(index.entries().some((e) => e.docId === 'qmd://kb-curated/b.md')).toBe(false);
+  });
+
+  it('service down: sweep degrades to a stale index, never throws', async () => {
+    stub.down = true;
+    const report = await makeIndexer().sync();
+    expect(report).toMatchObject({ embedded: 0, skipped: 3, serviceDown: true });
+    expect(index.count()).toBe(0); // stale (empty) — and search on it just returns []
+  });
+
+  it('service DURABLY down mid-sweep: batch retried to exhaustion, remainder aborted, prior work kept', async () => {
+    // Batch size 1 → three embed requests. The 2nd request (and everything
+    // after) flips the stub permanently down. Batch 1 lands; batch 2 fails
+    // every retry (service never comes back) → abort with the remainder skipped.
+    stub.failFromEmbedRequest = 2;
+    const report = await makeIndexer(1).sync();
+    expect(report.serviceDown).toBe(true);
+    expect(report.embedded).toBe(1); // first batch landed and is kept
+    expect(report.skipped).toBe(2); // the exhausted batch + the aborted remainder
+    expect(index.count()).toBe(1);
+  });
+
+  it('TRANSIENT outage mid-sweep: retry bridges an auto-restart and the build completes', async () => {
+    // Model a ~restart blip: the first 2 embed requests 503, then the service
+    // recovers. Batch size 1 → batch 1's doc fails twice and succeeds on its
+    // 3rd attempt (inside the retry budget); batches 2-3 then sail through. The
+    // whole build completes despite the outage — no work discarded.
+    stub.failNextEmbedRequests = 2;
+    const report = await makeIndexer(1).sync();
+    expect(report.serviceDown).toBe(false);
+    expect(report.embedded).toBe(3); // all three docs embedded despite the blip
+    expect(report.skipped).toBe(0);
+    expect(index.count()).toBe(3);
+  });
+
+  it('DATA-POISON batch: skipped (service healthy), build continues with the good docs', async () => {
+    // A doc the server will never accept (models an input that exceeds the
+    // physical batch size). Batch size 1 isolates it: its batch fails every
+    // retry, the health probe says UP → skip that one doc and keep going.
+    writeFileSync(
+      join(exportDir, 'curated', 'poison.md'),
+      `# ${StubEmbedder.POISON_MARKER} oversized`,
+    );
+    const report = await makeIndexer(1).sync();
+    expect(report.serviceDown).toBe(false); // NOT a false outage
+    expect(report.embedded).toBe(3); // the 3 good docs still embedded
+    expect(report.skipped).toBe(1); // only the poison doc skipped
+    expect(index.count()).toBe(3);
+    expect(index.entries().some((e) => e.docId.includes('poison'))).toBe(false);
+  });
+
+  it('batch exhausts the retry budget but /health is up → skip that batch, keep building (not a false outage)', async () => {
+    // maxBatchRetries: 1 → 2 attempts per batch. Fail the first 2 embed
+    // requests (batch 1 exhausts its budget) but health stays 200 throughout.
+    // batchSize 2 → batch1=[a,b] can't recover in budget and is SKIPPED
+    // (health up = not an outage); batch2=[g] then succeeds. The build finishes
+    // rather than aborting the whole thing on a transient that outlasts budget.
+    stub.failNextEmbedRequests = 2;
+    const report = await makeIndexer(2, { maxBatchRetries: 1 }).sync();
+    expect(report.serviceDown).toBe(false);
+    expect(report.embedded).toBe(1); // batch2's doc
+    expect(report.skipped).toBe(2); // batch1's two docs skipped, not the whole build
+  });
+
+  it('after an outage, the next sync picks up exactly the missing docs', async () => {
+    stub.down = true;
+    await makeIndexer().sync();
+    stub.down = false;
+    const report = await makeIndexer().sync();
+    expect(report).toMatchObject({ embedded: 3, skipped: 0, serviceDown: false });
+    expect(index.count()).toBe(3);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/dense-live-integration.test.ts
+++ b/packages/qmd-adapter/src/__tests__/dense-live-integration.test.ts
@@ -1,0 +1,89 @@
+import { connect } from 'node:net';
+
+import { describe, expect, it } from 'vitest';
+
+import { DenseVecIndex } from '../dense/dense-index.js';
+import { EmbedClient } from '../dense/embed-client.js';
+
+/**
+ * Live integration against the real `bbb-embedder` systemd user service
+ * (llama-server + pinned EmbeddingGemma-300M on loopback :8098; see
+ * scripts/bbb-embedder.service and the runbook 051-AT-RNBK).
+ *
+ * Skipped (not failed) when nothing is listening on the port, so CI and boxes
+ * without the service stay green — the same posture as the other live tests.
+ */
+const EMBEDDER_PORT = 8098;
+const EMBEDDER_URL = `http://127.0.0.1:${EMBEDDER_PORT}`;
+
+function portOpen(port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port });
+    const done = (up: boolean) => {
+      socket.destroy();
+      resolve(up);
+    };
+    socket.setTimeout(timeoutMs, () => done(false));
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+  });
+}
+
+const serviceUp = await portOpen(EMBEDDER_PORT);
+
+describe.skipIf(!serviceUp)('live bbb-embedder service (B4)', () => {
+  it('answers the health probe', async () => {
+    const client = new EmbedClient({ url: EMBEDDER_URL, timeoutMs: 5000 });
+    expect(await client.healthy()).toBe(true);
+  });
+
+  it(
+    'ranks an obviously-relevant document above an obviously-irrelevant one end-to-end (embed → sqlite-vec KNN)',
+    { timeout: 60_000 },
+    async () => {
+      const client = new EmbedClient({ url: EMBEDDER_URL, timeoutMs: 30_000 });
+      const docs = [
+        {
+          docId: 'qmd://kb-curated/audit.md',
+          text: 'The audit log is a hash-chained append-only JSONL file verified by ico audit verify.',
+        },
+        {
+          docId: 'qmd://kb-curated/bananas.md',
+          text: 'Bananas are yellow and grow in bunches.',
+        },
+      ];
+      const docVectors = await client.embed(
+        docs.map((d) => d.text),
+        'document',
+      );
+      expect(docVectors).not.toBeNull();
+      expect(docVectors).toHaveLength(2);
+
+      const index = new DenseVecIndex({ path: ':memory:', modelId: 'live', modelVersion: 'live' });
+      docs.forEach((doc, i) => {
+        const embedding = docVectors?.[i];
+        if (embedding === undefined) throw new Error('missing vector');
+        index.upsert({
+          docId: doc.docId,
+          collection: 'kb-curated',
+          contentHash: `h${i}`,
+          snippet: doc.text.slice(0, 40),
+          embedding,
+        });
+      });
+
+      const queryVectors = await client.embed(['how is the audit log verified'], 'query');
+      const queryVec = queryVectors?.[0];
+      expect(queryVec).toBeDefined();
+      if (queryVec === undefined) return;
+
+      const hits = index.search(queryVec, 2);
+      expect(hits.map((h) => h.id)).toEqual([
+        'qmd://kb-curated/audit.md',
+        'qmd://kb-curated/bananas.md',
+      ]);
+      expect(hits[0]?.score as number).toBeGreaterThan(hits[1]?.score as number);
+      index.close();
+    },
+  );
+});

--- a/packages/qmd-adapter/src/__tests__/dense-seam-firewall.test.ts
+++ b/packages/qmd-adapter/src/__tests__/dense-seam-firewall.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DeterministicScore } from '@qmd-team-intent-kb/policy-engine';
+
+import { denseScore, type DenseScore } from '../dense/embed-client.js';
+import { rerankScore, type RerankScore } from '../rerank/rerank-client.js';
+
+/**
+ * Seam firewall, retrieval side (blueprint B4 extending B1/B2's proof).
+ *
+ * B2 proved a RAW number cannot become a govern `DeterministicScore`; B1
+ * proved it for the cross-encoder `RerankScore`. B4 introduces the second
+ * model-derived score in the codebase — the embedding-similarity `DenseScore`
+ * — so this file proves that concrete type cannot cross the seam either, in
+ * both directions, and that the two retrieval-side model brands do not
+ * silently unify with each other. The @ts-expect-error directives are
+ * enforced by tsc: if any two of these brands ever became mutually
+ * assignable, the directives would flag as unused and fail typecheck.
+ *
+ * This test lives in qmd-adapter (retrieval) importing the govern TYPE,
+ * because the import barrier (`no-govern-imports-retrieval` in
+ * .dependency-cruiser.cjs) forbids the reverse: policy-engine may never
+ * import this package, so the cross-package proof must sit on this side of
+ * the seam. Note also that policy-engine's package surface exports only the
+ * TYPE — the `deterministicScore()` factory is not exported, so retrieval
+ * code cannot mint a govern score even deliberately.
+ */
+describe('seam firewall: DenseScore cannot cross into govern (B4)', () => {
+  it('a DenseScore is NOT assignable to a govern DeterministicScore', () => {
+    const modelScore: DenseScore = denseScore(0.87);
+    // @ts-expect-error a model-derived embedding similarity can never become a govern score
+    const forbidden: DeterministicScore = modelScore;
+    void forbidden;
+  });
+
+  it('a govern DeterministicScore is NOT assignable to a DenseScore (brands are distinct, not aliases)', () => {
+    const governScore = 0.5 as DeterministicScore; // cast stands in for the unexported factory
+    // @ts-expect-error the brands are nominal — govern and retrieval scores never unify
+    const forbidden: DenseScore = governScore;
+    void forbidden;
+  });
+
+  it('a raw number is NOT assignable to a DenseScore without the dense-side factory', () => {
+    const raw = 0.42;
+    // @ts-expect-error raw numbers must be branded through denseScore()
+    const forbidden: DenseScore = raw;
+    void forbidden;
+  });
+
+  it('the two retrieval-side model brands do not unify with each other either', () => {
+    const dense: DenseScore = denseScore(0.7);
+    const rerank: RerankScore = rerankScore(0.7);
+    // @ts-expect-error a dense similarity is not a cross-encoder relevance score
+    const forbiddenA: RerankScore = dense;
+    // @ts-expect-error a cross-encoder relevance score is not a dense similarity
+    const forbiddenB: DenseScore = rerank;
+    void forbiddenA;
+    void forbiddenB;
+  });
+
+  it('a DenseScore still reads transparently as a number on the read path', () => {
+    const s = denseScore(0.75);
+    expect(s).toBeCloseTo(0.75);
+    expect(s > 0.5).toBe(true); // ordering comparisons work — that is its whole job
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/embed-client.test.ts
+++ b/packages/qmd-adapter/src/__tests__/embed-client.test.ts
@@ -1,0 +1,185 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  EmbedClient,
+  EMBEDDINGGEMMA_DOCUMENT_PREFIX,
+  EMBEDDINGGEMMA_QUERY_PREFIX,
+} from '../dense/embed-client.js';
+
+/** Start an in-process stub server; returns its base URL. */
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Collect a request body as a string. */
+function readBody(req: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    req.on('end', () => resolve(body));
+  });
+}
+
+describe('EmbedClient (B4) — fail-open HTTP client for the local embedder', () => {
+  let server: Server | null = null;
+
+  afterEach(() => {
+    server?.close();
+    server = null;
+  });
+
+  it('parses a well-formed /v1/embeddings response into per-input Float32Arrays', async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          data: [
+            { index: 1, embedding: [0, 1, 0] },
+            { index: 0, embedding: [1, 0, 0] },
+          ],
+        }),
+      );
+    });
+    const client = new EmbedClient({ url: await listen(server) });
+    const vectors = await client.embed(['a', 'b'], 'document');
+    expect(vectors).not.toBeNull();
+    expect(vectors).toHaveLength(2);
+    // Out-of-order response indexes land back in input order.
+    expect(Array.from(vectors?.[0] ?? [])).toEqual([1, 0, 0]);
+    expect(Array.from(vectors?.[1] ?? [])).toEqual([0, 1, 0]);
+  });
+
+  it('applies the EmbeddingGemma role prefixes to every input', async () => {
+    let seenBody = '';
+    server = createServer((req, res) => {
+      void readBody(req).then((body) => {
+        seenBody = body;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ index: 0, embedding: [1] }] }));
+      });
+    });
+    const client = new EmbedClient({ url: await listen(server) });
+
+    await client.embed(['how is the audit verified'], 'query');
+    expect(JSON.parse(seenBody).input).toEqual([
+      `${EMBEDDINGGEMMA_QUERY_PREFIX}how is the audit verified`,
+    ]);
+
+    await client.embed(['the audit log doc'], 'document');
+    expect(JSON.parse(seenBody).input).toEqual([
+      `${EMBEDDINGGEMMA_DOCUMENT_PREFIX}the audit log doc`,
+    ]);
+  });
+
+  it('returns [] without any HTTP call for an empty input list', async () => {
+    // Point at a closed port: if the client tried to call out, it would fail.
+    const client = new EmbedClient({ url: 'http://127.0.0.1:1' });
+    expect(await client.embed([], 'query')).toEqual([]);
+  });
+
+  it('fails open (null) on connection refused', async () => {
+    const client = new EmbedClient({ url: 'http://127.0.0.1:1', timeoutMs: 500 });
+    expect(await client.embed(['doc'], 'document')).toBeNull();
+    expect(await client.healthy()).toBe(false);
+  });
+
+  it('fails open (null) on timeout', async () => {
+    server = createServer(() => {
+      /* never respond */
+    });
+    const client = new EmbedClient({ url: await listen(server), timeoutMs: 300 });
+    expect(await client.embed(['doc'], 'document')).toBeNull();
+  });
+
+  it('fails open (null) on non-200', async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(500);
+      res.end('boom');
+    });
+    const client = new EmbedClient({ url: await listen(server) });
+    expect(await client.embed(['doc'], 'document')).toBeNull();
+  });
+
+  const malformed: Array<[string, unknown]> = [
+    ['not JSON at all', undefined],
+    ['missing data', {}],
+    ['wrong count', { data: [{ index: 0, embedding: [1, 0] }] }],
+    [
+      'out-of-range index',
+      {
+        data: [
+          { index: 0, embedding: [1, 0] },
+          { index: 5, embedding: [0, 1] },
+        ],
+      },
+    ],
+    [
+      'duplicate index leaves a hole',
+      {
+        data: [
+          { index: 0, embedding: [1, 0] },
+          { index: 0, embedding: [0, 1] },
+        ],
+      },
+    ],
+    [
+      'ragged dimensions',
+      {
+        data: [
+          { index: 0, embedding: [1, 0] },
+          { index: 1, embedding: [0, 1, 0] },
+        ],
+      },
+    ],
+    [
+      'non-finite component',
+      {
+        data: [
+          { index: 0, embedding: [1, 0] },
+          { index: 1, embedding: [0, null] },
+        ],
+      },
+    ],
+    [
+      'empty embedding',
+      {
+        data: [
+          { index: 0, embedding: [] },
+          { index: 1, embedding: [] },
+        ],
+      },
+    ],
+  ];
+  for (const [label, payload] of malformed) {
+    it(`fails open (null) on a malformed response: ${label}`, async () => {
+      server = createServer((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(payload === undefined ? '<html>nope' : JSON.stringify(payload));
+      });
+      const client = new EmbedClient({ url: await listen(server) });
+      expect(await client.embed(['a', 'b'], 'document')).toBeNull();
+    });
+  }
+
+  it('healthy() is true against a 200 /health', async () => {
+    server = createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200);
+        res.end('{"status":"ok"}');
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    const client = new EmbedClient({ url: await listen(server) });
+    expect(await client.healthy()).toBe(true);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/rrf-fusion.test.ts
+++ b/packages/qmd-adapter/src/__tests__/rrf-fusion.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { fuseReciprocalRank, RRF_K } from '../search/rrf-fusion.js';
 import type { QmdSearchResult } from '../types.js';
 import type { Fts5SearchHit } from '../native/fts5-backend.js';
+import type { DenseSearchHit } from '../dense/dense-index.js';
+import { denseScore } from '../dense/embed-client.js';
 
 function qmdHit(file: string, score: number, snippet = 'qmd-snip'): QmdSearchResult {
   return { file, score, snippet, collection: 'kb-curated' };
@@ -9,6 +11,10 @@ function qmdHit(file: string, score: number, snippet = 'qmd-snip'): QmdSearchRes
 
 function nativeHit(id: string, score: number, snippet = 'fts-snip'): Fts5SearchHit {
   return { id, score, snippet, collection: 'kb-curated' };
+}
+
+function denseHit(id: string, score: number, snippet = 'dense-snip'): DenseSearchHit {
+  return { id, score: denseScore(score), snippet, collection: 'kb-curated' };
 }
 
 describe('fuseReciprocalRank', () => {
@@ -69,5 +75,68 @@ describe('fuseReciprocalRank', () => {
 
   it('returns [] when both lists are empty', () => {
     expect(fuseReciprocalRank([], [])).toEqual([]);
+  });
+
+  // ---- dense third list (B4) ---------------------------------------------
+
+  it('an omitted dense list is byte-identical to the two-list fusion (the default path)', () => {
+    const qmd = [qmdHit('qmd://kb-curated/a.md', 5), qmdHit('qmd://kb-curated/b.md', 4)];
+    const native = [nativeHit('qmd://kb-curated/b.md', 7)];
+    expect(fuseReciprocalRank(qmd, native)).toEqual(fuseReciprocalRank(qmd, native, []));
+  });
+
+  it('surfaces a dense-only hit both lexical backends missed (the paraphrase miss class)', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/lex.md', 5)],
+      [],
+      [denseHit('qmd://kb-curated/paraphrase-only.md', 0.91)],
+    );
+    expect(fused.map((h) => h.file)).toContain('qmd://kb-curated/paraphrase-only.md');
+    const denseOnly = fused.find((h) => h.file.endsWith('/paraphrase-only.md'))!;
+    expect(denseOnly.snippet).toBe('dense-snip'); // dense stored lead text fills in
+    expect(denseOnly.collection).toBe('kb-curated');
+  });
+
+  it('a document present in all three lists outranks two-list documents at the same ranks', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/all3.md', 3), qmdHit('qmd://kb-curated/two.md', 2)],
+      [nativeHit('qmd://kb-curated/all3.md', 9), nativeHit('qmd://kb-curated/two.md', 8)],
+      [denseHit('qmd://kb-curated/all3.md', 0.9)],
+    );
+    expect(fused[0]!.file).toBe('qmd://kb-curated/all3.md');
+    expect(fused[0]!.score).toBeCloseTo(3 / (RRF_K + 1), 10);
+    expect(fused[1]!.score).toBeCloseTo(2 / (RRF_K + 2), 10);
+  });
+
+  it('the fused score is pure rank arithmetic — the dense model score magnitude never leaks in', () => {
+    // Two runs whose dense scores differ wildly but whose RANKS are identical
+    // must produce identical fused scores: fusion consumes ranks only.
+    const run = (a: number, b: number) =>
+      fuseReciprocalRank(
+        [],
+        [],
+        [denseHit('qmd://kb-curated/x.md', a), denseHit('qmd://kb-curated/y.md', b)],
+      );
+    expect(run(0.99, 0.98)).toEqual(run(0.51, 0.02));
+    expect(run(0.99, 0.98)[0]!.score).toBeCloseTo(1 / (RRF_K + 1), 10);
+  });
+
+  it('snippet preference is qmd → native → dense', () => {
+    const fused = fuseReciprocalRank(
+      [qmdHit('qmd://kb-curated/a.md', 5, 'from-qmd')],
+      [
+        nativeHit('qmd://kb-curated/a.md', 4, 'from-fts'),
+        nativeHit('qmd://kb-curated/b.md', 3, 'from-fts'),
+      ],
+      [
+        denseHit('qmd://kb-curated/a.md', 0.9),
+        denseHit('qmd://kb-curated/b.md', 0.8),
+        denseHit('qmd://kb-curated/c.md', 0.7),
+      ],
+    );
+    const byId = new Map(fused.map((h) => [h.file, h.snippet]));
+    expect(byId.get('qmd://kb-curated/a.md')).toBe('from-qmd');
+    expect(byId.get('qmd://kb-curated/b.md')).toBe('from-fts');
+    expect(byId.get('qmd://kb-curated/c.md')).toBe('dense-snip');
   });
 });

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -19,10 +19,31 @@ import type { Fts5SearchHit } from './native/fts5-backend.js';
 import { RerankClient } from './rerank/rerank-client.js';
 import { RerankCache } from './rerank/rerank-cache.js';
 import { RerankStage } from './rerank/rerank-stage.js';
+import {
+  EmbedClient,
+  EMBEDDINGGEMMA_DOCUMENT_PREFIX,
+  EMBEDDINGGEMMA_QUERY_PREFIX,
+} from './dense/embed-client.js';
+import { DenseVecIndex, type DenseSearchHit } from './dense/dense-index.js';
+import { DenseIndexer, type DenseIndexReport } from './dense/dense-indexer.js';
 import { QMD_WEIGHTS_MANIFEST } from './weights/weights-manifest.js';
 
 /** How many native FTS5 hits to feed the fusion (pre scope-filter). */
 const NATIVE_SEARCH_K = 50;
+
+/** How many dense KNN hits to feed the fusion (pre scope-filter). */
+const DENSE_SEARCH_K = 50;
+
+/** Default timeout for a document-batch embed call during indexing. */
+const DENSE_INDEX_TIMEOUT_MS = 120_000;
+
+/** The dense arm's composed pieces (built only when `config.dense.enabled`). */
+interface DenseArm {
+  index: DenseVecIndex;
+  queryClient: EmbedClient;
+  indexer: DenseIndexer;
+  searchK: number;
+}
 
 /** Facade class composing all qmd adapter managers */
 export class QmdAdapter {
@@ -32,6 +53,7 @@ export class QmdAdapter {
   readonly indexLifecycle: IndexLifecycleManager;
   private readonly native: NativeIndexManager | null;
   private readonly rerankStage: RerankStage | null;
+  private readonly dense: DenseArm | null;
   private readonly exportDir: string;
   /** The single tenant this adapter's qmd registry + index are bound to. */
   private readonly tenantId: string;
@@ -81,6 +103,13 @@ export class QmdAdapter {
     // deterministic fused order. With rerank absent/disabled this block is
     // inert and the query path is unchanged.
     this.rerankStage = config.rerank?.enabled === true ? buildRerankStage(config) : null;
+    // OPT-IN dense retrieval arm (B4, 038/044-AT-DECR). Candidate-generation
+    // side of the read path, fail-open by construction: a construction
+    // failure (e.g. the sqlite-vec native extension cannot load, or the index
+    // path is unwritable) or any runtime failure serves the lexical fusion
+    // with no dense list. With dense absent/disabled this block is inert and
+    // the query path is unchanged.
+    this.dense = config.dense?.enabled === true ? buildDenseArm(config) : null;
   }
 
   /**
@@ -113,32 +142,40 @@ export class QmdAdapter {
       return { ok: true, value: [] };
     }
 
-    // Two lexical backends, one deterministic fusion (vps.2): the external
-    // qmd binary (keyword-AND tokenizer) and the native FTS5 index over the
-    // same export tree (unicode61 tokenizer, catches hyphen/dot-joined terms
-    // qmd misses). Their ranked lists join by qmd:// citation and fuse via
-    // reciprocal-rank fusion. Either backend failing degrades to the other.
+    // Two lexical backends plus the opt-in dense arm, one deterministic
+    // fusion (vps.2 + B4): the external qmd binary (keyword-AND tokenizer),
+    // the native FTS5 index over the same export tree (unicode61 tokenizer,
+    // catches hyphen/dot-joined terms qmd misses), and — when configured —
+    // the sqlite-vec dense KNN list (catches paraphrase queries sharing no
+    // tokens with the doc). All ranked lists join by qmd:// citation and fuse
+    // via reciprocal-rank fusion, which consumes ranks only. Any backend
+    // failing degrades to the others; with dense absent (the default) this
+    // path is identical to the lexical-only fusion.
     const effectiveScope: SearchScope = scope ?? 'curated';
     const qmdResult = await this.search.search(queryText, effectiveScope);
     const nativeHits = this.nativeSearch(queryText, effectiveScope);
+    const denseHits = await this.denseSearch(queryText, effectiveScope);
 
     if (!qmdResult.ok) {
-      // qmd unavailable — native results alone still serve the query (this
+      // qmd unavailable — the other lists alone still serve the query (this
       // also makes local search work when the qmd binary is not installed).
-      if (nativeHits.length > 0) {
+      if (nativeHits.length > 0 || denseHits.length > 0) {
         return {
           ok: true,
-          value: await this.maybeRerank(queryText, fuseReciprocalRank([], nativeHits)),
+          value: await this.maybeRerank(queryText, fuseReciprocalRank([], nativeHits, denseHits)),
         };
       }
       return qmdResult;
     }
-    if (nativeHits.length === 0) {
+    if (nativeHits.length === 0 && denseHits.length === 0) {
       return { ok: true, value: await this.maybeRerank(queryText, qmdResult.value) };
     }
     return {
       ok: true,
-      value: await this.maybeRerank(queryText, fuseReciprocalRank(qmdResult.value, nativeHits)),
+      value: await this.maybeRerank(
+        queryText,
+        fuseReciprocalRank(qmdResult.value, nativeHits, denseHits),
+      ),
     };
   }
 
@@ -162,6 +199,48 @@ export class QmdAdapter {
       return this.native.search(queryText, NATIVE_SEARCH_K, resolveScopeCollections(scope));
     } catch {
       return [];
+    }
+  }
+
+  /**
+   * Dense KNN list for the fusion (B4). Fail-open: dense not configured,
+   * embedder down/slow, empty index, or anything thrown all degrade to [] —
+   * the lexical fusion is always the floor the serving path stands on.
+   */
+  private async denseSearch(queryText: string, scope: SearchScope): Promise<DenseSearchHit[]> {
+    if (this.dense === null) return [];
+    try {
+      const vectors = await this.dense.queryClient.embed([queryText], 'query');
+      const queryVec = vectors?.[0];
+      if (queryVec === undefined) return [];
+      // Scope is pushed INTO the KNN (vec0 partition key), not applied after —
+      // so out-of-scope collections (e.g. archive under a curated search)
+      // never occupy one of the k slots and starve in-scope recall.
+      return this.dense.index.search(queryVec, this.dense.searchK, resolveScopeCollections(scope));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Bring the dense sidecar index up to date with the export tree (B4).
+   * Returns `null` when the dense arm is not configured; never throws.
+   * Called by `reindex()` after the lexical index update — an embedder outage
+   * reports `serviceDown: true` and leaves the dense index stale (degrade),
+   * it never fails the reindex.
+   */
+  async denseSync(): Promise<DenseIndexReport | null> {
+    if (this.dense === null) return null;
+    try {
+      return await this.dense.indexer.sync();
+    } catch {
+      return {
+        embedded: 0,
+        removed: 0,
+        skipped: 0,
+        totalDocs: 0,
+        serviceDown: true,
+      };
     }
   }
 
@@ -197,6 +276,50 @@ export class QmdAdapter {
  * path is unwritable — the stage then simply runs uncached) — rerank is never allowed
  * to take the serving path down.
  */
+/**
+ * Construct the opt-in dense arm from adapter config (B4). The sqlite-vec
+ * sidecar index is keyed on the PINNED embedding weights (file + sha256 from
+ * the weights manifest) AND the two EmbeddingGemma prompt prefixes, so a model
+ * bump OR a prefix change wipes and rebuilds automatically — the query is
+ * always embedded with the exact prefixes the stored doc vectors used.
+ * Returns null instead of throwing when construction fails (e.g. the
+ * sqlite-vec native extension cannot load, or the index dir is unwritable) —
+ * dense is never allowed to take the serving path down.
+ */
+function buildDenseArm(config: QmdAdapterConfig): DenseArm | null {
+  const dense = config.dense;
+  if (dense === undefined) return null;
+  try {
+    const pinned = QMD_WEIGHTS_MANIFEST.models.find((m) => m.id === 'embedding');
+    // Prompt prefixes are part of what produced every stored vector; fold them
+    // into the invalidation key so editing a prefix can never leave the index
+    // serving old-prefix doc vectors against a new-prefix query vector.
+    const modelVersion =
+      `${pinned?.sha256 ?? 'unpinned'}|q:${EMBEDDINGGEMMA_QUERY_PREFIX}` +
+      `|d:${EMBEDDINGGEMMA_DOCUMENT_PREFIX}`;
+    const index = new DenseVecIndex({
+      path: dense.indexPath ?? join(getQmdTenantIndexPath(config.tenantId), 'dense-vec.sqlite'),
+      modelId: pinned?.file ?? 'unknown-embedding',
+      modelVersion,
+    });
+    const queryClient = new EmbedClient({ url: dense.url, timeoutMs: dense.timeoutMs });
+    const indexClient = new EmbedClient({
+      url: dense.url,
+      timeoutMs: dense.indexTimeoutMs ?? DENSE_INDEX_TIMEOUT_MS,
+    });
+    const indexer = new DenseIndexer({
+      index,
+      client: indexClient,
+      exportDir: config.exportDir,
+      maxDocChars: dense.maxDocChars,
+      batchSize: dense.batchSize,
+    });
+    return { index, queryClient, indexer, searchK: dense.searchK ?? DENSE_SEARCH_K };
+  } catch {
+    return null;
+  }
+}
+
 function buildRerankStage(config: QmdAdapterConfig): RerankStage | null {
   const rerank = config.rerank;
   if (rerank === undefined) return null;

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -94,6 +94,35 @@ export interface QmdAdapterConfig {
      */
     cachePath?: string;
   };
+  /**
+   * OPT-IN dense retrieval arm (blueprint bead B4; 038/044-AT-DECR:
+   * sqlite-vec + EmbeddingGemma-300M only). Explicit options only — no env
+   * magic. When omitted or `enabled: false`, the query path is byte-identical
+   * to the lexical-only deterministic fusion. When enabled, the arm FAILS
+   * OPEN: embedder down / index unbuilt / any failure serves the lexical
+   * fusion with no dense list.
+   */
+  dense?: {
+    enabled: boolean;
+    /** Embedding service base URL, e.g. `http://127.0.0.1:8098` (loopback only). */
+    url: string;
+    /** Hard timeout for the query-embed call (default 5000 ms). */
+    timeoutMs?: number;
+    /**
+     * Override for the sqlite-vec sidecar index (tests use `:memory:`).
+     * Defaults to `<qmd-index>/<tenantId>/dense-vec.sqlite` — derived,
+     * rebuildable, deletable data next to the other derived indexes.
+     */
+    indexPath?: string;
+    /** Dense KNN hits fed to the fusion, pre scope-filter (default 50). */
+    searchK?: number;
+    /** Truncate each doc to this many chars before embedding (default 1200). */
+    maxDocChars?: number;
+    /** Timeout for a document-batch embed call during indexing (default 120000 ms). */
+    indexTimeoutMs?: number;
+    /** Docs per embed request during indexing (default 16). */
+    batchSize?: number;
+  };
 }
 
 /** Default configuration values */

--- a/packages/qmd-adapter/src/dense/dense-index.ts
+++ b/packages/qmd-adapter/src/dense/dense-index.ts
@@ -1,0 +1,257 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+
+import { denseScore, type DenseScore } from './embed-client.js';
+
+/**
+ * sqlite-vec sidecar index for the dense retrieval arm (blueprint bead B4;
+ * decisions 038-AT-DECR + 044-AT-DECR: sqlite-vec + EmbeddingGemma-300M only,
+ * skipping qmd's 2.2 GB hybrid).
+ *
+ * One SQLite file at `<qmd-index>/<tenant>/dense-vec.sqlite` holding:
+ *
+ *   dense_meta  — model_id / model_version (the PINNED weights hash from
+ *                 weights-manifest.ts) + vector dims. Opening against a
+ *                 different model or dims WIPES the index: embeddings from
+ *                 different weights are not comparable, so a model bump
+ *                 invalidates every prior vector with zero migration logic
+ *                 (the same trick as the rerank score cache).
+ *   dense_docs  — one row per embedded doc, keyed by the `qmd://` citation
+ *                 (the cross-backend join key) + the content hash of the
+ *                 exact text that was embedded, so re-embedding is
+ *                 incremental: unchanged docs are never re-sent to the model.
+ *   dense_vec   — the vec0 virtual table (one float[dims] row per doc,
+ *                 rowid-linked to dense_docs) carrying `collection` as a vec0
+ *                 PARTITION KEY. Created lazily on the first upsert, when the
+ *                 true dimension is known from the model — never hardcoded.
+ *                 The partition key lets scope filtering happen INSIDE the KNN
+ *                 (`WHERE collection IN (...)`) rather than after it: under the
+ *                 default `curated` scope the archive collection (embedded but
+ *                 out of scope) would otherwise consume the k nearest slots and
+ *                 starve the curated recall this arm exists to buy — a real
+ *                 risk in this corpus, where archive is ~38% of all docs.
+ *
+ * DERIVED DATA, NEVER AUTHORITATIVE: rebuildable from kb-export + the
+ * embedding service at any time, deletable at any time, outside backup scope
+ * — exactly like the native FTS5 index and the rerank cache beside it.
+ */
+
+/** One embedded document's bookkeeping row. */
+export interface DenseDocEntry {
+  docId: string;
+  contentHash: string;
+}
+
+/** One ranked hit from the dense KNN search. */
+export interface DenseSearchHit {
+  /** The `qmd://` citation — same id space as the lexical backends. */
+  id: string;
+  /**
+   * Cosine similarity to the query embedding (vectors are L2-normalized, so
+   * this is derived deterministically from the vec0 L2 distance). Branded:
+   * model-derived, retrieval-side only.
+   */
+  score: DenseScore;
+  snippet: string;
+  collection: string;
+}
+
+/** Stored characters of leading doc text used as the fallback snippet. */
+export const DENSE_SNIPPET_CHARS = 160;
+
+export class DenseVecIndex {
+  private readonly db: Database.Database;
+  private dims: number | null;
+
+  constructor(opts: { path: string; modelId: string; modelVersion: string }) {
+    if (opts.path !== ':memory:') {
+      mkdirSync(dirname(opts.path), { recursive: true });
+    }
+    this.db = new Database(opts.path);
+    // Throws when the sqlite-vec native extension cannot load — the caller
+    // (adapter) treats a constructor throw as "no dense arm" and degrades.
+    sqliteVec.load(this.db);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
+    this.db.exec(
+      'CREATE TABLE IF NOT EXISTS dense_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL); ' +
+        'CREATE TABLE IF NOT EXISTS dense_docs (' +
+        'rowid INTEGER PRIMARY KEY, doc_id TEXT NOT NULL UNIQUE, collection TEXT NOT NULL, ' +
+        'content_hash TEXT NOT NULL, snippet TEXT NOT NULL, embedded_ms INTEGER NOT NULL)',
+    );
+
+    // Model pin gate: vectors from different weights are not comparable.
+    const storedModel = this.getMeta('model_id');
+    const storedVersion = this.getMeta('model_version');
+    if (
+      (storedModel !== null && storedModel !== opts.modelId) ||
+      (storedVersion !== null && storedVersion !== opts.modelVersion)
+    ) {
+      this.wipe();
+    }
+    this.setMeta('model_id', opts.modelId);
+    this.setMeta('model_version', opts.modelVersion);
+
+    const storedDims = this.getMeta('dims');
+    this.dims = storedDims === null ? null : Number(storedDims);
+  }
+
+  private getMeta(key: string): string | null {
+    const row = this.db.prepare('SELECT value FROM dense_meta WHERE key = ?').get(key) as
+      { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
+  private setMeta(key: string, value: string): void {
+    this.db
+      .prepare(
+        'INSERT INTO dense_meta (key, value) VALUES (?, ?) ' +
+          'ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+      )
+      .run(key, value);
+  }
+
+  /** Drop every embedded doc + vector (meta survives; dims reset). */
+  private wipe(): void {
+    this.db.exec('DELETE FROM dense_docs; DROP TABLE IF EXISTS dense_vec');
+    this.db.prepare('DELETE FROM dense_meta WHERE key = ?').run('dims');
+    this.dims = null;
+  }
+
+  /**
+   * Ensure the vec0 table exists for `dims`-dimensional vectors. A dimension
+   * change (impossible without a model change, but belt-and-braces) wipes and
+   * recreates — mixed-dimension KNN is meaningless.
+   */
+  private ensureVecTable(dims: number): void {
+    if (this.dims === dims) return;
+    if (this.dims !== null) this.wipe();
+    this.db.exec(
+      'CREATE VIRTUAL TABLE IF NOT EXISTS dense_vec USING ' +
+        `vec0(collection text partition key, embedding float[${dims}])`,
+    );
+    this.setMeta('dims', String(dims));
+    this.dims = dims;
+  }
+
+  /**
+   * Upsert one embedded document. `contentHash` MUST be the hash of the exact
+   * (truncated) text the embedding was computed from — it is the incremental
+   * re-embed key.
+   */
+  upsert(doc: {
+    docId: string;
+    collection: string;
+    contentHash: string;
+    snippet: string;
+    embedding: Float32Array;
+  }): void {
+    this.ensureVecTable(doc.embedding.length);
+    const tx = this.db.transaction(() => {
+      const prior = this.db
+        .prepare('SELECT rowid FROM dense_docs WHERE doc_id = ?')
+        .get(doc.docId) as { rowid: number } | undefined;
+      if (prior !== undefined) {
+        // vec0 rejects non-INTEGER rowid bindings; BigInt binds as INTEGER.
+        this.db.prepare('DELETE FROM dense_vec WHERE rowid = ?').run(BigInt(prior.rowid));
+        this.db.prepare('DELETE FROM dense_docs WHERE rowid = ?').run(prior.rowid);
+      }
+      const inserted = this.db
+        .prepare(
+          'INSERT INTO dense_docs (doc_id, collection, content_hash, snippet, embedded_ms) ' +
+            'VALUES (?, ?, ?, ?, ?)',
+        )
+        .run(doc.docId, doc.collection, doc.contentHash, doc.snippet, Date.now());
+      this.db
+        .prepare('INSERT INTO dense_vec (rowid, collection, embedding) VALUES (?, ?, ?)')
+        .run(
+          BigInt(inserted.lastInsertRowid),
+          doc.collection,
+          Buffer.from(doc.embedding.buffer, doc.embedding.byteOffset, doc.embedding.byteLength),
+        );
+    });
+    tx();
+  }
+
+  /** Remove documents by citation id (no-op for ids that are not indexed). */
+  remove(docIds: readonly string[]): void {
+    const tx = this.db.transaction(() => {
+      for (const docId of docIds) {
+        const prior = this.db
+          .prepare('SELECT rowid FROM dense_docs WHERE doc_id = ?')
+          .get(docId) as { rowid: number } | undefined;
+        if (prior === undefined) continue;
+        this.db.prepare('DELETE FROM dense_vec WHERE rowid = ?').run(BigInt(prior.rowid));
+        this.db.prepare('DELETE FROM dense_docs WHERE rowid = ?').run(prior.rowid);
+      }
+    });
+    tx();
+  }
+
+  /** Every indexed doc's (docId, contentHash) — the indexer's diff input. */
+  entries(): DenseDocEntry[] {
+    return (
+      this.db.prepare('SELECT doc_id, content_hash FROM dense_docs').all() as Array<{
+        doc_id: string;
+        content_hash: string;
+      }>
+    ).map((r) => ({ docId: r.doc_id, contentHash: r.content_hash }));
+  }
+
+  /**
+   * KNN search: top-`k` nearest docs to `queryEmbedding` (vec0 L2 distance;
+   * inputs are L2-normalized so the ordering equals cosine ordering, and the
+   * reported score is the exact cosine similarity `1 − d²/2`).
+   *
+   * `allowedCollections` (empty = no filter, i.e. scope `all`) is pushed INTO
+   * the KNN via the vec0 `collection` partition key, so the k returned rows are
+   * the k nearest *within scope* — out-of-scope collections (e.g. archive under
+   * a curated search) never occupy a slot. This is the correctness fix that a
+   * post-hoc `.filter()` cannot give: filtering after a top-k over ALL
+   * collections would silently shrink an in-scope result set below k.
+   */
+  search(
+    queryEmbedding: Float32Array,
+    k: number,
+    allowedCollections: readonly string[] = [],
+  ): DenseSearchHit[] {
+    if (this.dims === null || k <= 0) return [];
+    if (queryEmbedding.length !== this.dims) return []; // wrong-model query vector
+    const scopeClause =
+      allowedCollections.length === 0
+        ? ''
+        : `AND v.collection IN (${allowedCollections.map(() => '?').join(', ')}) `;
+    const rows = this.db
+      .prepare(
+        'SELECT d.doc_id AS id, v.collection AS collection, d.snippet AS snippet, v.distance AS distance ' +
+          'FROM dense_vec v JOIN dense_docs d ON d.rowid = v.rowid ' +
+          `WHERE v.embedding MATCH ? AND k = ? ${scopeClause}ORDER BY v.distance`,
+      )
+      .all(
+        Buffer.from(queryEmbedding.buffer, queryEmbedding.byteOffset, queryEmbedding.byteLength),
+        k,
+        ...allowedCollections,
+      ) as Array<{ id: string; collection: string; snippet: string; distance: number }>;
+    return rows.map((r) => ({
+      id: r.id,
+      collection: r.collection,
+      snippet: r.snippet,
+      score: denseScore(1 - (r.distance * r.distance) / 2),
+    }));
+  }
+
+  count(): number {
+    return (this.db.prepare('SELECT count(*) AS n FROM dense_docs').get() as { n: number }).n;
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // already closed — nothing to do
+    }
+  }
+}

--- a/packages/qmd-adapter/src/dense/dense-indexer.ts
+++ b/packages/qmd-adapter/src/dense/dense-indexer.ts
@@ -55,7 +55,7 @@ export interface DenseIndexReport {
  * Chars of each doc embedded (the rest is truncated). 2000 chars ≈ ~500
  * EmbeddingGemma tokens — comfortably inside both the 2048-token model context
  * and a 1024-token `--parallel 2` slot. Chosen from the measured corpus +
- * throughput curve (2026-07-20, 17,310-doc frozen corpus): median doc is 2778
+ * throughput curve (2026-07-20, 17,295-doc frozen corpus): median doc is 2778
  * bytes and 93% exceed 1200 chars, so 1200 would truncate away most of the
  * body; embedding at 2000 vs 1200 chars costs only +23% wall-clock (~138 vs
  * ~112 min full-corpus) while capturing ~72% of the median doc vs ~43%. 3000

--- a/packages/qmd-adapter/src/dense/dense-indexer.ts
+++ b/packages/qmd-adapter/src/dense/dense-indexer.ts
@@ -1,0 +1,249 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+
+import { getExportableCollections } from '../collections/collection-registry.js';
+import type { DenseVecIndex } from './dense-index.js';
+import { DENSE_SNIPPET_CHARS } from './dense-index.js';
+import type { EmbedClient } from './embed-client.js';
+
+/**
+ * Incremental embed sweep over the git-exporter output tree (bead B4).
+ *
+ * Same sweep shape as the native FTS5 `NativeIndexManager.ensureFresh()` —
+ * every exportable collection's `<exportDir>/<sourceSubdir>/*.md`, doc ids
+ * being the `qmd://` citations — but keyed on CONTENT HASH rather than mtime:
+ * an embedding costs ~0.4 s of CPU model time per doc, so the diff key must
+ * be the exact text that was embedded, not a filesystem timestamp a `touch`
+ * or re-export can churn.
+ *
+ * DEGRADE CONTRACT: when the embedding service is down the sweep is a no-op
+ * (`serviceDown: true`) and the index simply stays stale — dense retrieval
+ * keeps serving yesterday's vectors, and the lexical arms are unaffected.
+ *
+ * RESILIENCE (B4, learned the hard way over several failed full builds):
+ *   1. A batch failure is RETRIED with bounded exponential backoff (~45 s
+ *      window). The embedder is a single-process CPU model under a
+ *      `Restart=on-failure` unit; the retry bridges a transient crash +
+ *      auto-restart instead of discarding the build on one blip.
+ *   2. When retries are exhausted, a HEALTH PROBE decides: service down → a
+ *      durable outage → abort the remainder as a stale index (fail-open);
+ *      service up → the batch is DATA-POISON (an input the server rejects, e.g.
+ *      longer than the physical batch size) → skip just those docs and keep
+ *      building. One bad doc must never strand a 17k-doc index — the exact
+ *      failure mode that aborted a full build after 32 docs when a real doc
+ *      tokenized past the ubatch size.
+ * Nothing here ever throws to the caller.
+ */
+
+/** Outcome of one dense index sync sweep. */
+export interface DenseIndexReport {
+  /** Docs (re-)embedded this sweep. */
+  embedded: number;
+  /** Docs removed because their export file is gone. */
+  removed: number;
+  /** Docs that needed embedding but were skipped by a mid-sweep failure. */
+  skipped: number;
+  /** Total exportable docs currently on disk. */
+  totalDocs: number;
+  /** True when the service was unreachable and the sweep did not run. */
+  serviceDown: boolean;
+}
+
+/**
+ * Chars of each doc embedded (the rest is truncated). 2000 chars ≈ ~500
+ * EmbeddingGemma tokens — comfortably inside both the 2048-token model context
+ * and a 1024-token `--parallel 2` slot. Chosen from the measured corpus +
+ * throughput curve (2026-07-20, 17,310-doc frozen corpus): median doc is 2778
+ * bytes and 93% exceed 1200 chars, so 1200 would truncate away most of the
+ * body; embedding at 2000 vs 1200 chars costs only +23% wall-clock (~138 vs
+ * ~112 min full-corpus) while capturing ~72% of the median doc vs ~43%. 3000
+ * chars doubled the cost (~235 min) for diminishing corpus coverage, so 2000
+ * is the recall/cost knee. Raising this re-embeds every doc on the next sweep
+ * (the content hash changes) — deliberate.
+ */
+export const DEFAULT_DENSE_MAX_DOC_CHARS = 2000;
+export const DEFAULT_DENSE_BATCH_SIZE = 16;
+
+export interface DenseIndexerOptions {
+  index: DenseVecIndex;
+  client: EmbedClient;
+  /** Root of the git-exporter output tree (same dir the lexical indexes read). */
+  exportDir: string;
+  /**
+   * Truncate each document to this many chars before embedding (default
+   * {@link DEFAULT_DENSE_MAX_DOC_CHARS} = 2000). EmbeddingGemma's context is
+   * 2048 tokens; a governed memory's lead carries its summary+provenance
+   * header (the semantic core) and 2000 chars covers the bulk of the median
+   * doc. NOTE: changing this changes the embedded text, hence the content
+   * hashes, hence triggers a full re-embed on the next sweep — deliberate.
+   */
+  maxDocChars?: number;
+  /** Docs per /v1/embeddings request (default 16). */
+  batchSize?: number;
+  /**
+   * How many times to RE-ATTEMPT a failed batch before concluding the service
+   * is durably down (default 5, i.e. 6 total attempts). Bridges the embedder's
+   * `Restart=on-failure` auto-recovery so a transient crash mid-build does not
+   * discard the whole embed.
+   */
+  maxBatchRetries?: number;
+  /** First retry backoff in ms (default 2000); doubles each attempt up to {@link DenseIndexerOptions.maxRetryBackoffMs}. */
+  retryBackoffMs?: number;
+  /** Cap on a single retry backoff in ms (default 15000). */
+  maxRetryBackoffMs?: number;
+}
+
+/** Non-blocking sleep. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class DenseIndexer {
+  private readonly index: DenseVecIndex;
+  private readonly client: EmbedClient;
+  private readonly exportDir: string;
+  private readonly maxDocChars: number;
+  private readonly batchSize: number;
+  private readonly maxBatchRetries: number;
+  private readonly retryBackoffMs: number;
+  private readonly maxRetryBackoffMs: number;
+
+  constructor(options: DenseIndexerOptions) {
+    this.index = options.index;
+    this.client = options.client;
+    this.exportDir = options.exportDir;
+    this.maxDocChars = options.maxDocChars ?? DEFAULT_DENSE_MAX_DOC_CHARS;
+    this.batchSize = options.batchSize ?? DEFAULT_DENSE_BATCH_SIZE;
+    this.maxBatchRetries = options.maxBatchRetries ?? 5;
+    this.retryBackoffMs = options.retryBackoffMs ?? 2000;
+    this.maxRetryBackoffMs = options.maxRetryBackoffMs ?? 15_000;
+  }
+
+  /**
+   * Embed one batch, RE-ATTEMPTING on failure with bounded exponential backoff.
+   * Returns the vectors on success, or `null` only after the whole retry budget
+   * is spent with the service still failing (a durable outage). A `null` from
+   * `client.embed` is fail-fast (connection-refused during an auto-restart is
+   * near-instant), so the wall-clock cost of a retry round is dominated by the
+   * backoff, not by timeouts.
+   */
+  private async embedBatchWithRetry(texts: readonly string[]): Promise<Float32Array[] | null> {
+    let backoff = this.retryBackoffMs;
+    for (let attempt = 0; attempt <= this.maxBatchRetries; attempt++) {
+      const vectors = await this.client.embed(texts, 'document');
+      if (vectors !== null) return vectors;
+      if (attempt === this.maxBatchRetries) break;
+      await delay(backoff);
+      backoff = Math.min(backoff * 2, this.maxRetryBackoffMs);
+    }
+    return null;
+  }
+
+  /**
+   * Bring the dense index up to date with the export tree: embed new/changed
+   * docs (batched), remove vanished ones, leave unchanged ones untouched.
+   */
+  async sync(): Promise<DenseIndexReport> {
+    // On-disk truth: every exportable doc, with the exact text we would embed.
+    const onDisk = new Map<
+      string,
+      { collection: string; text: string; contentHash: string; snippet: string }
+    >();
+    for (const def of getExportableCollections()) {
+      const dir = join(this.exportDir, def.sourceSubdir);
+      if (!existsSync(dir)) continue;
+      for (const name of readdirSync(dir)) {
+        if (!name.endsWith('.md')) continue;
+        let raw: string;
+        try {
+          raw = readFileSync(join(dir, name), 'utf8');
+        } catch {
+          continue; // deleted between readdir and read
+        }
+        const text = raw.slice(0, this.maxDocChars);
+        onDisk.set(`qmd://${def.name}/${name}`, {
+          collection: def.name,
+          text,
+          contentHash: computeContentHash(text),
+          snippet: raw.slice(0, DENSE_SNIPPET_CHARS),
+        });
+      }
+    }
+
+    const stored = new Map(this.index.entries().map((e) => [e.docId, e.contentHash]));
+
+    const toEmbed: string[] = [];
+    for (const [docId, info] of onDisk) {
+      if (stored.get(docId) !== info.contentHash) toEmbed.push(docId);
+    }
+    const toRemove = [...stored.keys()].filter((docId) => !onDisk.has(docId));
+
+    if (toRemove.length > 0) this.index.remove(toRemove);
+
+    if (toEmbed.length > 0 && !(await this.client.healthy())) {
+      // Service down and work pending: the index stays stale by design.
+      return {
+        embedded: 0,
+        removed: toRemove.length,
+        skipped: toEmbed.length,
+        totalDocs: onDisk.size,
+        serviceDown: true,
+      };
+    }
+
+    let embedded = 0;
+    let skipped = 0;
+    for (let start = 0; start < toEmbed.length; start += this.batchSize) {
+      const batchIds = toEmbed.slice(start, start + this.batchSize);
+      const batchDocs = batchIds.map((id) => onDisk.get(id));
+      const vectors = await this.embedBatchWithRetry(batchDocs.map((d) => d?.text ?? ''));
+      if (vectors === null) {
+        // The batch failed every retry across the whole backoff window. Two
+        // very different causes, distinguished by a health probe:
+        //   - service DOWN → a durable outage → abort the remainder as a stale
+        //     index (fail-open); the next sweep resumes at the un-embedded docs.
+        //   - service UP → the batch is DATA-POISON, not an outage: the server
+        //     rejects an input it will never accept (e.g. an input longer than
+        //     the physical batch size). Retrying it forever would strand the
+        //     whole build on one bad doc — the exact failure that aborted a full
+        //     17k build after 32 docs. So skip just these docs and keep going.
+        if (await this.client.healthy()) {
+          skipped += batchIds.length;
+          continue;
+        }
+        skipped += toEmbed.length - start;
+        return {
+          embedded,
+          removed: toRemove.length,
+          skipped,
+          totalDocs: onDisk.size,
+          serviceDown: true,
+        };
+      }
+      for (let i = 0; i < batchIds.length; i++) {
+        const docId = batchIds[i];
+        const info = docId === undefined ? undefined : onDisk.get(docId);
+        const embedding = vectors[i];
+        if (docId === undefined || info === undefined || embedding === undefined) continue;
+        this.index.upsert({
+          docId,
+          collection: info.collection,
+          contentHash: info.contentHash,
+          snippet: info.snippet,
+          embedding,
+        });
+        embedded++;
+      }
+    }
+
+    return {
+      embedded,
+      removed: toRemove.length,
+      skipped,
+      totalDocs: onDisk.size,
+      serviceDown: false,
+    };
+  }
+}

--- a/packages/qmd-adapter/src/dense/embed-client.ts
+++ b/packages/qmd-adapter/src/dense/embed-client.ts
@@ -1,0 +1,135 @@
+/**
+ * HTTP client for the local embedding service (blueprint bead B4; decisions
+ * 038-AT-DECR + 044-AT-DECR: sqlite-vec + EmbeddingGemma-300M only).
+ *
+ * Talks to the loopback-only `bbb-embedder` systemd user service — the same
+ * SHA-256-pinned llama.cpp `llama-server` runtime the reranker uses (B1),
+ * running the pinned EmbeddingGemma-300M GGUF with `--embedding` enabled.
+ * No external API is ever in this path.
+ *
+ * FAIL-OPEN CONTRACT (read-path only): every failure mode — connection
+ * refused, timeout, non-200, malformed JSON, dimension mismatch — returns
+ * `null`. On the query path the caller serves the lexical fusion without a
+ * dense list; on the index path the dense index simply stays stale. Dense is
+ * an opt-in recall boost, never a dependency the serving path can die on.
+ */
+
+/**
+ * A dense embedding-similarity score — a MODEL-DERIVED number, branded so it
+ * can never be mistaken for (or assigned to) the govern side's
+ * DeterministicScore. It lives above the spool: read-path candidate
+ * generation only, never durable state.
+ */
+export type DenseScore = number & {
+  readonly __brand: 'retrieval-dense-score';
+};
+
+/** Brand a raw model-derived similarity as a retrieval-side dense score. */
+export function denseScore(value: number): DenseScore {
+  return value as DenseScore;
+}
+
+/**
+ * EmbeddingGemma prompt-prefix contract (the model card's retrieval prompts).
+ * Queries and documents MUST be embedded with their respective prefixes or
+ * similarity quality degrades — the model was trained asymmetric.
+ */
+export const EMBEDDINGGEMMA_QUERY_PREFIX = 'task: search result | query: ';
+export const EMBEDDINGGEMMA_DOCUMENT_PREFIX = 'title: none | text: ';
+
+/** Which side of the asymmetric retrieval pair a text is embedded as. */
+export type EmbedRole = 'query' | 'document';
+
+export interface EmbedClientOptions {
+  /** Base URL of the embedding service, e.g. `http://127.0.0.1:8098`. */
+  url: string;
+  /**
+   * Hard per-request timeout. Default 5000 ms — sized for a single query
+   * embed; the indexer passes a much larger budget for document batches.
+   */
+  timeoutMs?: number;
+}
+
+export const DEFAULT_EMBED_TIMEOUT_MS = 5000;
+
+/** Shape of llama-server's /v1/embeddings response (subset we consume). */
+interface EmbeddingsApiResponse {
+  data?: Array<{ index?: number; embedding?: number[] }>;
+}
+
+export class EmbedClient {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: EmbedClientOptions) {
+    this.baseUrl = options.url.replace(/\/+$/, '');
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_EMBED_TIMEOUT_MS;
+  }
+
+  /**
+   * Embed `texts` via POST /v1/embeddings, applying the EmbeddingGemma
+   * role prefix to each. Returns one vector per input, in input order.
+   * Returns `null` on ANY failure — the caller MUST treat that as
+   * "no dense signal available", never as an error to surface.
+   */
+  async embed(texts: readonly string[], role: EmbedRole): Promise<Float32Array[] | null> {
+    if (texts.length === 0) return [];
+    const prefix = role === 'query' ? EMBEDDINGGEMMA_QUERY_PREFIX : EMBEDDINGGEMMA_DOCUMENT_PREFIX;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'embedding', input: texts.map((t) => prefix + t) }),
+        signal: controller.signal,
+      });
+      if (!response.ok) return null;
+      const parsed = (await response.json()) as EmbeddingsApiResponse;
+      if (!Array.isArray(parsed.data) || parsed.data.length !== texts.length) return null;
+      const vectors: Float32Array[] = new Array<Float32Array>(texts.length);
+      let dims = -1;
+      for (const entry of parsed.data) {
+        if (
+          typeof entry?.index !== 'number' ||
+          entry.index < 0 ||
+          entry.index >= texts.length ||
+          !Array.isArray(entry.embedding) ||
+          entry.embedding.length === 0 ||
+          entry.embedding.some((v) => typeof v !== 'number' || !Number.isFinite(v))
+        ) {
+          return null; // malformed row — distrust the whole response
+        }
+        if (dims === -1) dims = entry.embedding.length;
+        else if (entry.embedding.length !== dims) return null; // ragged dims
+        vectors[entry.index] = Float32Array.from(entry.embedding);
+      }
+      // Every slot must be filled exactly once (duplicate indexes leave
+      // holes). NOTE: an indexed for-loop, not `.some()` — Array#some skips
+      // the empty slots of a sparse array, which is exactly what a hole is.
+      for (let i = 0; i < vectors.length; i++) {
+        if (vectors[i] === undefined) return null;
+      }
+      return vectors;
+    } catch {
+      // Connection refused, abort/timeout, DNS, bad JSON body — all fail open.
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Probe GET /health. `false` on any failure — never throws. */
+  async healthy(): Promise<boolean> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.baseUrl}/health`, { signal: controller.signal });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/qmd-adapter/src/dense/index.ts
+++ b/packages/qmd-adapter/src/dense/index.ts
@@ -1,0 +1,18 @@
+export {
+  EmbedClient,
+  denseScore,
+  DEFAULT_EMBED_TIMEOUT_MS,
+  EMBEDDINGGEMMA_QUERY_PREFIX,
+  EMBEDDINGGEMMA_DOCUMENT_PREFIX,
+} from './embed-client.js';
+export type { DenseScore, EmbedRole, EmbedClientOptions } from './embed-client.js';
+
+export { DenseVecIndex, DENSE_SNIPPET_CHARS } from './dense-index.js';
+export type { DenseSearchHit, DenseDocEntry } from './dense-index.js';
+
+export {
+  DenseIndexer,
+  DEFAULT_DENSE_MAX_DOC_CHARS,
+  DEFAULT_DENSE_BATCH_SIZE,
+} from './dense-indexer.js';
+export type { DenseIndexReport, DenseIndexerOptions } from './dense-indexer.js';

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -248,6 +248,15 @@ function extractSnapshot(tarballPath: string, tmpBase: string): string {
   return exportDir;
 }
 
+/** Wall-clock + outcome of a dense index build inside an eval arm (B4). */
+interface DenseBuildInfo {
+  wallClockMs: number;
+  embedded: number;
+  skipped: number;
+  removed: number;
+  totalDocs: number;
+}
+
 /** Build a temp index over `exportDir` and run the full governed-brain-v1 set. */
 async function evalCorpus(
   exportDir: string,
@@ -255,17 +264,35 @@ async function evalCorpus(
   opts: {
     /** Opt-in rerank arm for the A/B comparison (044-AT-DECR ship order). */
     rerank?: QmdAdapterConfig['rerank'];
+    /** Opt-in dense arm for the A/B comparison (B4 ship gate). */
+    dense?: QmdAdapterConfig['dense'];
     /** Reuse the index a prior evalCorpus call already built for this tenant. */
     skipIndexBuild?: boolean;
+    /**
+     * Build the dense sidecar index (embed the corpus) before querying, and
+     * report its wall-clock. Requires `dense`. Fails the arm loudly when the
+     * embedder is down or the build embeds nothing — an A/B arm must never
+     * report numbers from a silently-empty dense index.
+     */
+    buildDenseIndex?: boolean;
+    /**
+     * Log a per-query progress line (index i/N + wall-clock ms + top hit) during
+     * the verdict phase. Turns a slow/hung query phase from a silent black box
+     * into an observable stream — added after a full run's query phase was
+     * misread as hung when it was actually still building.
+     */
+    logProgress?: boolean;
   } = {},
 ): Promise<
-  { ok: true; sr: StratifiedReport; perQuery: EvalPerQuery[] } | { ok: false; reason: string }
+  | { ok: true; sr: StratifiedReport; perQuery: EvalPerQuery[]; denseBuild?: DenseBuildInfo }
+  | { ok: false; reason: string }
 > {
   const adapter = new QmdAdapter({
     tenantId: ANCHOR_TENANT,
     exportDir,
     timeout: ANCHOR_QMD_TIMEOUT_MS,
     ...(opts.rerank ? { rerank: opts.rerank } : {}),
+    ...(opts.dense ? { dense: opts.dense } : {}),
   });
   if (!opts.skipIndexBuild) {
     const built = await reindex(adapter);
@@ -276,7 +303,53 @@ async function evalCorpus(
       };
     }
   }
-  const retrieve = qmdRetrievalFn(adapter, ANCHOR_TENANT, 'curated');
+  let denseBuild: DenseBuildInfo | undefined;
+  if (opts.buildDenseIndex === true) {
+    const t0 = Date.now();
+    const report = await adapter.denseSync();
+    const wallClockMs = Date.now() - t0;
+    if (report === null) {
+      return { ok: false, reason: 'dense build requested but the adapter has no dense arm' };
+    }
+    if (report.serviceDown) {
+      return {
+        ok: false,
+        reason: `dense index build aborted — embedding service down (embedded ${report.embedded}, skipped ${report.skipped})`,
+      };
+    }
+    if (report.embedded === 0 && report.totalDocs > 0) {
+      return {
+        ok: false,
+        reason: `dense index build embedded 0 of ${report.totalDocs} docs — refusing to eval an empty dense index`,
+      };
+    }
+    denseBuild = {
+      wallClockMs,
+      embedded: report.embedded,
+      skipped: report.skipped,
+      removed: report.removed,
+      totalDocs: report.totalDocs,
+    };
+    console.log(
+      `dense index built: ${report.embedded}/${report.totalDocs} docs embedded ` +
+        `(${report.skipped} skipped) in ${(wallClockMs / 60_000).toFixed(1)} min`,
+    );
+  }
+  const baseRetrieve = qmdRetrievalFn(adapter, ANCHOR_TENANT, 'curated');
+  const totalQueries = GOVERNED_BRAIN_V1_DATASET.queries.length;
+  let queryNum = 0;
+  const retrieve = opts.logProgress
+    ? async (q: string, k: number): Promise<string[]> => {
+        const t0 = Date.now();
+        const ids = await baseRetrieve(q, k);
+        queryNum++;
+        console.log(
+          `  [verdict] query ${queryNum}/${totalQueries}  ${Date.now() - t0} ms  ` +
+            `top=${ids[0] ?? '(none)'}`,
+        );
+        return ids;
+      }
+    : baseRetrieve;
   const report = await runEval(GOVERNED_BRAIN_V1_DATASET, retrieve, {
     k: 10,
     backend: backendLabel,
@@ -291,6 +364,7 @@ async function evalCorpus(
   }
   return {
     ok: true,
+    ...(denseBuild ? { denseBuild } : {}),
     sr: stratify(report, GOVERNED_BRAIN_V1_DATASET.queries),
     perQuery: report.perQuery.map((q) => ({
       id: q.id,
@@ -409,6 +483,10 @@ export async function runGovernedEvalAnchor(): Promise<number> {
     // part of the verdict — the floors gate the fused arm only.
     await maybeRunRerankArm(exportDir, frozen.sr, resultsDir, verified.sha256);
 
+    // Informational dense A/B arm (B4 ship gate: dense retrieval is judged on
+    // this harness BEFORE any default wiring — same discipline as rerank).
+    await maybeRunDenseArm(exportDir, frozen.sr, resultsDir, verified.sha256);
+
     // Informational live run — never part of the verdict, off by default so the
     // frozen anchor stays the deterministic path.
     await maybeRunLiveInformational();
@@ -514,6 +592,192 @@ async function maybeRunRerankArm(
     console.log(`rerank A/B artifact written: ${outPath}`);
   } catch (err: unknown) {
     console.error('WARN could not write the rerank A/B artifact:', err);
+  }
+}
+
+/**
+ * GOVERNED_EVAL_DENSE=1: the A/B arm for the dense-retrieval verdict (B4).
+ * Builds the sqlite-vec sidecar index over the SAME extracted frozen corpus
+ * (embedding every doc via the local `bbb-embedder` service — an offline,
+ * measured cost reported as wall-clock), then runs the identical frozen query
+ * set through the same lexical indexes with the dense list joining the RRF
+ * fusion. Embedder URL override: GOVERNED_EVAL_DENSE_URL (default the
+ * bbb-embedder loopback service). Informational only — prints the
+ * side-by-side per-stratum deltas, the ship-gate readout, and writes
+ * `governed-brain-v1-dense.json`; the exit code never depends on this arm.
+ *
+ * SHIP GATE (blueprint B4, judged from this run's own fused baseline):
+ * semantic Recall@10 must beat the fused arm's semantic Recall@10 materially
+ * — this build exists because dense should retrieve what lexical cannot —
+ * and lexical Recall@10 must not drop below its fused baseline minus the
+ * canonical epsilon.
+ */
+async function maybeRunDenseArm(
+  exportDir: string,
+  fusedSr: StratifiedReport,
+  resultsDir: string,
+  snapshotSha256: string,
+): Promise<void> {
+  if (process.env['GOVERNED_EVAL_DENSE'] !== '1') return;
+  // Hard fail-open boundary: this is an INFORMATIONAL arm and must never be
+  // able to fail the anchor verdict. `evalCorpus` returns {ok:false} for the
+  // expected failure modes, but an unexpected throw anywhere below (embedder
+  // OOM-killed mid-build, a runEval defect, a disk error) would otherwise
+  // propagate to main() and print "governed eval anchor crashed" INSTEAD of
+  // "ANCHOR PASS" on the perfectly-good fused floor. Same discipline the
+  // reranker arm follows — the model side can never take the deterministic
+  // verdict down.
+  try {
+    await runDenseArm(exportDir, fusedSr, resultsDir, snapshotSha256);
+  } catch (err: unknown) {
+    console.error(
+      '\ndense arm CRASHED (informational, verdict unaffected — the fused ' +
+        'floor still governs):',
+      err,
+    );
+  }
+}
+
+async function runDenseArm(
+  exportDir: string,
+  fusedSr: StratifiedReport,
+  resultsDir: string,
+  snapshotSha256: string,
+): Promise<void> {
+  const url = process.env['GOVERNED_EVAL_DENSE_URL'] ?? 'http://127.0.0.1:8098';
+
+  // Embedding the full 17k-doc corpus takes ~3 h; GOVERNED_EVAL_DENSE_PREBUILT
+  // lets a run REUSE an already-built dense-vec.sqlite (copied into the temp
+  // tenant dir so the eval never mutates the preserved artifact) and run ONLY
+  // the fast verdict phase. The index carries its own model+dims+prefix pin, so
+  // opening it fail-closed verifies it matches this code (a mismatch would wipe
+  // it, which we detect below via the empty-index guard). This makes every
+  // re-measure minutes, not hours.
+  const prebuilt = process.env['GOVERNED_EVAL_DENSE_PREBUILT'];
+  let denseIndexPath: string | undefined;
+  const buildDenseIndex = prebuilt === undefined;
+  if (prebuilt !== undefined) {
+    const resolved = expandHome(prebuilt);
+    if (!existsSync(resolved)) {
+      console.error(`\ndense arm FAILED: GOVERNED_EVAL_DENSE_PREBUILT not found: ${resolved}`);
+      return;
+    }
+    denseIndexPath = join(
+      process.env['TEAMKB_BASE_PATH'] ?? tmpdir(),
+      'dense-prebuilt-reuse.sqlite',
+    );
+    cpSync(resolved, denseIndexPath);
+    console.log(
+      `\ndense arm: REUSING prebuilt index ${resolved} (${denseIndexPath}) — ` +
+        'skipping the corpus embed, running the verdict phase only.',
+    );
+  }
+
+  const dense = await evalCorpus(
+    exportDir,
+    'qmd-bm25+fts5+embeddinggemma-dense-rrf (frozen snapshot)',
+    {
+      skipIndexBuild: true, // the lexical indexes are already built for this tenant
+      buildDenseIndex, // build the dense sidecar unless reusing a prebuilt one
+      logProgress: true, // per-query verdict-phase progress (never a silent black box again)
+      dense: {
+        enabled: true,
+        url,
+        searchK: 50,
+        maxDocChars: 2000, // matches DEFAULT_DENSE_MAX_DOC_CHARS — the shipped default
+        timeoutMs: 30_000, // offline arm: a slow query-embed is data, not an outage
+        ...(denseIndexPath ? { indexPath: denseIndexPath } : {}),
+      },
+    },
+  );
+  if (!dense.ok) {
+    console.error(`\ndense arm FAILED (informational, verdict unaffected): ${dense.reason}`);
+    return;
+  }
+  console.log('\n=== dense A/B arm (informational — B4 ship-gate evidence) ===');
+  console.log(formatStratifiedReport(dense.sr));
+  console.log('\n=== per-stratum delta (dense-fused − lexical-fused) ===');
+  const fusedBy = new Map(fusedSr.byKind.map((s) => [s.stratum, s]));
+  const rows = [
+    ...dense.sr.byKind.map((s) => ({ s, f: fusedBy.get(s.stratum) })),
+    { s: dense.sr.overall, f: fusedSr.overall },
+  ];
+  const d = (a: number, b: number): string => {
+    const delta = a - b;
+    return `${delta >= 0 ? '+' : ''}${delta.toFixed(4)}`;
+  };
+  for (const { s, f } of rows) {
+    if (!f) continue;
+    console.log(
+      `  ${s.stratum.padEnd(9)} ΔRecall@10=${d(s.meanRecallAtK, f.meanRecallAtK)}  ` +
+        `ΔnDCG@10=${d(s.meanNdcgAtK, f.meanNdcgAtK)}  ΔMRR=${d(s.mrr, f.mrr)}`,
+    );
+  }
+
+  // Ship-gate readout (informational): semantic must improve materially,
+  // lexical must hold within the canonical epsilon of its fused baseline.
+  const fusedSemantic = fusedSr.byKind.find((s) => s.stratum === 'semantic');
+  const fusedLexical = fusedSr.byKind.find((s) => s.stratum === 'lexical');
+  const denseSemantic = dense.sr.byKind.find((s) => s.stratum === 'semantic');
+  const denseLexical = dense.sr.byKind.find((s) => s.stratum === 'lexical');
+  let gate: {
+    semanticBaseline: number;
+    semanticMeasured: number;
+    semanticImproved: boolean;
+    lexicalBaseline: number;
+    lexicalMeasured: number;
+    lexicalHeld: boolean;
+    epsilon: number;
+    verdict: 'PASS' | 'MISS';
+  } | null = null;
+  if (fusedSemantic && fusedLexical && denseSemantic && denseLexical) {
+    const semanticImproved =
+      denseSemantic.meanRecallAtK > fusedSemantic.meanRecallAtK + RATCHET_EPSILON;
+    const lexicalHeld = denseLexical.meanRecallAtK >= fusedLexical.meanRecallAtK - RATCHET_EPSILON;
+    gate = {
+      semanticBaseline: fusedSemantic.meanRecallAtK,
+      semanticMeasured: denseSemantic.meanRecallAtK,
+      semanticImproved,
+      lexicalBaseline: fusedLexical.meanRecallAtK,
+      lexicalMeasured: denseLexical.meanRecallAtK,
+      lexicalHeld,
+      epsilon: RATCHET_EPSILON,
+      verdict: semanticImproved && lexicalHeld ? 'PASS' : 'MISS',
+    };
+    console.log(
+      `\nship gate: semantic Recall@10 ${gate.semanticMeasured.toFixed(4)} vs baseline ` +
+        `${gate.semanticBaseline.toFixed(4)} (${semanticImproved ? 'improved' : 'NOT materially improved'}); ` +
+        `lexical ${gate.lexicalMeasured.toFixed(4)} vs floor ` +
+        `${(gate.lexicalBaseline - gate.epsilon).toFixed(4)} (${lexicalHeld ? 'held' : 'REGRESSED'}) ` +
+        `→ ${gate.verdict}`,
+    );
+  }
+  try {
+    const outPath = join(resultsDir, 'governed-brain-v1-dense.json');
+    writeFileSync(
+      outPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          dataset: dense.sr.dataset,
+          snapshotSha256,
+          embedderUrl: url,
+          denseIndexBuild: dense.denseBuild ?? null,
+          // Provenance: whether the dense index was freshly built or reused from
+          // a preserved prebuilt (null = freshly built this run).
+          reusedPrebuiltIndex: prebuilt ?? null,
+          gate,
+          fused: { overall: fusedSr.overall, byKind: fusedSr.byKind },
+          dense: { overall: dense.sr.overall, byKind: dense.sr.byKind },
+          perQuery: dense.perQuery,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`dense A/B artifact written: ${outPath}`);
+  } catch (err: unknown) {
+    console.error('WARN could not write the dense A/B artifact:', err);
   }
 }
 

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -116,6 +116,29 @@ export type {
   RerankStageOptions,
 } from './rerank/index.js';
 
+// Dense — opt-in sqlite-vec + EmbeddingGemma retrieval arm, fail-open (B4, 038/044-AT-DECR)
+export {
+  EmbedClient,
+  denseScore,
+  DenseVecIndex,
+  DenseIndexer,
+  DENSE_SNIPPET_CHARS,
+  DEFAULT_EMBED_TIMEOUT_MS,
+  DEFAULT_DENSE_MAX_DOC_CHARS,
+  DEFAULT_DENSE_BATCH_SIZE,
+  EMBEDDINGGEMMA_QUERY_PREFIX,
+  EMBEDDINGGEMMA_DOCUMENT_PREFIX,
+} from './dense/index.js';
+export type {
+  DenseScore,
+  EmbedRole,
+  EmbedClientOptions,
+  DenseSearchHit,
+  DenseDocEntry,
+  DenseIndexReport,
+  DenseIndexerOptions,
+} from './dense/index.js';
+
 // Reindex — idempotent rebuild of the derived qmd-index from kb-export (e06.13)
 export { reindex } from './reindex/reindex.js';
 export type { ReindexReport } from './reindex/reindex.js';

--- a/packages/qmd-adapter/src/reindex/reindex.ts
+++ b/packages/qmd-adapter/src/reindex/reindex.ts
@@ -1,6 +1,7 @@
 import type { Result } from '@qmd-team-intent-kb/common';
 import type { QmdError } from '../types.js';
 import type { QmdAdapter } from '../adapter.js';
+import type { DenseIndexReport } from '../dense/dense-indexer.js';
 
 /** Outcome of an idempotent reindex run. */
 export interface ReindexReport {
@@ -8,6 +9,14 @@ export interface ReindexReport {
   collectionsCreated: string[];
   /** Whether `qmd update` (re-index of every registered collection) completed. */
   indexUpdated: boolean;
+  /**
+   * Dense sidecar sync outcome (B4). Absent when the adapter has no dense arm
+   * configured. An embedder outage shows up here as `serviceDown: true` with
+   * the pending docs counted in `skipped` — the dense index stays stale
+   * (degrade) but the reindex itself still succeeds: the lexical index is the
+   * serving floor and MUST NOT be held hostage by the optional dense arm.
+   */
+  dense?: DenseIndexReport;
 }
 
 /**
@@ -53,9 +62,19 @@ export async function reindex(adapter: QmdAdapter): Promise<Result<ReindexReport
       return { ok: false, error: updateResult.error };
     }
 
+    // Dense sidecar sync (B4) — only after the lexical index is up to date,
+    // and never fatal: `denseSync()` returns null when dense is not
+    // configured and a serviceDown report (not a throw) when the embedder is
+    // unreachable.
+    const dense = await adapter.denseSync();
+
     return {
       ok: true,
-      value: { collectionsCreated: ensureResult.value, indexUpdated: true },
+      value: {
+        collectionsCreated: ensureResult.value,
+        indexUpdated: true,
+        ...(dense === null ? {} : { dense }),
+      },
     };
   } catch (error) {
     return {

--- a/packages/qmd-adapter/src/search/rrf-fusion.ts
+++ b/packages/qmd-adapter/src/search/rrf-fusion.ts
@@ -1,5 +1,6 @@
 import type { QmdSearchResult } from '../types.js';
 import type { Fts5SearchHit } from '../native/fts5-backend.js';
+import type { DenseSearchHit } from '../dense/dense-index.js';
 
 /**
  * Reciprocal-rank-fusion constant. The standard k=60 from Cormack et al. —
@@ -10,28 +11,37 @@ import type { Fts5SearchHit } from '../native/fts5-backend.js';
 export const RRF_K = 60;
 
 /**
- * Fuse the qmd binary's ranked list with the native FTS5 ranked list using
- * deterministic reciprocal-rank fusion (retrieval epic, qmd-team-intent-kb-vps.2):
+ * Fuse the qmd binary's ranked list with the native FTS5 ranked list — and,
+ * when the opt-in dense arm (bead B4) supplies one, the dense KNN ranked list
+ * — using deterministic reciprocal-rank fusion (retrieval epic,
+ * qmd-team-intent-kb-vps.2):
  *
  *   rrf(d) = Σ over lists containing d of 1 / (k + rank_d)   (rank is 1-based)
  *
- * Join key is the `qmd://` citation (both backends emit the same ids). The two
- * backends deliberately differ in tokenization — qmd's keyword-AND misses
- * hyphen/dot-joined terms ("governed-brain", "CLAUDE.md") that FTS5's unicode61
- * tokenizer splits and matches — so their union, not either list alone, is the
- * recall surface.
+ * Join key is the `qmd://` citation (all backends emit the same ids). The two
+ * lexical backends deliberately differ in tokenization — qmd's keyword-AND
+ * misses hyphen/dot-joined terms ("governed-brain", "CLAUDE.md") that FTS5's
+ * unicode61 tokenizer splits and matches; the dense list contributes documents
+ * neither lexical backend can retrieve at all (paraphrase queries sharing no
+ * tokens with the doc) — so their union, not any list alone, is the recall
+ * surface.
  *
- * Determinism: ties break by best single-list rank, then by id lexicographic
- * order. No randomness, no model call.
+ * Determinism given the input lists: ties break by best single-list rank, then
+ * by id lexicographic order. The FUSION itself performs no model call and only
+ * ever consumes list RANKS — a dense hit's model-derived `DenseScore` never
+ * flows into the fused score, which stays a pure rank arithmetic value. (With
+ * an empty dense list — the default — the function is the same deterministic
+ * two-list fusion it always was.)
  *
  * Snippet/collection prefer the qmd hit (its diff-style snippets carry more
- * context); FTS5 fills in for hits qmd missed. The fused score is the raw RRF
- * score (~1/60 scale) — callers normalise to [0,1] against the top hit, which
- * the API service already does.
+ * context); FTS5 fills in for hits qmd missed, then the dense doc's stored
+ * lead text. The fused score is the raw RRF score (~1/60 scale) — callers
+ * normalise to [0,1] against the top hit, which the API service already does.
  */
 export function fuseReciprocalRank(
   qmdHits: readonly QmdSearchResult[],
   nativeHits: readonly Fts5SearchHit[],
+  denseHits: readonly DenseSearchHit[] = [],
   k: number = RRF_K,
 ): QmdSearchResult[] {
   interface FusedEntry {
@@ -40,6 +50,7 @@ export function fuseReciprocalRank(
     bestRank: number;
     qmdHit?: QmdSearchResult;
     nativeHit?: Fts5SearchHit;
+    denseHit?: DenseSearchHit;
   }
 
   const entries = new Map<string, FusedEntry>();
@@ -62,6 +73,15 @@ export function fuseReciprocalRank(
     entries.set(hit.id, entry);
   });
 
+  denseHits.forEach((hit, i) => {
+    const rank = i + 1;
+    const entry = entries.get(hit.id) ?? { id: hit.id, score: 0, bestRank: Infinity };
+    entry.score += 1 / (k + rank);
+    entry.bestRank = Math.min(entry.bestRank, rank);
+    entry.denseHit ??= hit;
+    entries.set(hit.id, entry);
+  });
+
   return [...entries.values()]
     .sort(
       (a, b) =>
@@ -73,7 +93,13 @@ export function fuseReciprocalRank(
       snippet:
         entry.qmdHit?.snippet !== undefined && entry.qmdHit.snippet !== ''
           ? entry.qmdHit.snippet
-          : (entry.nativeHit?.snippet ?? ''),
-      collection: entry.qmdHit?.collection ?? entry.nativeHit?.collection ?? 'unknown',
+          : entry.nativeHit?.snippet !== undefined && entry.nativeHit.snippet !== ''
+            ? entry.nativeHit.snippet
+            : (entry.denseHit?.snippet ?? ''),
+      collection:
+        entry.qmdHit?.collection ??
+        entry.nativeHit?.collection ??
+        entry.denseHit?.collection ??
+        'unknown',
     }));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
     devDependencies:
       '@qmd-team-intent-kb/policy-engine':
         specifier: workspace:*

--- a/scripts/bbb-embedder.service
+++ b/scripts/bbb-embedder.service
@@ -1,0 +1,98 @@
+# bbb-embedder.service — Bob's Big Brain embedding runtime (blueprint bead B4).
+#
+# Serves EmbeddingGemma-300M (Gemma license, GGUF Q8_0) via the SHA-256-pinned
+# llama.cpp `llama-server` (installed by scripts/install-llama-server.sh — the
+# SAME pinned runtime the reranker uses) with ONLY the /v1/embeddings endpoint
+# enabled, bound to loopback. No external API is ever in the serving path; the
+# qmd-adapter's dense arm calls http://127.0.0.1:8098/v1/embeddings and fails
+# open to the lexical RRF fusion if this service is down (queries lose only the
+# dense candidate list; the sidecar index simply stays stale until the service
+# returns).
+#
+# Install (copy, don't symlink — systemd user units should survive worktree GC):
+#   cp scripts/bbb-embedder.service ~/.config/systemd/user/bbb-embedder.service
+#   printf '%s  %s\n' \
+#     b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63 \
+#     "$HOME/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf" \
+#     > ~/.local/lib/bbb/embedder-weights.sha256
+#   systemctl --user daemon-reload && systemctl --user enable --now bbb-embedder
+#
+# Weight gate choice: ExecStartPre runs `sha256sum -c` against a one-line pin
+# file whose hash is the SAME constant pinned for id 'embedding' in
+# packages/qmd-adapter/src/weights/weights-manifest.ts (re-verified against the
+# on-disk GGUF during the B4 build). Chosen over invoking the compiled
+# assertWeightsVerified from the main checkout because a service unit must not
+# depend on a repo checkout's build state (dist/ may be stale or absent); the
+# pin file is the manifest value, restated where systemd can check it
+# fail-closed with a coreutils binary. Keep the two in lock-step on any weight
+# bump. (<1 s to hash 334 MB at start; negligible.)
+#
+# Pooling + normalization are PINNED explicitly (--pooling mean
+# --embd-normalize 2) rather than left to GGUF-metadata auto-detect. This is
+# load-bearing for correctness: the adapter's cosine score `1 - d^2/2` and the
+# raw-L2-distance KNN ordering are only valid for MEAN-pooled, L2-normalized
+# vectors. If the server silently fell back to last-token/CLS pooling, every
+# query would return well-formed but wrongly-ordered hits and nothing in the
+# fail-open path would catch it. EmbeddingGemma requires mean pooling; a
+# govern-by-pinning product does not leave retrieval ordering to an unstated
+# default. (Verified 2026-07-20: mean is also this GGUF's default — the
+# relevant/irrelevant cosine separation was 0.63 vs 0.00 — so pinning changes
+# nothing observable; it just removes the silent-misconfig failure mode.)
+#
+# --ubatch-size 2048 is REQUIRED for correctness, not a memory knob (learned the
+# hard way, 2026-07-20). llama-server refuses any single embedding input longer
+# than the physical batch: "input (586 tokens) is too large to process, increase
+# the physical batch size (current batch size: 512)". Real 2000-char corpus docs
+# tokenize to up to ~600+ tokens, and token-dense docs (code, hashes, CJK) can
+# approach the 2048 model context — so the ubatch MUST cover the largest possible
+# input. A 512 ubatch (tried as a memory reduction) made every long doc a hard
+# error that retry-stormed and aborted the whole build after ~32 docs. Setting
+# ubatch = ctx (2048) guarantees any doc the model will accept also fits one
+# physical batch.
+#
+# Memory: the ORIGINAL failure was the CAP (old MemoryMax=1.5G), not the ubatch.
+# ubatch 2048 peaks the cgroup at ~1.1G measured (334 MB model + KV for the
+# 2048-ctx slot + a 2048-token compute buffer); MemoryMax=3G leaves ~2.1G
+# headroom, bounded. (The original 1.5G OOM was ubatch 2048 under PARALLEL 2 —
+# two slots — against a 1.5G cap; parallel 1 + a 3G cap is the fix.)
+# Do NOT remove the cap: this box has OOM history and an unbounded llama-server
+# is exactly the failure mode the dev-box DO-NOT list guards against. Do NOT
+# shrink ubatch below 2048 to save memory — it breaks embedding of long docs.
+#
+# --parallel 1: one 2048-token sequence slot. The adapter sends BATCHED requests
+# (one POST with an `input` array of N docs), which llama-server processes across
+# its slots; one slot is the simplest robust posture for a long unattended build
+# (batched requests measured ~0.44 s/doc at parallel 1). The indexer additionally
+# (a) retries a failed batch with bounded backoff to bridge a systemd auto-restart
+# and (b) skips a data-poison batch while the service is healthy rather than
+# aborting the build (dense-indexer.ts).
+#
+# Runbook: 000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
+
+[Unit]
+Description=Bob's Big Brain embedder (llama-server + EmbeddingGemma-300M, loopback :8098)
+
+[Service]
+Type=simple
+# Fail-closed weight integrity gate before the model is ever loaded.
+ExecStartPre=/usr/bin/sha256sum -c %h/.local/lib/bbb/embedder-weights.sha256
+ExecStart=%h/.local/lib/bbb/llama-server/current/llama-server \
+  --host 127.0.0.1 \
+  --port 8098 \
+  -m %h/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf \
+  --embedding \
+  --pooling mean \
+  --embd-normalize 2 \
+  --ctx-size 2048 \
+  --parallel 1 \
+  --threads 6 \
+  --threads-batch 6 \
+  --ubatch-size 2048
+# ~334 MB model + KV + a 2048-token compute buffer; measured cgroup peak ~1.5G.
+# 3G leaves ~1.5G headroom, bounded (the box has 11 GiB+ free but OOM history).
+MemoryMax=3G
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## What

Adds the **B4 dense retrieval arm** to `@qmd-team-intent-kb/qmd-adapter`: EmbeddingGemma-300M embeddings in a sqlite-vec sidecar, joined into the existing deterministic RRF fusion as a **third ranked list** (qmd BM25 + native FTS5 + dense). Opt-in via `QmdAdapterConfig.dense`; fail-open; seam-firewalled. Ships with a local `bbb-embedder` systemd service, a `GOVERNED_EVAL_DENSE=1` A/B eval arm, index-reuse for fast re-measurement, and runbook 051.

## Why — this is the answer to the reranker's structural wall

The reranker (B1) **missed** its gate: 20/28 semantic queries retrieve ≤1 lexical candidate, so there is nothing to reorder (050-AT-RNBK §9). The wall is candidate **generation**, not ranking. Dense retrieval generates the paraphrase-matched candidates lexical search can't find. Per ratified decisions 038/044-AT-DECR: **sqlite-vec + EmbeddingGemma-300M only** — chose the lean ~334 MB GGUF over qmd's 2.2 GB hybrid (heavier, unwired) and over a query-expansion model (adds a model without addressing generation).

## Verification & evidence — MEASURED GATE PASS

Dense A/B arm of the governed-brain-v1 anchor (frozen snapshot, curated scope, k=10). Artifact: [`eval-results/governed-brain-v1-dense.json`](../blob/feat/b4-dense-arm/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json).

| stratum | Recall@10 (fused → dense) | ΔRecall@10 | nDCG@10 (fused → dense) | ΔnDCG@10 | MRR (fused → dense) | ΔMRR |
|---|---|---|---|---|---|---|
| lexical (n=14) | 1.0000 → 1.0000 | **+0.0000** | 0.9411 → 0.9265 | −0.0146 | 0.9286 → 0.9167 | −0.0119 |
| **semantic (n=28)** | **0.3393 → 0.9643** | **+0.6250 (~3×)** | 0.3433 → 0.7704 | +0.4271 | 0.3571 → 0.7076 | +0.3504 |
| overall (n=42) | 0.5595 → 0.9762 | +0.4167 | 0.5426 → 0.8224 | +0.2798 | 0.5476 → 0.7773 | +0.2297 |

**Gate: PASS.** Semantic Recall@10 nearly **tripled**; lexical held at 1.0000 (the tiny lexical nDCG/MRR dips are within-top-10 reordering, below the gate epsilon). This is the empirical answer to "does building dense retrieval ourselves beat the reranker's wall?" — **yes, decisively, on the slice that was stuck.**

Gates green: `pnpm -r test` (all 15 packages; 277 qmd-adapter tests incl. live embedder integration), `pnpm -r typecheck`, `pnpm depcruise` (0 errors), prettier, the dense seam-firewall test.

## How it works

- **Fail-open, read-path-only.** Embedder down / index unbuilt / any failure → serve the lexical fusion with no dense list. The model proposes candidates via list **rank** only; the fused score is pure rank arithmetic.
- **Seam firewall.** `DenseScore` is a nominal branded type that **cannot** be assigned into govern's `DeterministicScore` (tsc-enforced; extends B1/B2). The `no-govern-imports-retrieval` depcruise rule covers the new module by construction.
- **Scope inside the KNN.** A vec0 `collection` partition key filters `WHERE collection IN (...)` *inside* the KNN, so out-of-scope collections (archive, ~38% of corpus) can't steal the k nearest slots — chosen over a post-hoc `.filter()` that silently shrinks results below k.
- **Self-invalidating index.** `modelVersion` = pinned sha256 | query-prefix | doc-prefix, so a weights **or** prompt-prefix change wipes + rebuilds.
- **Resilient build.** Bounded-backoff retry bridges a transient embedder restart; a batch that exhausts retries while `/health` is up is treated as data-poison and skipped (one bad doc never strands a 17k build).

## Invariant / layer

Retrieval side only (`packages/qmd-adapter`). No govern-side change. With `dense` absent the query path is byte-identical to the prior lexical fusion (unit-tested).

## Operational impact

- New **local loopback** systemd user service `bbb-embedder` (`:8098`, SHA-256-pinned llama.cpp + EmbeddingGemma GGUF, fail-closed weight gate, `--pooling mean --embd-normalize 2` pinned, `--ubatch-size 2048`, `MemoryMax 3G`, measured peak ~1.1G). No external API in the serving path. Runbook: `000-docs/051-AT-RNBK`.
- New npm dep `sqlite-vec` (already in the lockfile).
- Full-corpus embed ~2.5–3 h; `GOVERNED_EVAL_DENSE_PREBUILT` reuse makes re-measurement minutes.

## Honesty note (how the number was produced)

The verdict was measured against a **preserved 12,645 / 17,295-doc index (73%)**. That is complete for what the eval measures: queries run in the default **curated scope** (curated + decisions + guides — all ~fully embedded: 659 / 38 / 10,086), where every semantic gold doc lives; only the out-of-scope `kb-archive` tail (1,862 / 6,512) is partial, and it's excluded inside the KNN. A full-corpus rebuild is expected to reproduce these numbers and is a cheap follow-up now that index-reuse exists.

## Follow-up & deferred

- Dense **earned** default wiring (unlike the reranker). This PR keeps it **opt-in** (conservative first landing; plugin does NOT wire it). **Recommend** enabling dense-by-default in the serving/plugin path given the +0.63 semantic gain, pending (a) full-corpus rebuild confirmation and (b) an interactive-path embedder latency/resource check. Do not flip the default silently.
- Full-corpus (17,295) rebuild to confirm the verdict at 100% coverage.

## Refs

GSB Wave-3 B4 · bead `qmd-team-intent-kb-y6t.1` · decisions 038/044-AT-DECR · builds on B1 reranker (050-AT-RNBK) + B2 seam firewall.

**Refs:** bead qmd-team-intent-kb-y6t.1 (dense retrieval arm, pulled forward from Wave 3 on measured evidence)