### PR TITLE
feat(ops): add dual-tenant qmd reindex self-heal

### DIFF
--- a/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md
+++ b/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md
@@ -43,6 +43,42 @@ pnpm reindex
 
 Tenant default: `TEAMKB_TENANT_ID=intent-solutions`.
 
+## Scheduled reindex and self-heal
+
+The qmd index is derived state. A successful compile is not enough to prove
+that promoted memories are searchable, so the Registrar ships
+`bin/bbb-reindex-heal.sh`. It runs the known-positive canary with `--heal` for
+both `intent-solutions` and `local`, using the pinned workspace qmd binary when
+available and requiring qmd `2.5.3`. It exits non-zero if either tenant is still unhealthy after one
+reindex attempt; `notify-lib` turns that failure into a `bbb-reindex-heal`
+failure page and maintains the `.beat`/`.ok` liveness markers.
+
+Install the wrapper to `~/bin` from a reviewed Registrar checkout and ensure
+the adapter has been built:
+
+```bash
+install -m 0755 bin/bbb-reindex-heal.sh ~/bin/bbb-reindex-heal.sh
+pnpm --filter @qmd-team-intent-kb/qmd-adapter... build
+TEAMKB_BASE_PATH="$HOME/.teamkb" ~/bin/bbb-reindex-heal.sh
+```
+
+The user timer templates are `scripts/systemd/bbb-reindex-heal.{service,timer}`.
+Mission Control owns installation and enablement after the compile window; the
+timer must run from the same user that owns `~/.teamkb` and `~/bin`.
+
+Useful overrides for a disposable fixture or a controlled drill:
+
+```bash
+BBB_REGISTRAR_ROOT=/path/to/bobs-big-brain-registrar \
+BBB_REINDEX_TENANTS='intent-solutions local' \
+BBB_REINDEX_MAX_STALENESS_SECONDS=86400 \
+~/bin/bbb-reindex-heal.sh
+```
+
+Verification is outcome-based: each tenant must report all six known-positive
+controls healthy after the optional heal. A zero exit from the surrounding
+compile job does not bypass this check.
+
 ## Auto-update when Tobi releases
 
 1. Dependabot weekly opens PR when `@tobilu/qmd` bumps (not ignored).

