### PR TITLE
fix(hooks): chain beads through Husky

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.61.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-checkout "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'post-checkout' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run post-checkout "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.61.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.61.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-merge "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'post-merge' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run post-merge "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.61.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.61.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-commit "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'pre-commit' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run pre-commit "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.61.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.61.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-push "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'pre-push' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run pre-push "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.61.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.61.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'prepare-commit-msg' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run prepare-commit-msg "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.61.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.husky/beads-hook
+++ b/.husky/beads-hook
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# Chain the tracked beads shim without replacing Husky's load-bearing hook path.
+# Beads is fail-open here: lint and policy-hash gates remain authoritative.
+
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+hook_name=$1
+shift
+
+case "$hook_name" in
+  pre-commit|pre-push|post-checkout|post-merge|prepare-commit-msg)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+beads_hook="$repo_root/.beads/hooks/$hook_name"
+
+if [ -x "$beads_hook" ]; then
+  "$beads_hook" "$@" || true
+fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+.husky/beads-hook post-checkout "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+.husky/beads-hook post-merge "$@"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -39,3 +39,5 @@ MSG
     exit 2
   fi
 fi
+
+.husky/beads-hook pre-commit "$@"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+.husky/beads-hook pre-push "$@"

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+.husky/beads-hook prepare-commit-msg "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,10 @@ Incremental export of curated memories to `kb-export/` as Markdown with YAML fro
 - Always `bd sync` after closing
 - Workflow: `bd update <id> --status in_progress` → work → `bd close <id> --reason "evidence"` → `bd sync`
 
+### Git hooks and Beads
+
+This repository keeps `core.hooksPath=.husky/_` so Husky's lint-staged and policy-hash gates remain active. The tracked `.husky/*` hooks chain into `.beads/hooks/<hook>` through `.husky/beads-hook`; do not repoint `core.hooksPath` to `.beads/hooks` or bypass the Husky gates. The beads chain is deliberately fail-open, while the repository's lint and policy verification gates remain fail-closed.
+
 ### Scaffolding vs Implemented
 
 - Be explicit about what is currently scaffolding vs implemented


### PR DESCRIPTION
## Summary

Focused branch from `origin/main` containing only the beads↔Husky hook-chain fix.

- chain all five Beads hook events through tracked Husky hooks
- preserve `core.hooksPath=.husky/_` and existing lint/policy-hash gates
- refresh the five versioned `.beads/hooks/*` shims to `bd 1.1.2`
- document the invariant in `CLAUDE.md`

## Tracking

- Bead: `bd_000-projects-nxwm`
- Registrar issue: #320
- Compiler companion: https://github.com/jeremylongshore/bobs-big-brain-compiler/issues/95
- Plane: LAB-132

## Verification

- `shellcheck` and `sh -n` on all Husky and beads hook scripts
- generated Husky runners dispatch all five hooks
- registrar lint-staged and pre-commit path pass
- `pnpm exec prettier --check CLAUDE.md`
- `git diff --check`

The beads delegation is fail-open; repository policy gates remain authoritative. Registrar commit `bdeada2` refreshes the tracked shims to the installed `bd 1.1.2`.