### PR TITLE
feat(curator): add evidence-linked staleness detection (dry-run only) with the historical-record exemption

### DIFF
--- a/apps/curator/src/__tests__/staleness-detector.test.ts
+++ b/apps/curator/src/__tests__/staleness-detector.test.ts
@@ -133,7 +133,7 @@ describe('detectStaleness — provenance and scope', () => {
           tags: [],
           repoUrl: 'https://github.com/jeremylongshore/intentional-cognition-os',
         },
-      } as Partial<Subject>),
+      }),
     );
 
     expect(findings.map((f) => f.ruleId)).toContain('repo-renamed-2026-07-19-compiler');
@@ -151,7 +151,7 @@ describe('detectStaleness — provenance and scope', () => {
           filePaths: ['docs/legacy/retired/old-notes.md'],
           tags: [],
         },
-      } as Partial<Subject>),
+      }),
     );
 
     expect(findings).toHaveLength(1);

--- a/apps/curator/src/__tests__/staleness-detector.test.ts
+++ b/apps/curator/src/__tests__/staleness-detector.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectStaleness,
+  ESTATE_STALENESS_RULES,
+  mentions,
+  readsAsHistorical,
+  type StalenessRule,
+} from '../staleness/staleness-detector.js';
+
+/**
+ * Tests for evidence-linked staleness detection (bead `compile-then-govern-39z.2`).
+ *
+ * The central risk this suite guards is NOT "does it find gcloud". It is the
+ * prescriptive-vs-historical distinction: a sweep that deprecates the memory
+ * recording "GCP was torn down, never use it" would delete the estate's own
+ * explanation of why GCP is gone — the exact answer the sweep exists to protect.
+ */
+
+type Subject = Parameters<typeof detectStaleness>[0];
+
+function memory(overrides: Partial<Subject> = {}): Subject {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    title: 'A memory',
+    content: 'Some content.',
+    metadata: { filePaths: [], tags: [] },
+    ...overrides,
+  } as Subject;
+}
+
+describe('mentions — word-boundary token matching', () => {
+  it('matches a token surrounded by non-word characters', () => {
+    expect(mentions('run `gcloud run deploy` first', 'gcloud')).toBe(true);
+    expect(mentions('deploy to Cloud Run today', 'cloud run')).toBe(true);
+  });
+
+  it('does NOT match a token embedded in a longer word', () => {
+    // The short-token false-positive risk that motivated boundary checking:
+    // `bq` must not fire inside unrelated identifiers.
+    expect(mentions('the bqueue consumer lagged', 'bq')).toBe(false);
+    expect(mentions('sbq is not bq', 'bq')).toBe(true); // present standalone too
+    expect(mentions('ntfyd is a different daemon', 'ntfy')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(mentions('Use BigQuery for this', 'bigquery')).toBe(true);
+    expect(mentions('VERTEX AI is gone', 'vertex ai')).toBe(true);
+  });
+
+  it('treats regex metacharacters in tokens literally', () => {
+    // Tokens carry `/` and `-`; a naive RegExp build would need escaping.
+    expect(
+      mentions('see jeremylongshore/qmd-team-intent-kb#12', 'jeremylongshore/qmd-team-intent-kb'),
+    ).toBe(true);
+  });
+
+  it('returns false for an empty token rather than matching everything', () => {
+    expect(mentions('anything at all', '')).toBe(false);
+  });
+});
+
+describe('readsAsHistorical', () => {
+  it('recognizes teardown framing', () => {
+    expect(readsAsHistorical('The GCP estate was torn down on 2026-07-09.')).toBe(true);
+    expect(readsAsHistorical('We fully exited GCP; never use gcloud.')).toBe(true);
+  });
+
+  it('does not fire on plain prescriptive instructions', () => {
+    expect(readsAsHistorical('Deploy the service with gcloud run deploy.')).toBe(false);
+  });
+});
+
+describe('detectStaleness — prescriptive vs historical (the load-bearing case)', () => {
+  it('FLAGS a memory that tells you to USE a torn-down platform', () => {
+    const findings = detectStaleness(
+      memory({
+        title: 'Deploying Hustle',
+        content:
+          'Hustle should use a single GCP project with Firebase and Firestore, ' +
+          'and run inference on Vertex AI.',
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.ruleId).toBe('gcp-torn-down-2026-07-09');
+    // The evidence string is what lands in the audit event — it must name both
+    // the dead fact and what matched, so a retirement can be explained later.
+    expect(findings[0]!.evidence).toContain('torn down on 2026-07-09');
+    expect(findings[0]!.matched).toEqual(expect.arrayContaining(['firebase', 'firestore']));
+  });
+
+  it('KEEPS the memory that RECORDS the teardown — deleting it would erase the answer', () => {
+    const findings = detectStaleness(
+      memory({
+        title: 'GCP exodus complete',
+        content:
+          'The GCP estate was torn down on 2026-07-09: 0 billing-enabled projects, ' +
+          'BigQuery and Vertex AI and Firebase all gone. Never use gcloud or bq for ' +
+          'these projects.',
+      }),
+    );
+
+    // This memory mentions MORE dead-platform tokens than the prescriptive one
+    // above. Token counting alone would rank it as the MOST stale row in the
+    // brain, when it is in fact the correct answer to "why no GCP?".
+    expect(findings).toHaveLength(0);
+  });
+
+  it('still flags a rename even when framed historically', () => {
+    // Renames are not exempt: the old repo URL does not resolve regardless of
+    // how the sentence is framed, so a reader following it still gets a 404.
+    const findings = detectStaleness(
+      memory({
+        title: 'Old engine link',
+        content: 'Formerly at https://github.com/jeremylongshore/qmd-team-intent-kb (legacy).',
+      }),
+    );
+
+    expect(findings.map((f) => f.ruleId)).toContain('repo-renamed-2026-07-19-registrar');
+  });
+});
+
+describe('detectStaleness — provenance and scope', () => {
+  it('detects a renamed repo via metadata provenance alone', () => {
+    // The prose never names the repo; only the provenance does.
+    const findings = detectStaleness(
+      memory({
+        title: 'Spool config',
+        content: 'The spool path is resolved at startup.',
+        metadata: {
+          filePaths: ['packages/kernel/src/spool.ts'],
+          tags: [],
+          repoUrl: 'https://github.com/jeremylongshore/intentional-cognition-os',
+        },
+      } as Partial<Subject>),
+    );
+
+    expect(findings.map((f) => f.ruleId)).toContain('repo-renamed-2026-07-19-compiler');
+  });
+
+  it('does not let an inert provenance path vote on historical framing', () => {
+    // A file path cannot narrate a teardown. If provenance were allowed into the
+    // historical check, an incidental path component could exempt a genuinely
+    // prescriptive memory and silently defeat the sweep.
+    const findings = detectStaleness(
+      memory({
+        title: 'Deploy steps',
+        content: 'Run gcloud run deploy to ship the service.',
+        metadata: {
+          filePaths: ['docs/legacy/retired/old-notes.md'],
+          tags: [],
+        },
+      } as Partial<Subject>),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.ruleId).toBe('gcp-torn-down-2026-07-09');
+  });
+
+  it('returns an empty array for a memory with nothing stale', () => {
+    expect(
+      detectStaleness(
+        memory({
+          title: 'Commit and PR standard',
+          content: 'Branch from origin/main, never commit to main, wait for required checks.',
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('reports one finding per matching rule', () => {
+    const findings = detectStaleness(
+      memory({
+        title: 'Old stack',
+        content: 'Deploy with gcloud, and publish alerts to the ntfy topic prod-alerts.',
+      }),
+    );
+
+    expect(findings.map((f) => f.ruleId).sort()).toEqual([
+      'gcp-torn-down-2026-07-09',
+      'ntfy-removed-2026-06-13',
+    ]);
+  });
+
+  it('accepts an injected rule set so tests never depend on the live estate', () => {
+    const rules: StalenessRule[] = [
+      {
+        id: 'test-only',
+        because: 'Widgets were discontinued.',
+        tokens: ['widget'],
+        exemptIfHistorical: false,
+      },
+    ];
+
+    expect(detectStaleness(memory({ content: 'use a widget' }), rules)).toHaveLength(1);
+    expect(detectStaleness(memory({ content: 'use a gadget' }), rules)).toHaveLength(0);
+  });
+});
+
+describe('ESTATE_STALENESS_RULES — rule hygiene', () => {
+  it('has unique rule ids', () => {
+    const ids = ESTATE_STALENESS_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('states a date in every `because`, so a retirement is always explainable', () => {
+    for (const rule of ESTATE_STALENESS_RULES) {
+      expect(rule.because, `rule ${rule.id} must cite a date`).toMatch(/\d{4}-\d{2}-\d{2}/);
+    }
+  });
+
+  it('declares at least one token per rule', () => {
+    for (const rule of ESTATE_STALENESS_RULES) {
+      expect(rule.tokens.length, `rule ${rule.id} must have tokens`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/curator/src/staleness/staleness-detector.ts
+++ b/apps/curator/src/staleness/staleness-detector.ts
@@ -4,7 +4,9 @@ import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
  * Evidence-linked staleness detection (bead `compile-then-govern-39z.2`).
  *
  * The deterministic, model-free half of truth-maintenance: a memory is stale
- * when the ESTATE FACT it depends on is provably gone — a platform that was torn
+ * when a rule in {@link ESTATE_STALENESS_RULES} declares the estate fact it
+ * depends on gone, and the memory's text or provenance implicates that rule's
+ * tokens — a platform that was torn
  * down, a repo that was renamed, a service that was removed. No LLM, no
  * embeddings, no similarity. Just: does the thing this answer tells you to use
  * still exist?
@@ -54,7 +56,12 @@ import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
  * @module staleness/staleness-detector
  */
 
-/** A single estate fact that has provably stopped being true. */
+/**
+ * A single estate fact declared dead by the rule author. The rule hygiene test
+ * (every `because` carries a date) makes a retirement EXPLAINABLE — not proven:
+ * the code never independently verifies the estate; it verifies the memory
+ * against the rule.
+ */
 export interface StalenessRule {
   /** Stable id, recorded in the audit event so a retirement can be explained. */
   readonly id: string;

--- a/apps/curator/src/staleness/staleness-detector.ts
+++ b/apps/curator/src/staleness/staleness-detector.ts
@@ -1,0 +1,298 @@
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+
+/**
+ * Evidence-linked staleness detection (bead `compile-then-govern-39z.2`).
+ *
+ * The deterministic, model-free half of truth-maintenance: a memory is stale
+ * when the ESTATE FACT it depends on is provably gone — a platform that was torn
+ * down, a repo that was renamed, a service that was removed. No LLM, no
+ * embeddings, no similarity. Just: does the thing this answer tells you to use
+ * still exist?
+ *
+ * ## Why this exists
+ *
+ * Supersession as built is a near-duplicate collapser (Jaccard over title tokens
+ * within one category), so nothing has ever been retired for being WRONG — only
+ * for being RESTATED. Meanwhile a live probe of `how do I deploy to production`
+ * on 2026-07-31 returned 5 hits, 0 correct, 2 of them recommending `gcloud`
+ * against an estate whose GCP footprint was torn down on 2026-07-09.
+ *
+ * Retrieval quality cannot fix that: those answers are genuinely ON TOPIC, so a
+ * better ranker surfaces them HIGHER. The fix has to retire them.
+ *
+ * Pattern borrowed from the RCSB PDB AI Help Desk (arXiv:2604.22800), which
+ * keeps a KB current by hash-detecting changes in its source documents. Ours is
+ * the same shape at the estate level, and it is the cheapest signal available.
+ *
+ * ## The distinction that makes or breaks this
+ *
+ * A naive `content.includes('gcloud')` sweep deprecates the wrong rows. Two
+ * kinds of memory mention a dead platform, and they are OPPOSITE:
+ *
+ *   PRESCRIPTIVE — "deploy with `gcloud run deploy`, store secrets in Secret
+ *                  Manager"  → the answer is now WRONG. Retire it.
+ *
+ *   HISTORICAL   — "the GCP estate was torn down 2026-07-09; never use gcloud"
+ *                  → this IS the correct answer to "why no GCP?". Retiring it
+ *                    would delete the very record that justifies the retirement,
+ *                    and would make the estate LESS able to explain itself.
+ *
+ * So every dead-platform rule is gated behind {@link readsAsHistorical}. When in
+ * doubt this module KEEPS the memory: a false negative leaves one stale row for
+ * a later pass, while a false positive silently removes institutional memory.
+ * That asymmetry is deliberate and is the whole safety argument.
+ *
+ * ## What this module does NOT do
+ *
+ * It does not mutate anything. It returns findings. The caller performs the
+ * governed `active -> deprecated` transition with a hash-chained audit event
+ * citing {@link StalenessFinding.evidence}, so every retirement has a receipt
+ * and is reversible (`deprecated -> active` is a legal transition). Soft belief
+ * update, never hard delete — per ExComm (arXiv:2605.22102), because "conflict
+ * resolution is not guaranteed to be perfect".
+ *
+ * @module staleness/staleness-detector
+ */
+
+/** A single estate fact that has provably stopped being true. */
+export interface StalenessRule {
+  /** Stable id, recorded in the audit event so a retirement can be explained. */
+  readonly id: string;
+  /** Plain-English statement of the dead fact, including the date it died. */
+  readonly because: string;
+  /**
+   * Tokens whose presence implicates this rule. Matched case-insensitively on
+   * word-ish boundaries (see {@link mentions}) so `bq` does not fire inside
+   * `bqueue` and `ntfy` does not fire inside `ntfyd`.
+   */
+  readonly tokens: readonly string[];
+  /**
+   * Whether a HISTORICAL framing exempts the memory.
+   *
+   * `true` for torn-down platforms: a memory recording the teardown is the
+   * answer we want to keep. `false` for pure renames — "the repo is called
+   * `qmd-team-intent-kb`" is wrong whether stated prescriptively or
+   * historically, because the name simply no longer resolves.
+   */
+  readonly exemptIfHistorical: boolean;
+}
+
+/** Why one memory was flagged. */
+export interface StalenessFinding {
+  readonly memoryId: string;
+  readonly ruleId: string;
+  /** Audit-event-ready sentence: the dead fact plus the token that matched. */
+  readonly evidence: string;
+  /** The matched tokens, for operator review before a bulk apply. */
+  readonly matched: readonly string[];
+}
+
+/**
+ * The estate's dead facts, each with the date it died.
+ *
+ * Every entry here is a CLAIM ABOUT THE ESTATE, not about language. Adding a
+ * rule means asserting "this no longer exists", so each carries its date and
+ * should be traceable to a decision record or teardown.
+ */
+export const ESTATE_STALENESS_RULES: readonly StalenessRule[] = [
+  {
+    id: 'gcp-torn-down-2026-07-09',
+    because:
+      'The GCP estate was torn down on 2026-07-09 (0 billing-enabled projects; ' +
+      'BigQuery, Vertex, Firebase and Cloud Run all gone). Any answer that tells ' +
+      'you to USE these is wrong.',
+    tokens: [
+      'gcloud',
+      'bq',
+      'bigquery',
+      'vertex ai',
+      'vertexai',
+      'firebase',
+      'firestore',
+      'cloud run',
+      'app engine',
+      'secret manager',
+      'gcp project',
+    ],
+    exemptIfHistorical: true,
+  },
+  {
+    id: 'repo-renamed-2026-07-19-compiler',
+    because:
+      'The repo `intentional-cognition-os` was renamed to `bobs-big-brain-compiler` ' +
+      'on 2026-07-19. (The npm package name and the `@ico/*` scope did NOT change, ' +
+      'so this rule matches the REPO/URL form only.)',
+    tokens: ['jeremylongshore/intentional-cognition-os'],
+    exemptIfHistorical: false,
+  },
+  {
+    id: 'repo-renamed-2026-07-19-registrar',
+    because:
+      'The repo `qmd-team-intent-kb` was renamed to `bobs-big-brain-registrar` on ' +
+      '2026-07-19. (The `@qmd-team-intent-kb/*` package scope and the GHCR image ' +
+      'did NOT change, so this rule matches the REPO/URL form only.)',
+    tokens: ['jeremylongshore/qmd-team-intent-kb'],
+    exemptIfHistorical: false,
+  },
+  {
+    id: 'repo-renamed-2026-07-14-plugin',
+    because:
+      'The plugin repo/dir `governed-second-brain-plugin` was renamed to ' +
+      '`bobs-big-brain-plugin` on 2026-07-14.',
+    tokens: ['governed-second-brain-plugin'],
+    exemptIfHistorical: false,
+  },
+  {
+    id: 'marketplace-retired-2026-07-17',
+    because:
+      'The private marketplace repo `team-intent-claude-plugins` was retired and ' +
+      'archived on 2026-07-17. "Team" is a runtime MODE of the public plugin, not ' +
+      'a separate repo.',
+    tokens: ['team-intent-claude-plugins'],
+    exemptIfHistorical: true,
+  },
+  {
+    id: 'ntfy-removed-2026-06-13',
+    because:
+      'The ntfy container was removed on 2026-06-13 when alerting was rebuilt ' +
+      'Slack-only. There is no ntfy topic to publish to.',
+    tokens: ['ntfy'],
+    exemptIfHistorical: true,
+  },
+];
+
+/**
+ * Phrases that mark a mention as a RECORD of something being gone rather than
+ * INSTRUCTIONS to use it.
+ *
+ * Deliberately generous. Each phrase here converts a would-be retirement into a
+ * keep, and the asymmetry argument in the module docs says that is the safe
+ * direction to err.
+ */
+const HISTORICAL_MARKERS: readonly string[] = [
+  'torn down',
+  'tore down',
+  'teardown',
+  'decommission',
+  'exodus',
+  'migrated off',
+  'migrated away',
+  'moved off',
+  'no longer use',
+  'no longer used',
+  'do not use',
+  "don't use",
+  'never use',
+  'stopped using',
+  'retired',
+  'deprecated',
+  'archived',
+  'sunset',
+  'no gcp',
+  'not used',
+  'fully exited',
+  'exited',
+  'wound down',
+  'shut down',
+  'removed',
+  'legacy',
+  'historical',
+  'formerly',
+  'used to',
+  'superseded',
+  'replaced by',
+  'renamed to',
+];
+
+/**
+ * Case-insensitive token match on word-ish boundaries.
+ *
+ * Uses `indexOf` plus an explicit boundary check rather than a built `RegExp`:
+ * rule tokens contain regex metacharacters in practice (`.`, `/`, `-`) and would
+ * otherwise need escaping, and a scan has no backtracking behaviour to reason
+ * about on long memory bodies. A boundary is "not a letter or digit", which lets
+ * `cloud run` match inside a sentence while keeping `bq` from firing inside
+ * `bqueue` or `sbq`.
+ */
+export function mentions(haystack: string, token: string): boolean {
+  const hay = haystack.toLowerCase();
+  const needle = token.toLowerCase();
+  if (needle === '') return false;
+
+  let from = 0;
+  for (;;) {
+    const at = hay.indexOf(needle, from);
+    if (at === -1) return false;
+
+    const before = at === 0 ? '' : hay[at - 1]!;
+    const afterIdx = at + needle.length;
+    const after = afterIdx >= hay.length ? '' : hay[afterIdx]!;
+    if (!isWordChar(before) && !isWordChar(after)) return true;
+
+    from = at + 1;
+  }
+}
+
+function isWordChar(ch: string): boolean {
+  if (ch === '') return false;
+  return /[a-z0-9]/.test(ch);
+}
+
+/**
+ * Does this text read as a RECORD that something is gone, rather than
+ * instructions to use it?
+ *
+ * @see HISTORICAL_MARKERS for the (deliberately generous) marker list.
+ */
+export function readsAsHistorical(text: string): boolean {
+  const lower = text.toLowerCase();
+  return HISTORICAL_MARKERS.some((marker) => lower.includes(marker));
+}
+
+/**
+ * Detect estate-fact staleness in one memory.
+ *
+ * Scans title + content + the metadata provenance fields (`filePaths`,
+ * `repoUrl`, `projectContext`), because a memory can implicate a renamed repo
+ * purely through its provenance while its prose never names it.
+ *
+ * @param memory - The curated memory to inspect. Lifecycle is NOT checked here;
+ *                 the caller decides which lifecycle states are in scope (a
+ *                 sweep normally passes only `active` ones).
+ * @param rules  - Rule set to apply. Defaults to {@link ESTATE_STALENESS_RULES};
+ *                 injectable so tests do not depend on the live estate.
+ * @returns One finding per matching rule, or an empty array when nothing is
+ *          stale. Never throws.
+ */
+export function detectStaleness(
+  memory: Pick<CuratedMemory, 'id' | 'title' | 'content' | 'metadata'>,
+  rules: readonly StalenessRule[] = ESTATE_STALENESS_RULES,
+): StalenessFinding[] {
+  const provenance = [
+    ...(memory.metadata?.filePaths ?? []),
+    memory.metadata?.repoUrl ?? '',
+    memory.metadata?.projectContext ?? '',
+  ].join(' ');
+
+  const haystack = `${memory.title}\n${memory.content}\n${provenance}`;
+  // Historical framing is judged on the PROSE only. Provenance paths are inert
+  // strings — a file path cannot narrate that a platform was torn down, and
+  // letting it vote would misclassify on an incidental path component.
+  const prose = `${memory.title}\n${memory.content}`;
+  const historical = readsAsHistorical(prose);
+
+  const findings: StalenessFinding[] = [];
+  for (const rule of rules) {
+    const matched = rule.tokens.filter((t) => mentions(haystack, t));
+    if (matched.length === 0) continue;
+    if (rule.exemptIfHistorical && historical) continue;
+
+    findings.push({
+      memoryId: memory.id,
+      ruleId: rule.id,
+      evidence: `${rule.because} Matched: ${matched.map((m) => `"${m}"`).join(', ')}.`,
+      matched,
+    });
+  }
+  return findings;
+}


### PR DESCRIPTION
**Beads:** `compile-then-govern-39z.2` (epic `compile-then-govern-39z`, umbrella intent-solutions-io/bobs-big-brain-umbrella#74)

## What

A pure, deterministic detector — `detectStaleness` — that flags a curated memory when a rule in `ESTATE_STALENESS_RULES` **declares the estate fact it depends on gone** and the memory's text or provenance implicates that rule's tokens: a torn-down platform, a renamed repo, a removed service. No LLM, no embeddings, no similarity. It returns findings and **mutates nothing**.

## Why + decision rationale

Supersession as built is a near-duplicate collapser (Jaccard over title tokens, filtered to one category), so **nothing has ever been retired for being wrong** — only for being *restated*. A live probe of `how do I deploy to production` on 2026-07-31 returned **5 hits, 0 correct, 2 recommending `gcloud`** against an estate whose GCP footprint was torn down 2026-07-09.

Retrieval quality cannot fix this. Those answers are genuinely *on topic*, so a better ranker surfaces them **higher**. They have to be retired. Pattern follows the RCSB PDB AI Help Desk (arXiv:2604.22800), which keeps a KB current by change-detecting its source documents — the cheapest signal available, and unused here until now.

### The distinction that makes or breaks it

A naive `content.includes('gcloud')` sweep deprecates the **wrong** rows. Two kinds of memory mention a dead platform, and they are opposite:

| Framing | Example | Correct action |
|---|---|---|
| **Prescriptive** | *"deploy with `gcloud run deploy`"* | now wrong → **retire** |
| **Historical** | *"GCP was torn down 2026-07-09; never use it"* | this **is** the right answer to "why no GCP?" → **keep** |

Retiring the second would delete the record that justifies the retirement. So every dead-platform rule is gated behind `readsAsHistorical()`.

*Chose a deliberately generous marker list over a precise one* because the errors are asymmetric: a false negative leaves one stale row for a later pass; a false positive silently destroys institutional memory.

*Chose `indexOf` + explicit boundary checks over built `RegExp`s* because rule tokens contain regex metacharacters in practice (`.`, `/`, `-`), and a scan has no backtracking to reason about on long bodies. Boundary checking is load-bearing: `bq` must not fire inside `bqueue`, `ntfy` must not fire inside `ntfyd`.

Historical framing is judged on **prose only, never provenance** — a file path cannot narrate a teardown, and letting an incidental `docs/legacy/` component vote would silently exempt genuinely prescriptive memories.

## Layer(s) touched

`apps/curator/src/staleness/` — new module, sibling to the existing `supersession/` and `dedup/`. **No invariant change**; nothing imports it yet. *(History note: the branch originally carried a stale copy of the #318 eval-anchor change from being cut off that branch — rebuilt 2026-08-03 from `origin/main` so the diff is exactly these two curator files.)*

## Verification & evidence

- **18 unit tests pass** (vitest-confirmed on the rebuilt branch: `Tests  18 passed (18)`); `tsc --noEmit` and `eslint src/` clean.
- The load-bearing test asserts the memory *recording* the teardown is **kept** even though it mentions **more** dead-platform tokens than the prescriptive one — token counting alone would rank it the most stale row in the brain.
- **Out-of-band dry run** against the live brain (read-only, 10,190 active memories; driver was a session scratchpad script piping `sqlite3 -readonly` JSON through the compiled detector — deliberately not committed, numbers author-attested):

```
WOULD flag : 1,025  (10.06%)
  999  gcp-torn-down-2026-07-09
   11  ntfy-removed-2026-06-13
   14  renames / retired marketplace
by source   : 1,013 import  /  12 mcp
by category :   969 reference
EXEMPTED as historical: 154 GCP-mentioning rows
```

The safety valve fired **154 times on real data** — those are rows a naive sweep would have destroyed.

## Risk assessment

**None to the running system.** Nothing imports this module yet and it performs no writes; the change is purely additive. Rollback is deleting two files.

## Operational impact

None. No env vars, migrations, deps, secrets, or deploy ordering.

## Follow-up & deferred

**Deliberately not wired to apply.** The dry run surfaced a precision problem that must be settled *before* any transition runs: the flagged set is dominated by **imported blog posts and CLAUDE.md snapshots** (e.g. *"Building a 254-Table BigQuery Schema in 72 Hours"*), which are **records of past work**, not prescriptive estate guidance. Deprecating those is arguably wrong, and the exemption list also over-fires on incidental words. Shipping the apply step on these rules would retire ~1,000 memories on a rule set that has not earned it.

Remaining:
- Tighten precision — separate narrative/blog content from prescriptive guidance.
- The governed apply step: `active → deprecated` with a hash-chained audit event citing `StalenessFinding.evidence`, reusing the existing `memory-service` transition path. Reversible by design (`deprecated → active` is a legal transition), per ExComm soft belief update (arXiv:2605.22102).

## Governance links

Epic `compile-then-govern-39z` / umbrella #74. Related in flight: registrar #318 (preserve the dense eval index), compiler #183 (MiniMax `<think>` strip + pricing).

- Jeremy Longshore
intentsolutions.io