--- a/bin/bbb-reindex-heal.sh
+++ b/bin/bbb-reindex-heal.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# bbb-reindex-heal.sh — fail-loud search-health self-heal for both BBB tenants.
+#
+# The qmd index is derived state. This wrapper is safe to run after a compile or
+# from a user systemd timer: it probes known-positive controls, reindexes once
+# when the probe is unhealthy, and exits non-zero if the final probe is still
+# unhealthy. notify-lib owns the two-marker liveness contract and failure page.
+set -euo pipefail
+umask 077
+
+export PATH="${HOME}/.local/bin:${HOME}/.bun/bin:${HOME}/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+NOTIFY_LIB="${BBB_NOTIFY_LIB:-$HOME/bin/lib/notify-lib.sh}"
+if [[ ! -r "$NOTIFY_LIB" ]]; then
+  echo "bbb-reindex-heal: notify-lib is missing or unreadable: $NOTIFY_LIB" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$NOTIFY_LIB"
+arm_fail_trap "bbb-reindex-heal" ""
+
+REGISTRAR_ROOT="${BBB_REGISTRAR_ROOT:-$HOME/000-projects/bobs-big-brain-registrar}"
+CLI="${BBB_REINDEX_CLI:-$REGISTRAR_ROOT/packages/qmd-adapter/dist/cli.js}"
+NODE_BIN="${BBB_NODE_BIN:-$(command -v node || true)}"
+BASE="${TEAMKB_BASE_PATH:-$HOME/.teamkb}"
+MAX_STALENESS="${BBB_REINDEX_MAX_STALENESS_SECONDS:-86400}"
+EXPECTED_QMD_VERSION="${BBB_QMD_EXPECTED_VERSION:-2.5.3}"
+
+if [[ -z "$NODE_BIN" || ! -x "$NODE_BIN" ]]; then
+  echo "bbb-reindex-heal: node is not executable: ${NODE_BIN:-<not found>}" >&2
+  exit 1
+fi
+if [[ ! -r "$CLI" ]]; then
+  echo "bbb-reindex-heal: qmd adapter CLI is missing: $CLI" >&2
+  echo "bbb-reindex-heal: build Registrar first (pnpm --filter @qmd-team-intent-kb/qmd-adapter... build)" >&2
+  exit 1
+fi
+if [[ ! -d "$BASE/kb-export" ]]; then
+  echo "bbb-reindex-heal: export tree is missing: $BASE/kb-export" >&2
+  exit 1
+fi
+if [[ ! "$MAX_STALENESS" =~ ^[0-9]+$ ]]; then
+  echo "bbb-reindex-heal: BBB_REINDEX_MAX_STALENESS_SECONDS must be a non-negative integer" >&2
+  exit 1
+fi
+
+# Prefer the pinned qmd shipped by Registrar. The CLI itself delegates to qmd;
+# allowing an older personal PATH binary here would recreate the tenant/index
+# split this guard exists to catch. A version mismatch is an infrastructure
+# failure, not a reason to run a best-effort heal with an unknown binary.
+QMD_BIN=""
+if [[ -n "${BBB_QMD_BIN:-}" ]]; then
+  QMD_BIN="$BBB_QMD_BIN"
+elif [[ -x "$REGISTRAR_ROOT/node_modules/.bin/qmd" ]]; then
+  QMD_BIN="$REGISTRAR_ROOT/node_modules/.bin/qmd"
+elif command -v qmd >/dev/null 2>&1; then
+  QMD_BIN="$(command -v qmd)"
+fi
+if [[ -z "$QMD_BIN" || ! -x "$QMD_BIN" ]]; then
+  echo "bbb-reindex-heal: qmd binary not found (expected $EXPECTED_QMD_VERSION)" >&2
+  exit 1
+fi
+QMD_VERSION="$("$QMD_BIN" --version 2>/dev/null | sed -nE 's/^qmd ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n1)"
+if [[ "$QMD_VERSION" != "$EXPECTED_QMD_VERSION" ]]; then
+  echo "bbb-reindex-heal: qmd version mismatch: expected $EXPECTED_QMD_VERSION, got ${QMD_VERSION:-unknown} ($QMD_BIN)" >&2
+  exit 1
+fi
+QMD_DIR="$(dirname "$QMD_BIN")"
+export PATH="$QMD_DIR:$PATH"
+
+read -r -a TENANTS <<< "${BBB_REINDEX_TENANTS:-intent-solutions local}"
+if [[ "${#TENANTS[@]}" -eq 0 ]]; then
+  echo "bbb-reindex-heal: BBB_REINDEX_TENANTS resolved to an empty tenant list" >&2
+  exit 1
+fi
+
+for tenant in "${TENANTS[@]}"; do
+  [[ -n "$tenant" ]] || { echo "bbb-reindex-heal: empty tenant id" >&2; exit 1; }
+  echo "bbb-reindex-heal: canary --heal tenant=$tenant base=$BASE max_staleness=${MAX_STALENESS}s"
+  TEAMKB_BASE_PATH="$BASE" TEAMKB_TENANT_ID="$tenant" \
+    "$NODE_BIN" "$CLI" canary --heal --max-staleness-seconds "$MAX_STALENESS"
+done
+
+echo "bbb-reindex-heal: all tenants healthy (${TENANTS[*]})"

--- a/scripts/systemd/bbb-reindex-heal.service
+++ b/scripts/systemd/bbb-reindex-heal.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Bob's Big Brain — reindex and search-health self-heal
+Documentation=https://github.com/jeremylongshore/bobs-big-brain-registrar/blob/main/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/bbb-reindex-heal.sh

--- a/scripts/systemd/bbb-reindex-heal.timer
+++ b/scripts/systemd/bbb-reindex-heal.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run Bob's Big Brain reindex self-heal after the nightly compile window
+
+[Timer]
+# The compile runs at about 03:30 CT and the brain backup at about 04:30 CT.
+# Run after both windows have normally settled; Persistent catches a missed run.
+OnCalendar=*-*-* 05:15:00
+Persistent=true
+RandomizedDelaySec=120
+Unit=bbb-reindex-heal.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Tracking bead: bd_000-projects-gybo.2

## Summary

- Add executable `bin/bbb-reindex-heal.sh` for both `intent-solutions` and `local`.
- Run the known-positive canary with `--heal` and the 24-hour staleness threshold.
- Prefer and verify pinned qmd `2.5.3`; fail closed on missing/mismatched binaries.
- Add user systemd service/timer templates scheduled after the compile and backup windows.
- Document installation, overrides, and outcome-based verification in the qmd operator runbook.

## Verification

- `bash -n bin/bbb-reindex-heal.sh`
- Real local-brain run: all six controls healthy for both tenants; qmd `2.5.3` verified.
- `git diff --check`

The compiler gate and Mission Control registry are coordinated in sibling PRs on the same feature branch name.