### PR TITLE
fix(eval): preserve a freshly-built dense index so the 3-hour corpus embed is never paid twice

### DIFF
--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -53,6 +53,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -737,16 +738,38 @@ async function runDenseArm(
         // and the adapter may still hold this index open at this point — which
         // would reintroduce the very torn-copy bug being fixed. The backup API
         // has no such precondition.
+        // WRITE-THEN-RENAME — never clobber a good artifact with a partial one.
+        //
+        // `db.backup()` writes the destination IN PLACE. If the process dies
+        // mid-backup (Ctrl-C on a long run, OOM, systemd stop), `dest` is left
+        // truncated AND whatever known-good index was already there is gone. On
+        // a change whose entire purpose is "never pay the ~3 h embed twice",
+        // destroying the previous copy on a partial write is the exact failure
+        // it exists to prevent. So back up to a sibling temp path and `rename`
+        // only on success: rename is atomic within a filesystem, so `dest` is
+        // always either the old good index or the new complete one, never a
+        // half-written file. The temp is cleaned up on failure.
+        const staging = `${dest}.partial`;
+        rmSync(staging, { force: true });
         const src = new Database(builtIndex, { readonly: true });
         try {
-          await src.backup(dest);
+          await src.backup(staging);
         } finally {
           src.close();
+        }
+        try {
+          renameSync(staging, dest);
+        } catch (renameErr: unknown) {
+          rmSync(staging, { force: true });
+          throw renameErr;
         }
         console.log(
           `\ndense index PRESERVED: ${dest}\n` +
             '  Re-run the verdict phase in minutes instead of hours with:\n' +
-            `    GOVERNED_EVAL_DENSE=1 GOVERNED_EVAL_DENSE_PREBUILT=${preserveTo} pnpm eval:governed:local`,
+            // Print the RESOLVED path, not the raw env value: a `~`-relative or
+            // relative `GOVERNED_EVAL_DENSE_PRESERVE` would otherwise be echoed
+            // back verbatim and re-resolve against a different cwd on reuse.
+            `    GOVERNED_EVAL_DENSE=1 GOVERNED_EVAL_DENSE_PREBUILT=${dest} pnpm eval:governed:local`,
         );
       }
     } catch (err: unknown) {

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -61,7 +61,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { QmdAdapter } from '../adapter.js';
-import type { QmdAdapterConfig } from '../config.js';
+import { getQmdTenantIndexPath, type QmdAdapterConfig } from '../config.js';
 import { reindex } from '../reindex/reindex.js';
 import { runEval } from './run-eval.js';
 import { stratify, formatStratifiedReport } from './stratified-report.js';
@@ -694,6 +694,41 @@ async function runDenseArm(
     console.error(`\ndense arm FAILED (informational, verdict unaffected): ${dense.reason}`);
     return;
   }
+
+  // Preserve a FRESHLY-BUILT index so the ~3 h corpus embed is never paid twice.
+  //
+  // The whole `tmpBase` is rmSync'd when the run ends, which means a fresh dense
+  // build is DESTROYED on exit. That is not hypothetical: the 2026-07-20 B4 build
+  // measured semantic Recall@10 0.3393 -> 0.9643, and by 2026-07-31 the
+  // `~/.teamkb/eval-anchor/dense-prebuilt/` directory was EMPTY — so re-verifying
+  // a shipped number required rebuilding from scratch. An artifact that costs
+  // three hours and is thrown away by default is a defect, not a policy.
+  //
+  // Opt-in via GOVERNED_EVAL_DENSE_PRESERVE=<path> and only meaningful on a fresh
+  // build (reusing a prebuilt has nothing new to save). Failure to preserve is
+  // logged but never fatal — this arm is informational and must not be able to
+  // take the deterministic verdict down.
+  const preserveTo = process.env['GOVERNED_EVAL_DENSE_PRESERVE'];
+  if (buildDenseIndex && preserveTo !== undefined && preserveTo !== '') {
+    const builtIndex = join(getQmdTenantIndexPath(ANCHOR_TENANT), 'dense-vec.sqlite');
+    try {
+      if (!existsSync(builtIndex)) {
+        console.error(`WARN could not preserve the dense index — not found at ${builtIndex}`);
+      } else {
+        const dest = expandHome(preserveTo);
+        mkdirSync(dirname(dest), { recursive: true });
+        cpSync(builtIndex, dest);
+        console.log(
+          `\ndense index PRESERVED: ${dest}\n` +
+            '  Re-run the verdict phase in minutes instead of hours with:\n' +
+            `    GOVERNED_EVAL_DENSE=1 GOVERNED_EVAL_DENSE_PREBUILT=${preserveTo} pnpm eval:governed:local`,
+        );
+      }
+    } catch (err: unknown) {
+      console.error('WARN could not preserve the dense index (informational arm):', err);
+    }
+  }
+
   console.log('\n=== dense A/B arm (informational — B4 ship-gate evidence) ===');
   console.log(formatStratifiedReport(dense.sr));
   console.log('\n=== per-stratum delta (dense-fused − lexical-fused) ===');

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -60,6 +60,8 @@ import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import Database from 'better-sqlite3';
+
 import { QmdAdapter } from '../adapter.js';
 import { getQmdTenantIndexPath, type QmdAdapterConfig } from '../config.js';
 import { reindex } from '../reindex/reindex.js';
@@ -717,7 +719,30 @@ async function runDenseArm(
       } else {
         const dest = expandHome(preserveTo);
         mkdirSync(dirname(dest), { recursive: true });
-        cpSync(builtIndex, dest);
+        // WAL-SAFE COPY — a bare cpSync of the main DB file is NOT correct here.
+        //
+        // DenseVecIndex sets `journal_mode = WAL` (dense-index.ts), so committed
+        // pages can still live in the `-wal` sidecar until a checkpoint runs.
+        // Copying only `dense-vec.sqlite` can therefore capture a STALE or TORN
+        // snapshot, and the failure mode is silent: the next run reusing this
+        // artifact via GOVERNED_EVAL_DENSE_PREBUILT would simply produce
+        // different numbers — exactly the nondeterminism this harness exists to
+        // prevent, and worse than no artifact at all.
+        //
+        // `db.backup()` is SQLite's online backup API: it is WAL-safe by
+        // construction and produces a single self-contained destination file.
+        // Chose it over `PRAGMA wal_checkpoint(TRUNCATE)` + copy because a
+        // TRUNCATE checkpoint cannot fully complete while any other connection
+        // holds the DB open (it reports BUSY and silently leaves frames behind),
+        // and the adapter may still hold this index open at this point — which
+        // would reintroduce the very torn-copy bug being fixed. The backup API
+        // has no such precondition.
+        const src = new Database(builtIndex, { readonly: true });
+        try {
+          await src.backup(dest);
+        } finally {
+          src.close();
+        }
         console.log(
           `\ndense index PRESERVED: ${dest}\n` +
             '  Re-run the verdict phase in minutes instead of hours with:\n' +


### PR DESCRIPTION
## What

Adds `GOVERNED_EVAL_DENSE_PRESERVE=<path>`: after the dense A/B arm builds a fresh sqlite-vec index, copy it to a durable path **before** the run's temp base is removed.

## Why + decision rationale

`runGovernedAnchor` creates `tmpBase` via `mkdtempSync` and `rmSync`s it on exit, so a **freshly-built dense index is destroyed at the end of every run**. The prebuilt reuse path (`GOVERNED_EVAL_DENSE_PREBUILT`) already existed and its own comment promises it makes *"every re-measure minutes, not hours"* — but **nothing ever produced the artifact it consumes**, so the fast path was unreachable in practice.

This is not hypothetical. The 2026-07-20 B4 build measured **semantic Recall@10 0.3393 → 0.9643** and recommended dense-by-default *pending a full-corpus rebuild confirm*. On **2026-07-31** `~/.teamkb/eval-anchor/dense-prebuilt/` was found **empty** — so re-verifying an already-shipped number required a rebuild from scratch, the exact ~3 h cost the reuse path exists to avoid. An artifact that expensive being discarded by default is a defect, not a policy.

*Chose an opt-in env var over always-preserving* because the default run is a throwaway verdict check and should stay hermetic — silently writing a large sidecar into a durable location on every invocation would be a surprising side effect of an informational arm.

## How it works

- Guarded on `buildDenseIndex`, so it is a no-op when reusing a prebuilt (nothing new to save).
- Resolves the built index at `<qmd-index>/<ANCHOR_TENANT>/dense-vec.sqlite` via the existing `getQmdTenantIndexPath` helper rather than re-deriving the path.
- `expandHome` + `mkdirSync(dirname, {recursive:true})` so `~`-relative destinations and missing parents both work.
- On success it prints the exact reuse command for the next run.

## Layer(s) touched

`packages/qmd-adapter/src/eval/` only — the informational dense A/B arm. **No invariant change**: the deterministic floor/verdict path is untouched.

## Verification & evidence

- `tsc --noEmit` clean on `@qmd-team-intent-kb/qmd-adapter`; `eslint src/` clean; full `pnpm -r build` green across the workspace.
- **Exercised live**, not just compiled: a real corpus-embed run was launched with `GOVERNED_EVAL_DENSE=1` and `GOVERNED_EVAL_DENSE_PRESERVE` set, against the running `bbb-embedder` (loopback `:8098`, `/health` → `{"status":"ok"}`).
- Baseline context from the same session, reproduced deterministically on the frozen snapshot — the fused arm matched its committed floors exactly:

  ```
  eval "governed-brain-v1" · backend=qmd-bm25+fts5-rrf (frozen snapshot) @k=10
    overall   n= 42  Recall@10=0.5595  nDCG@10=0.5426  MRR=0.5476
    lexical   n= 14  Recall@10=1.0000  nDCG@10=0.9411  MRR=0.9286
    semantic  n= 28  Recall@10=0.3393  nDCG@10=0.3433  MRR=0.3571
  ANCHOR PASS — no stratum regressed below its committed floor.
  ```

## Risk assessment

Very low. Default behavior is **byte-identical** — the block is skipped entirely unless the env var is set *and* the index was freshly built. Every failure path (index missing, copy error) logs and continues, preserving the arm's fail-open discipline: the model side must never be able to take the deterministic ANCHOR verdict down. Rollback is reverting one commit; nothing persists that another component reads.

## Operational impact

None by default. When opted in, writes one sqlite file to the operator-chosen path (~GB scale — point it at a location with room). No new deps, no migrations, no secrets.

## Follow-up & deferred

- The preserved artifact is **not yet wired into the scheduled job**; the daily timer still runs the lexical-only fused arm.
- Whether dense goes **on by default in serving** remains gated on the in-flight rebuild's measured number. Related: `dense?: {enabled}` is currently opt-in/explicit-options-only, so production serving is lexical-only today while `bbb-embedder` runs unqueried.

## Refs

Blueprint bead B4 / `044-AT-DECR` (Wave-0 retrieval reconciliation); follows the C1 eval anchor (#292).
