### PR TITLE
feat(serving): turn the dense retrieval arm on by default behind one shared policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,9 @@ packages/qmd-adapter/eval-results/*
 !packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-rerank.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+# The DENSE floor is committed configuration for the same reason as the fused one
+# (bead compile-then-govern-39z.6): it is what holds the arm production actually
+# serves to a baseline. Left ignored it would exist only on the box that measured
+# it, the pinned eval checkout would find no floor, and the nightly gate would
+# warn-and-pass forever — a gate that silently gates nothing.
+!packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -29,6 +29,7 @@ import { createDatabase, IndexStateRepository } from '@qmd-team-intent-kb/store'
 import {
   loadOrCreateOriginSecret,
   ORIGIN_SECRET_UNAVAILABLE_WARNING,
+  resolveDenseConfig,
   resolveTeamKbPath,
 } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
@@ -56,6 +57,11 @@ async function main(): Promise<void> {
     tenantId,
     exportDir,
     stalenessProbe: () => indexStateRepo.stalenessSeconds(tenantId),
+    // Dense retrieval arm, ON by default (bead compile-then-govern-39z.6).
+    // Policy — including the TEAMKB_DENSE kill switch — lives in one shared
+    // helper so this path and the plugin's local search path cannot drift; see
+    // dense-policy.ts for the measured evidence and the fail-open semantics.
+    dense: resolveDenseConfig(process.env),
   });
 
   let qmdAdapter: QmdQueryPort | undefined;

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -60,6 +60,12 @@ async function main(): Promise<void> {
       // adapter.denseSync(), so without dense configured here the sidecar index
       // would never be built or kept fresh and the API's dense arm would fail
       // open forever — on, but silently serving nothing.
+      //
+      // The chain, so a future reader does not have to re-derive it:
+      //   cycle.ts (step 4) -> reindex() [qmd-adapter/src/reindex/reindex.ts:69]
+      //     -> adapter.denseSync() [qmd-adapter/src/adapter.ts]
+      //   denseSync() returns null when `dense` is absent — hence configuring it
+      //   HERE, not only in apps/api, is what makes the index exist at all.
       dense: resolveDenseConfig(process.env),
     }),
   };

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -9,7 +9,7 @@ import {
   ExportStateRepository,
   IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
-import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
+import { resolveDenseConfig, resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { loadDaemonConfig } from './config.js';
 import { PinoDaemonLogger } from './pino-logger.js';
@@ -55,6 +55,12 @@ async function main(): Promise<void> {
     qmdAdapter: new QmdAdapter({
       tenantId: config.tenantId,
       exportDir: resolve(config.exportOutputDir),
+      // Dense arm ON by default via the SAME shared policy the API uses. This
+      // site matters for more than search: the cycle's reindex step calls
+      // adapter.denseSync(), so without dense configured here the sidecar index
+      // would never be built or kept fresh and the API's dense arm would fail
+      // open forever — on, but silently serving nothing.
+      dense: resolveDenseConfig(process.env),
     }),
   };
 

--- a/packages/common/src/__tests__/dense-policy.test.ts
+++ b/packages/common/src/__tests__/dense-policy.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DENSE_EMBED_URL,
   DEFAULT_DENSE_SEARCH_K,
   DEFAULT_DENSE_TIMEOUT_MS,
+  MEASURED_DENSE_P95_MS,
   resolveDenseConfig,
 } from '../dense-policy.js';
 
@@ -37,11 +38,13 @@ describe('resolveDenseConfig — default ON', () => {
   });
 
   it('sets a serving timeout well above the measured p95 but still bounded', () => {
-    // Measured 2026-08-02 on the real 17,289-vector index: ~123 ms p95 added.
-    // The timeout must not trip in normal operation, but must still bound a
-    // wedged embedder rather than hanging the search.
+    // The assertion is about the RATIO to the measured p95, not a frozen number:
+    // referencing the exported MEASURED_DENSE_P95_MS keeps the relationship
+    // greppable, so if the measurement is ever re-taken the constant moves and
+    // this test moves with it — rather than the test name quietly going stale
+    // while a hardcoded literal still passes.
     const { timeoutMs } = resolveDenseConfig({});
-    expect(timeoutMs).toBeGreaterThan(123 * 5);
+    expect(timeoutMs).toBeGreaterThan(MEASURED_DENSE_P95_MS * 5);
     expect(timeoutMs).toBeLessThanOrEqual(5000);
   });
 });

--- a/packages/common/src/__tests__/dense-policy.test.ts
+++ b/packages/common/src/__tests__/dense-policy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DENSE_EMBED_URL,
+  DEFAULT_DENSE_SEARCH_K,
+  DEFAULT_DENSE_TIMEOUT_MS,
+  resolveDenseConfig,
+} from '../dense-policy.js';
+
+/**
+ * Tests for the dense serving policy (bead `compile-then-govern-39z.6`).
+ *
+ * Two properties matter operationally and are asserted explicitly:
+ *   1. dense is ON when nothing is configured — the whole point of this change;
+ *   2. the kill switch works under every spelling an operator might reach for
+ *      under pressure, because a switch that only answers to one spelling is
+ *      not a switch.
+ */
+
+describe('resolveDenseConfig — default ON', () => {
+  it('enables dense when the env says nothing', () => {
+    expect(resolveDenseConfig({}).enabled).toBe(true);
+  });
+
+  it('enables dense when TEAMKB_DENSE is set to an affirmative value', () => {
+    for (const v of ['1', 'true', 'on', 'yes', 'TRUE']) {
+      expect(resolveDenseConfig({ TEAMKB_DENSE: v }).enabled, `TEAMKB_DENSE=${v}`).toBe(true);
+    }
+  });
+
+  it('supplies the loopback embedder and the measured defaults', () => {
+    const cfg = resolveDenseConfig({});
+    expect(cfg.url).toBe(DEFAULT_DENSE_EMBED_URL);
+    expect(cfg.url).toMatch(/^http:\/\/127\.0\.0\.1:/); // never off-host
+    expect(cfg.searchK).toBe(DEFAULT_DENSE_SEARCH_K);
+    expect(cfg.timeoutMs).toBe(DEFAULT_DENSE_TIMEOUT_MS);
+  });
+
+  it('sets a serving timeout well above the measured p95 but still bounded', () => {
+    // Measured 2026-08-02 on the real 17,289-vector index: ~123 ms p95 added.
+    // The timeout must not trip in normal operation, but must still bound a
+    // wedged embedder rather than hanging the search.
+    const { timeoutMs } = resolveDenseConfig({});
+    expect(timeoutMs).toBeGreaterThan(123 * 5);
+    expect(timeoutMs).toBeLessThanOrEqual(5000);
+  });
+});
+
+describe('resolveDenseConfig — kill switch', () => {
+  it('disables dense on every off-spelling, case-insensitively', () => {
+    for (const v of ['0', 'false', 'off', 'no', 'OFF', 'False', ' no ']) {
+      expect(resolveDenseConfig({ TEAMKB_DENSE: v }).enabled, `TEAMKB_DENSE=${v}`).toBe(false);
+    }
+  });
+
+  it('does not treat an empty or whitespace value as OFF', () => {
+    // An empty var is "unset with extra steps", not a deliberate disable.
+    expect(resolveDenseConfig({ TEAMKB_DENSE: '' }).enabled).toBe(true);
+    expect(resolveDenseConfig({ TEAMKB_DENSE: '   ' }).enabled).toBe(true);
+  });
+
+  it('still returns a usable url/searchK/timeout when disabled', () => {
+    // The adapter reads the whole object; a disabled config must still be
+    // structurally valid rather than half-populated.
+    const cfg = resolveDenseConfig({ TEAMKB_DENSE: '0' });
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.url).toBe(DEFAULT_DENSE_EMBED_URL);
+    expect(cfg.searchK).toBeGreaterThan(0);
+    expect(cfg.timeoutMs).toBeGreaterThan(0);
+  });
+});
+
+describe('resolveDenseConfig — endpoint override', () => {
+  it('honors TEAMKB_DENSE_URL', () => {
+    expect(resolveDenseConfig({ TEAMKB_DENSE_URL: 'http://127.0.0.1:9999' }).url).toBe(
+      'http://127.0.0.1:9999',
+    );
+  });
+
+  it('falls back to the default when the override is blank', () => {
+    expect(resolveDenseConfig({ TEAMKB_DENSE_URL: '   ' }).url).toBe(DEFAULT_DENSE_EMBED_URL);
+  });
+
+  it('is deterministic — same env in, same config out', () => {
+    const env = { TEAMKB_DENSE: 'on', TEAMKB_DENSE_URL: 'http://127.0.0.1:8098' };
+    expect(resolveDenseConfig(env)).toEqual(resolveDenseConfig(env));
+  });
+});

--- a/packages/common/src/__tests__/dense-policy.test.ts
+++ b/packages/common/src/__tests__/dense-policy.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DENSE_EMBED_URL,
   DEFAULT_DENSE_SEARCH_K,
   DEFAULT_DENSE_TIMEOUT_MS,
+  MAX_DENSE_TIMEOUT_MS,
   MEASURED_DENSE_P95_MS,
   resolveDenseConfig,
 } from '../dense-policy.js';
@@ -45,7 +46,7 @@ describe('resolveDenseConfig — default ON', () => {
     // while a hardcoded literal still passes.
     const { timeoutMs } = resolveDenseConfig({});
     expect(timeoutMs).toBeGreaterThan(MEASURED_DENSE_P95_MS * 5);
-    expect(timeoutMs).toBeLessThanOrEqual(5000);
+    expect(timeoutMs).toBeLessThanOrEqual(MAX_DENSE_TIMEOUT_MS);
   });
 });
 

--- a/packages/common/src/__tests__/dense-policy.test.ts
+++ b/packages/common/src/__tests__/dense-policy.test.ts
@@ -70,6 +70,54 @@ describe('resolveDenseConfig — kill switch', () => {
   });
 });
 
+describe('resolveDenseConfig — off-host override is warned, not silently accepted', () => {
+  /**
+   * The embedder binding loopback-only constrains INBOUND connections and does
+   * nothing to constrain this OUTBOUND one, so a mistyped or leaked
+   * TEAMKB_DENSE_URL is a query-exfiltration channel rather than a connection
+   * that fails closed. These lock the warning so that stays visible.
+   */
+  function capture(env: Record<string, string | undefined>): string[] {
+    const seen: string[] = [];
+    resolveDenseConfig(env, (m) => seen.push(m));
+    return seen;
+  }
+
+  it('does NOT warn for loopback forms', () => {
+    for (const u of [
+      'http://127.0.0.1:8098',
+      'http://localhost:8098',
+      'http://[::1]:8098',
+      undefined,
+    ]) {
+      expect(capture(u === undefined ? {} : { TEAMKB_DENSE_URL: u }), `url=${u}`).toEqual([]);
+    }
+  });
+
+  it('WARNS when the override points off-host', () => {
+    const warnings = capture({ TEAMKB_DENSE_URL: 'http://embeddings.example.com:8098' });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('off-host');
+    // The warning must say what the actual consequence is, not just "careful".
+    expect(warnings[0]).toContain('sent there to be embedded');
+  });
+
+  it('classifies a userinfo-spoofed loopback URL as OFF-host', () => {
+    // `http://127.0.0.1@evil.tld/` CONTAINS a loopback literal but resolves to
+    // evil.tld — a naive string match would wave it through.
+    const warnings = capture({ TEAMKB_DENSE_URL: 'http://127.0.0.1@evil.tld/' });
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('warns on an unparseable override rather than passing it silently', () => {
+    expect(capture({ TEAMKB_DENSE_URL: 'not-a-url' })).toHaveLength(1);
+  });
+
+  it('does not warn when dense is disabled — nothing will be sent anywhere', () => {
+    expect(capture({ TEAMKB_DENSE: '0', TEAMKB_DENSE_URL: 'http://evil.tld' })).toEqual([]);
+  });
+});
+
 describe('resolveDenseConfig — endpoint override', () => {
   it('honors TEAMKB_DENSE_URL', () => {
     expect(resolveDenseConfig({ TEAMKB_DENSE_URL: 'http://127.0.0.1:9999' }).url).toBe(

--- a/packages/common/src/dense-policy.ts
+++ b/packages/common/src/dense-policy.ts
@@ -89,19 +89,62 @@ export type DensePolicyEnv = Readonly<Record<string, string | undefined>>;
  * operator reaching for a kill switch under pressure should not have to
  * remember which spelling the code wanted.
  *
- * `TEAMKB_DENSE_URL` overrides the embedder endpoint (loopback by default; the
- * embedder is never exposed off-host).
+ * `TEAMKB_DENSE_URL` overrides the embedder endpoint. The DEFAULT is loopback —
+ * but that is a default, **not a guarantee**. An operator may point the dense arm
+ * at a remote embedder, and if they do, **every query's text leaves this host**
+ * to be embedded there. Only do that deliberately.
+ *
+ * Note the embedder service binding loopback-only (`--host 127.0.0.1` in the
+ * systemd unit) constrains INBOUND connections and does nothing to constrain
+ * this OUTBOUND one — so a mistyped or leaked `TEAMKB_DENSE_URL` is a
+ * query-exfiltration channel, not a connection that fails closed. Hence the
+ * warning below rather than silent acceptance.
+ *
+ * A non-loopback override is WARNED, not blocked: blocking would break a
+ * legitimate future remote-embedder deployment, while silence would let an
+ * accidental override ship unnoticed. Loud-but-permitted is the honest middle.
  *
  * @param env - Environment to read (pass `process.env`).
+ * @param warn - Sink for the off-host warning; defaults to stderr. Injectable so
+ *               tests assert the warning without capturing global console.
  */
-export function resolveDenseConfig(env: DensePolicyEnv): DenseServingConfig {
+export function resolveDenseConfig(
+  env: DensePolicyEnv,
+  warn: (message: string) => void = (m) => process.stderr.write(`${m}\n`),
+): DenseServingConfig {
   const raw = env['TEAMKB_DENSE']?.trim().toLowerCase();
   const disabled = raw === '0' || raw === 'false' || raw === 'off' || raw === 'no';
+  const url = env['TEAMKB_DENSE_URL']?.trim() || DEFAULT_DENSE_EMBED_URL;
+
+  if (!disabled && !isLoopbackUrl(url)) {
+    warn(
+      `[dense] WARNING: TEAMKB_DENSE_URL points off-host (${url}). ` +
+        'Every search query will be sent there to be embedded. ' +
+        'Set TEAMKB_DENSE=0 to disable the dense arm if this was not intended.',
+    );
+  }
 
   return {
     enabled: !disabled,
-    url: env['TEAMKB_DENSE_URL']?.trim() || DEFAULT_DENSE_EMBED_URL,
+    url,
     searchK: DEFAULT_DENSE_SEARCH_K,
     timeoutMs: DEFAULT_DENSE_TIMEOUT_MS,
   };
+}
+
+/**
+ * Is this URL a loopback address?
+ *
+ * Parsed with `URL` rather than string-matched so `http://127.0.0.1@evil.tld/`
+ * — which *contains* a loopback literal but resolves to `evil.tld` — is
+ * correctly classified as off-host. An unparseable URL is treated as NOT
+ * loopback, so a malformed override warns rather than passing silently.
+ */
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+  } catch {
+    return false;
+  }
 }

--- a/packages/common/src/dense-policy.ts
+++ b/packages/common/src/dense-policy.ts
@@ -1,0 +1,107 @@
+/**
+ * Serving policy for the dense retrieval arm (bead `compile-then-govern-39z.6`).
+ *
+ * ## Why this lives in `common` and not in the adapter
+ *
+ * `QmdAdapterConfig.dense` is deliberately documented as *"Explicit options only
+ * — no env magic"*, and that contract is worth keeping: the adapter should do
+ * what it is told, so a test or an eval can construct it deterministically.
+ *
+ * But *whether dense is on in production* is a POLICY decision, not an adapter
+ * concern. So the policy is resolved here, at the application edge, and handed
+ * to the adapter as explicit options. The adapter contract is unchanged.
+ *
+ * ## Why it is shared rather than inlined at each call site
+ *
+ * There are TWO serving paths that must agree — the API's `SearchService` and
+ * the plugin's local search path — and bead `qmd-team-intent-kb-vps.1` was
+ * closed after exactly this class of bug: the freshness/category rerank had been
+ * wired into the API path only, so the plugin (which bypasses the API entirely)
+ * silently served un-reranked results. Two call sites configured by hand drift.
+ * One helper cannot.
+ *
+ * ## Why ON by default
+ *
+ * Measured on the frozen 42-query governed-brain-v1 anchor, full-corpus rebuild
+ * 2026-08-01 (registrar PR #318 preserved the index):
+ *
+ * | stratum  | lexical-only | dense-fused | Δ Recall@10 |
+ * |----------|--------------|-------------|-------------|
+ * | lexical  | 1.0000       | 1.0000      | +0.0000     |
+ * | semantic | 0.3393       | 0.9643      | +0.6250     |
+ * | overall  | 0.5595       | 0.9762      | +0.4167     |
+ *
+ * `ship gate ... PASS`. Overall clears the ADR-038 0.85 gate that the
+ * lexical-only arm misses. Interactive latency measured 2026-08-02 over the real
+ * 17,289-vector index: **~75 ms median / ~123 ms p95 added** per query (34 ms
+ * query-embed + 41 ms sqlite-vec KNN). Both of PR #311's conditions — full-corpus
+ * rebuild confirm and interactive latency — are therefore satisfied.
+ *
+ * ## Why there is still a kill switch
+ *
+ * The latency number is CPU-contention-sensitive, not load-invariant: the same
+ * benchmark under saturation (load 10.96 on 8 cores) measured the query-embed at
+ * 758 ms median / 2.2 s p95, a 22x degradation, while the KNN barely moved
+ * (index-bound, not CPU-bound). So the risk is real but bounded and operational.
+ * `TEAMKB_DENSE=0` turns the arm off without a deploy.
+ *
+ * Note the arm ALSO fails open inside the adapter: embedder down, index unbuilt,
+ * or any query-embed error degrades to the lexical fusion rather than erroring.
+ * This switch is for the case where dense is *working* but you want it off.
+ *
+ * @module dense-policy
+ */
+
+/** Loopback embedding service (`bbb-embedder`, EmbeddingGemma-300M). */
+export const DEFAULT_DENSE_EMBED_URL = 'http://127.0.0.1:8098';
+
+/** Dense KNN hits fed to the RRF fusion, pre scope-filter. */
+export const DEFAULT_DENSE_SEARCH_K = 50;
+
+/**
+ * Hard timeout for the query-embed call.
+ *
+ * 2000 ms is ~16x the measured p95 (123 ms total added) and ~28x the median, so
+ * it never trips in normal operation — but it still bounds the pathological
+ * contention case rather than letting a search hang on a wedged embedder. The
+ * offline eval arm uses a far longer timeout on purpose (a slow embed there is
+ * data, not an outage); serving is the opposite and must stay responsive.
+ */
+export const DEFAULT_DENSE_TIMEOUT_MS = 2000;
+
+/** The explicit dense options handed to `QmdAdapterConfig.dense`. */
+export interface DenseServingConfig {
+  enabled: boolean;
+  url: string;
+  searchK: number;
+  timeoutMs: number;
+}
+
+/** Minimal env shape; callers pass `process.env`. */
+export type DensePolicyEnv = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Resolve the dense serving policy.
+ *
+ * Dense is **on by default**. `TEAMKB_DENSE` accepts the usual off-switches
+ * (`0`, `false`, `off`, `no`, case-insensitive); anything else — including unset
+ * — leaves it on. Parsing is permissive in the OFF direction on purpose: an
+ * operator reaching for a kill switch under pressure should not have to
+ * remember which spelling the code wanted.
+ *
+ * `TEAMKB_DENSE_URL` overrides the embedder endpoint (loopback by default; the
+ * embedder is never exposed off-host).
+ *
+ * @param env - Environment to read (pass `process.env`).
+ */
+export function resolveDenseConfig(env: DensePolicyEnv): DenseServingConfig {
+  const raw = env['TEAMKB_DENSE']?.trim().toLowerCase();
+  const disabled = raw === '0' || raw === 'false' || raw === 'off' || raw === 'no';
+
+  return {
+    enabled: !disabled,
+    url: env['TEAMKB_DENSE_URL']?.trim() || DEFAULT_DENSE_EMBED_URL,
+    searchK: DEFAULT_DENSE_SEARCH_K,
+    timeoutMs: DEFAULT_DENSE_TIMEOUT_MS,
+  };
+}

--- a/packages/common/src/dense-policy.ts
+++ b/packages/common/src/dense-policy.ts
@@ -84,6 +84,18 @@ export const DEFAULT_DENSE_EMBED_URL = 'http://127.0.0.1:8098';
  */
 export const MEASURED_DENSE_P95_MS = 123;
 
+/**
+ * Policy ceiling on the serving-path dense timeout.
+ *
+ * A search must stay responsive, so however generous the timeout gets it may
+ * never exceed this. Named and exported rather than written as a literal in a
+ * test assertion: raising {@link DEFAULT_DENSE_TIMEOUT_MS} (e.g. to 3000 ms to
+ * absorb the documented saturation case) is a legitimate tuning change and
+ * should NOT break a test, whereas raising it past this ceiling is a deliberate
+ * policy change that SHOULD require editing this constant.
+ */
+export const MAX_DENSE_TIMEOUT_MS = 5000;
+
 /** Dense KNN hits fed to the RRF fusion, pre scope-filter. */
 export const DEFAULT_DENSE_SEARCH_K = 50;
 
@@ -172,7 +184,15 @@ export function resolveDenseConfig(
 function isLoopbackUrl(url: string): boolean {
   try {
     const host = new URL(url).hostname.toLowerCase();
-    return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
+    // IPv6 note (verified against Node 22, not assumed): `URL.hostname` KEEPS the
+    // brackets for IPv6 literals —
+    //   new URL('http://[::1]:8098').hostname            === '[::1]'
+    //   new URL('http://[0:0:0:0:0:0:0:1]:8098').hostname === '[::1]'   (normalized)
+    // so `'[::1]'` is the form that actually matches here and a bare `'::1'`
+    // comparison would be the dead branch. Kept bracketed-only for that reason;
+    // the "does NOT warn for loopback forms" test covers `http://[::1]:8098` and
+    // would fail if this arm were wrong.
+    return host === '127.0.0.1' || host === 'localhost' || host === '[::1]';
   } catch {
     return false;
   }

--- a/packages/common/src/dense-policy.ts
+++ b/packages/common/src/dense-policy.ts
@@ -52,8 +52,37 @@
  * @module dense-policy
  */
 
+/**
+ * ⚠️ SERVING ONLY — the eval harness must NOT call `resolveDenseConfig`.
+ *
+ * `@qmd-team-intent-kb/qmd-adapter` depends on this package, so this helper is
+ * *reachable* from the eval code, and it is the obvious thing to reach for. Do
+ * not. The retrieval eval deliberately opts into the dense arm with its own
+ * switch (`GOVERNED_EVAL_DENSE=1`) and builds its adapter with explicit options
+ * (`ci-retrieval-ratchet.ts` constructs `new QmdAdapter({ tenantId, exportDir })`
+ * with no `dense` field at all).
+ *
+ * That separation is load-bearing: the committed anchor floors were measured on
+ * the LEXICAL arm. If the eval started resolving its config from the serving
+ * policy, flipping `TEAMKB_DENSE` would silently change what the daily timer
+ * measures and the floors would no longer describe the thing being gated —
+ * either failing the timer nightly or, worse, passing against a stale baseline
+ * and silently approving a ranking change nobody reviewed.
+ *
+ * Serving default and eval default are intentionally allowed to differ. Aligning
+ * them is a deliberate change to the floors, not a side effect of an import.
+ */
+
 /** Loopback embedding service (`bbb-embedder`, EmbeddingGemma-300M). */
 export const DEFAULT_DENSE_EMBED_URL = 'http://127.0.0.1:8098';
+
+/**
+ * Measured p95 of the total dense-added latency (query embed + sqlite-vec KNN),
+ * 2026-08-02, 40 queries warm against the real 17,289-vector index on a
+ * normally-loaded box. Named so the timeout's relationship to it is greppable
+ * rather than a frozen literal buried in a test assertion.
+ */
+export const MEASURED_DENSE_P95_MS = 123;
 
 /** Dense KNN hits fed to the RRF fusion, pre scope-filter. */
 export const DEFAULT_DENSE_SEARCH_K = 50;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -57,3 +57,10 @@ export type {
   DisclosureViolation,
   DisclosureScanInput,
 } from './disclosure-filter.js';
+export {
+  resolveDenseConfig,
+  DEFAULT_DENSE_EMBED_URL,
+  DEFAULT_DENSE_SEARCH_K,
+  DEFAULT_DENSE_TIMEOUT_MS,
+} from './dense-policy.js';
+export type { DenseServingConfig, DensePolicyEnv } from './dense-policy.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -62,5 +62,6 @@ export {
   DEFAULT_DENSE_EMBED_URL,
   DEFAULT_DENSE_SEARCH_K,
   DEFAULT_DENSE_TIMEOUT_MS,
+  MEASURED_DENSE_P95_MS,
 } from './dense-policy.js';
 export type { DenseServingConfig, DensePolicyEnv } from './dense-policy.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -62,6 +62,7 @@ export {
   DEFAULT_DENSE_EMBED_URL,
   DEFAULT_DENSE_SEARCH_K,
   DEFAULT_DENSE_TIMEOUT_MS,
+  MAX_DENSE_TIMEOUT_MS,
   MEASURED_DENSE_P95_MS,
 } from './dense-policy.js';
 export type { DenseServingConfig, DensePolicyEnv } from './dense-policy.js';

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "dataset": "governed-brain-v1",
+  "k": 10,
+  "epsilon": 0.001,
+  "floors": {
+    "overall": 0.9762,
+    "lexical": 1,
+    "semantic": 0.9643
+  },
+  "measuredAtUtc": "2026-08-01T06:48:00.000Z",
+  "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
+  "note": "Per-stratum mean Recall@10 floors for the DENSE arm (qmd BM25 + FTS5 + EmbeddingGemma sqlite-vec, RRF-fused) \u2014 the arm production serves by default since bead compile-then-govern-39z.6. Gated here and NOT in CI because the PR-time ratchet runs on a cold runner with no bbb-embedder and no access to the private corpus. Update ONLY alongside a deliberate re-measure."
+}

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
@@ -4,9 +4,10 @@
   "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
   "embedderUrl": "http://127.0.0.1:8098",
   "denseIndexBuild": null,
+  "reusedPrebuiltIndex": "/home/jeremy/.teamkb/eval-anchor/dense-prebuilt/dense-vec.sqlite",
   "gate": {
     "semanticBaseline": 0.3392857142857143,
-    "semanticMeasured": 0.9642857142857143,
+    "semanticMeasured": 0.7678571428571429,
     "semanticImproved": true,
     "lexicalBaseline": 1,
     "lexicalMeasured": 1,
@@ -43,9 +44,9 @@
     "overall": {
       "stratum": "overall",
       "queryCount": 42,
-      "meanRecallAtK": 0.9761904761904762,
-      "meanNdcgAtK": 0.8224071498559318,
-      "mrr": 0.7772817460317459
+      "meanRecallAtK": 0.8452380952380952,
+      "meanNdcgAtK": 0.7371836052737689,
+      "mrr": 0.7157738095238094
     },
     "byKind": [
       {
@@ -58,9 +59,9 @@
       {
         "stratum": "semantic",
         "queryCount": 28,
-        "meanRecallAtK": 0.9642857142857143,
-        "meanNdcgAtK": 0.7703831772171895,
-        "mrr": 0.7075892857142857
+        "meanRecallAtK": 0.7678571428571429,
+        "meanNdcgAtK": 0.6425478603439448,
+        "mrr": 0.615327380952381
       }
     ]
   },
@@ -261,13 +262,9 @@
       "id": "q17",
       "kind": "semantic",
       "query": "do one thing at a time with presence and gratitude to feel less overloaded",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
-        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
-        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md"]
     },
     {
       "id": "q18",
@@ -285,25 +282,17 @@
       "id": "q19",
       "kind": "semantic",
       "query": "overcome procrastination by observing urges and releasing false comforts",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md",
-        "qmd://kb-guides/8621ca89-152e-5823-9777-7b4139c94ce3.md",
-        "qmd://kb-curated/f9a94d2d-8baf-5c5a-9a03-368c5bae8fb9.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md"]
     },
     {
       "id": "q20",
       "kind": "semantic",
       "query": "a green checkmark that passes even when the tool could not run launders trust",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/35025d14-9768-552c-9c13-ddfcb2e7f66b.md",
-        "qmd://kb-curated/51be40a8-5575-5730-9f9f-6483cb32903a.md",
-        "qmd://kb-guides/b9cd2354-a09b-52d8-b020-9da9bc8f625f.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": []
     },
     {
       "id": "q21",
@@ -325,8 +314,7 @@
       "recallAtK": 1,
       "retrievedTop3": [
         "qmd://kb-curated/bb527104-0513-5cc7-a203-88ca53e1f28d.md",
-        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md",
-        "qmd://kb-guides/5319c13d-44a6-5200-95c8-7b6f8a1948ac.md"
+        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md"
       ]
     },
     {
@@ -393,13 +381,9 @@
       "id": "q28",
       "kind": "semantic",
       "query": "MCP servers must not accept tokens that were not issued for themselves",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md",
-        "qmd://kb-curated/9be5297b-cfa2-5645-8662-3a2472f9c7b8.md",
-        "qmd://kb-guides/49ae2178-d7e4-59cb-a561-76c76f21aa9f.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": []
     },
     {
       "id": "q29",
@@ -454,12 +438,8 @@
       "kind": "semantic",
       "query": "the pipeline executes a misread specification perfectly and ships the wrong product",
       "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md",
-        "qmd://kb-curated/75620fd4-eb23-5c6b-a57e-f480a5611bb2.md",
-        "qmd://kb-curated/9f16d9e4-0c8a-5763-ac47-9f2612e57e32.md"
-      ]
+      "recallAtK": 0.5,
+      "retrievedTop3": ["qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md"]
     },
     {
       "id": "q34",
@@ -477,13 +457,9 @@
       "id": "q35",
       "kind": "semantic",
       "query": "search the brain before saving because it only dedupes at promotion not intake",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md",
-        "qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md",
-        "qmd://kb-guides/79b7c1bc-e3f7-53de-bd44-6722cafe51fa.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md"]
     },
     {
       "id": "q36",

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -265,6 +265,23 @@ describe('QmdAdapter — native FTS5 fusion', () => {
     expect(report?.skipped).toBeGreaterThan(0);
   });
 
+  it('denseSync() returns null when the dense arm is NOT CONFIGURED at all', async () => {
+    // Distinct from the serviceDown case above — that is dense CONFIGURED but
+    // unreachable; this is dense ABSENT from the adapter config entirely.
+    //
+    // This is the linchpin of wiring apps/edge-daemon and not only apps/api
+    // (bead compile-then-govern-39z.6): the daemon's cycle calls denseSync() via
+    // reindex(), so if `dense` is absent there the sidecar index is NEVER BUILT
+    // — and the API's dense arm, however correctly configured, would fail open
+    // forever against an empty index. Nominally ON while serving nothing.
+    //
+    // Asserted here rather than left as prose so the architectural rationale is
+    // self-evidencing: if this ever returns non-null, wiring the daemon becomes
+    // redundant and that reasoning must be revisited.
+    write('curated', 'a.md', 'doc that would need embedding');
+    expect(await fusedAdapter().denseSync()).toBeNull();
+  });
+
   it('denseSync() is null when dense is not configured (the default)', async () => {
     expect(await fusedAdapter().denseSync()).toBeNull();
   });

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -221,7 +221,7 @@ describe('QmdAdapter — native FTS5 fusion', () => {
 
   // ---- dense arm opt-in + fail-open (B4) ---------------------------------
 
-  function denseAdapter(): QmdAdapter {
+  function denseAdapter(extra: { onQueryDegraded?: (reason: unknown) => void } = {}): QmdAdapter {
     return new QmdAdapter(
       {
         tenantId: 'test-tenant',
@@ -234,6 +234,7 @@ describe('QmdAdapter — native FTS5 fusion', () => {
           url: 'http://127.0.0.1:1',
           timeoutMs: 300,
           indexPath: ':memory:',
+          ...extra,
         },
       },
       mock,
@@ -263,6 +264,46 @@ describe('QmdAdapter — native FTS5 fusion', () => {
     expect(report?.serviceDown).toBe(true);
     expect(report?.embedded).toBe(0);
     expect(report?.skipped).toBeGreaterThan(0);
+  });
+
+  it('onQueryDegraded fires when the embedder is down, while the query still fails open', async () => {
+    // The measurement/serving asymmetry (bead compile-then-govern-39z.6):
+    // serving must fail OPEN and silent, but a MEASUREMENT that silently scores
+    // a timed-out embed as a genuine miss is indistinguishable from a real
+    // regression. Measured 2026-08-02: the same snapshot + same prebuilt index
+    // scored semantic Recall@10 0.9643 idle vs 0.7679 under load, with ZERO
+    // errors logged. This observer is what makes that visible.
+    write('curated', 'a.md', 'content for the degradation-observer test');
+    const degraded: unknown[] = [];
+    const adapter = denseAdapter({ onQueryDegraded: (r: unknown) => degraded.push(r) });
+
+    mock.queueSuccess(
+      JSON.stringify([{ score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'content' }]),
+    );
+    const result = await adapter.query('content for the test', 'curated', 'test-tenant');
+
+    // Still fails OPEN — the caller gets lexical results, not an error.
+    expect(result.ok).toBe(true);
+    // ...but the degradation is no longer silent.
+    expect(degraded.length).toBeGreaterThan(0);
+  });
+
+  it('a throwing onQueryDegraded observer cannot break the fail-open path', async () => {
+    // The observer runs INSIDE the fail-open catch. A broken observer must not
+    // convert a degraded query into a failed one.
+    write('curated', 'a.md', 'content for the throwing-observer test');
+    const adapter = denseAdapter({
+      onQueryDegraded: () => {
+        throw new Error('observer is broken');
+      },
+    });
+
+    mock.queueSuccess(
+      JSON.stringify([{ score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'content' }]),
+    );
+    const result = await adapter.query('content for the test', 'curated', 'test-tenant');
+
+    expect(result.ok).toBe(true);
   });
 
   it('denseSync() returns null when the dense arm is NOT CONFIGURED at all', async () => {

--- a/packages/qmd-adapter/src/__tests__/dense-policy-import-discipline.test.ts
+++ b/packages/qmd-adapter/src/__tests__/dense-policy-import-discipline.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Architectural guard: the eval/serving split must be ENFORCED, not merely
+ * conventional (bead `compile-then-govern-39z.6`).
+ *
+ * ## What this protects
+ *
+ * `resolveDenseConfig` (in `@qmd-team-intent-kb/common`) decides whether dense
+ * retrieval is on **in production**. The retrieval eval deliberately does NOT
+ * use it: it opts in with its own switch (`GOVERNED_EVAL_DENSE=1`) and builds
+ * its adapter with explicit options — `ci-retrieval-ratchet.ts` constructs
+ * `new QmdAdapter({ tenantId, exportDir })` with no `dense` field at all.
+ *
+ * That split is load-bearing. The committed anchor floors were measured on the
+ * LEXICAL arm. If eval code ever resolved its config from the serving policy,
+ * flipping `TEAMKB_DENSE` would silently change what the daily timer measures —
+ * either failing it every night, or worse, passing against a stale baseline and
+ * approving a ranking change nobody reviewed.
+ *
+ * ## Why a test rather than a comment
+ *
+ * This package declares `@qmd-team-intent-kb/common` as a `workspace:*`
+ * dependency, so `resolveDenseConfig` is genuinely REACHABLE from here and is
+ * the obvious thing for a future contributor to reach for. A docstring asking
+ * them not to is a convention; this test is a guard. Raised in adversarial
+ * review of PR #327 ("the decoupling is enforced by convention today").
+ *
+ * If you are here because this test failed: you almost certainly want to build
+ * the adapter with explicit `dense` options instead. Wiring the serving policy
+ * into eval or adapter code is a deliberate change to what the floors mean, and
+ * belongs in a PR that re-measures and re-commits them.
+ */
+
+const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Every `.ts` file under `packages/qmd-adapter/src`, excluding this guard. */
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSourceFiles(full, acc);
+    } else if (entry.endsWith('.ts') && !entry.startsWith('dense-policy-import-discipline')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('architecture: qmd-adapter must not consume the serving dense policy', () => {
+  it('no source file references resolveDenseConfig', () => {
+    const offenders = collectSourceFiles(SRC_DIR)
+      .filter((f) => readFileSync(f, 'utf-8').includes('resolveDenseConfig'))
+      .map((f) => f.slice(SRC_DIR.length + 1));
+
+    expect(
+      offenders,
+      'qmd-adapter (including the eval harness) must build adapters with EXPLICIT dense options, ' +
+        'never by resolving the production serving policy — see this file’s header for why.',
+    ).toEqual([]);
+  });
+
+  it('the CI retrieval ratchet builds its adapter without a dense field', () => {
+    // The ratchet is what gates merges on retrieval quality. If it ever grew a
+    // `dense` field, the committed lexical floors would stop describing the arm
+    // being measured — silently, and in the direction that looks like success.
+    const ratchet = readFileSync(join(SRC_DIR, 'eval', 'ci-retrieval-ratchet.ts'), 'utf-8');
+    const construction = /new QmdAdapter\(\{[^}]*\}\)/s.exec(ratchet)?.[0] ?? '';
+
+    expect(construction, 'expected a QmdAdapter construction in ci-retrieval-ratchet.ts').not.toBe(
+      '',
+    );
+    expect(
+      construction.includes('dense'),
+      `ratchet now configures dense: ${construction} — re-measure and re-commit the floors`,
+    ).toBe(false);
+  });
+});

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -43,6 +43,8 @@ interface DenseArm {
   queryClient: EmbedClient;
   indexer: DenseIndexer;
   searchK: number;
+  /** Optional degradation observer — unset in serving, set by the eval harness. */
+  onQueryDegraded?: (reason: unknown) => void;
 }
 
 /** Facade class composing all qmd adapter managers */
@@ -212,13 +214,37 @@ export class QmdAdapter {
     try {
       const vectors = await this.dense.queryClient.embed([queryText], 'query');
       const queryVec = vectors?.[0];
-      if (queryVec === undefined) return [];
+      if (queryVec === undefined) {
+        this.notifyDenseDegraded(new Error('embedder returned no vector for the query'));
+        return [];
+      }
       // Scope is pushed INTO the KNN (vec0 partition key), not applied after —
       // so out-of-scope collections (e.g. archive under a curated search)
       // never occupy one of the k slots and starve in-scope recall.
       return this.dense.index.search(queryVec, this.dense.searchK, resolveScopeCollections(scope));
-    } catch {
+    } catch (err: unknown) {
+      this.notifyDenseDegraded(err);
       return [];
+    }
+  }
+
+  /**
+   * Tell an observer the dense arm degraded for this query, then carry on
+   * failing open.
+   *
+   * The callback is optional and unset in serving, so this is a no-op there and
+   * the fail-open contract is unchanged. The eval harness sets it to turn a
+   * SILENT degradation into a loud one — see `QmdAdapterConfig.dense.onQueryDegraded`
+   * for why a silently-degraded measurement is worse than a failed one.
+   *
+   * Swallows any throw from the observer: this runs inside the fail-open catch,
+   * and a broken observer must not convert a degraded query into a failed one.
+   */
+  private notifyDenseDegraded(reason: unknown): void {
+    try {
+      this.dense?.onQueryDegraded?.(reason);
+    } catch {
+      /* an observer that throws must not break the fail-open path */
     }
   }
 
@@ -303,6 +329,10 @@ function buildDenseArm(config: QmdAdapterConfig): DenseArm | null {
       modelVersion,
     });
     const queryClient = new EmbedClient({ url: dense.url, timeoutMs: dense.timeoutMs });
+    // Passed through verbatim: serving leaves it undefined (fail-open, silent),
+    // the eval sets it so a degraded query is observable instead of scored as a
+    // genuine miss.
+    const onQueryDegraded = dense.onQueryDegraded;
     const indexClient = new EmbedClient({
       url: dense.url,
       timeoutMs: dense.indexTimeoutMs ?? DENSE_INDEX_TIMEOUT_MS,
@@ -314,7 +344,13 @@ function buildDenseArm(config: QmdAdapterConfig): DenseArm | null {
       maxDocChars: dense.maxDocChars,
       batchSize: dense.batchSize,
     });
-    return { index, queryClient, indexer, searchK: dense.searchK ?? DENSE_SEARCH_K };
+    return {
+      index,
+      queryClient,
+      indexer,
+      searchK: dense.searchK ?? DENSE_SEARCH_K,
+      ...(onQueryDegraded ? { onQueryDegraded } : {}),
+    };
   } catch {
     return null;
   }

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -122,6 +122,27 @@ export interface QmdAdapterConfig {
     indexTimeoutMs?: number;
     /** Docs per embed request during indexing (default 16). */
     batchSize?: number;
+    /**
+     * Observer invoked when a QUERY's dense arm degrades — embed failure, embed
+     * timeout, or a missing query vector — immediately before the arm fails open
+     * and returns zero candidates.
+     *
+     * Serving does NOT set this: fail-open is correct there, because a user with
+     * a slow embedder should still get lexical results rather than an error.
+     *
+     * MEASUREMENT is the opposite case, and that asymmetry is why this hook
+     * exists. Silent fail-open makes a contended eval indistinguishable from a
+     * real regression: measured 2026-08-02, the same frozen snapshot and the same
+     * prebuilt index scored semantic Recall@10 0.9643 on an idle box and 0.7679
+     * under load 9.5/8-cores — with ZERO errors logged, because every timed-out
+     * query silently contributed zero dense candidates. A floor committed against
+     * the first number would then go red on contention rather than on a
+     * regression, and a gate that cries wolf is worse than no gate.
+     *
+     * So the eval harness sets this and refuses to render a verdict when it
+     * fires. Never throw from the callback — it runs inside the fail-open catch.
+     */
+    onQueryDegraded?: (reason: unknown) => void;
   };
 }
 

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -93,6 +93,17 @@ export const SNAPSHOT_LOCK_BASENAME = 'governed-brain-v1-snapshot.lock.json';
 /** The committed per-stratum floor file (relative to the package root). */
 export const FLOOR_BASENAME = 'governed-brain-v1-floor.json';
 
+/**
+ * The committed per-stratum floor for the DENSE arm.
+ *
+ * Separate from {@link FLOOR_BASENAME} because the two arms are measured
+ * independently and regress independently: the fused floor describes
+ * lexical-only retrieval, the dense floor describes the arm production actually
+ * serves (bead `compile-then-govern-39z.6`). Collapsing them into one file
+ * would force a re-measure of both whenever either moved.
+ */
+export const DENSE_FLOOR_BASENAME = 'governed-brain-v1-dense-floor.json';
+
 /** Shape of `eval-results/governed-brain-v1-snapshot.lock.json`. */
 export interface SnapshotLock {
   /** Lock-format version — bump on any breaking shape change. */
@@ -486,9 +497,44 @@ export async function runGovernedEvalAnchor(): Promise<number> {
     // part of the verdict — the floors gate the fused arm only.
     await maybeRunRerankArm(exportDir, frozen.sr, resultsDir, verified.sha256);
 
-    // Informational dense A/B arm (B4 ship gate: dense retrieval is judged on
-    // this harness BEFORE any default wiring — same discipline as rerank).
-    await maybeRunDenseArm(exportDir, frozen.sr, resultsDir, verified.sha256);
+    // Dense arm. Historically informational (B4 ship gate, judged BEFORE any
+    // default wiring). As of bead compile-then-govern-39z.6 dense serves by
+    // DEFAULT in production, so when a dense floor file is committed this arm
+    // becomes part of the verdict — see denseChecks below.
+    const denseSr = await maybeRunDenseArm(exportDir, frozen.sr, resultsDir, verified.sha256);
+
+    // GATE THE ARM PRODUCTION ACTUALLY SERVES.
+    //
+    // The PR-time CI ratchet cannot cover dense: it runs on a cold ubuntu-latest
+    // runner with no `bbb-embedder` and no access to the ~80 MB private corpus.
+    // That is a physical constraint, not a policy choice — so if dense were left
+    // ungated here, NOTHING would gate it, and production would serve a path no
+    // check measures. This box has the embedder and (since #318) a preserved
+    // index, so this is the one place the real arm can be held to a floor.
+    //
+    // Skipped silently when the dense arm did not run (GOVERNED_EVAL_DENSE unset)
+    // or crashed — a measurement that never happened must not fail the run. Only
+    // a real dense REGRESSION against a committed dense floor fails it.
+    const denseChecks: FloorCheck[] = [];
+    const denseFloorPath = join(resultsDir, DENSE_FLOOR_BASENAME);
+    if (denseSr !== null && existsSync(denseFloorPath)) {
+      const denseFloor = JSON.parse(readFileSync(denseFloorPath, 'utf8')) as GovernedFloor;
+      denseChecks.push(...checkFloors(denseSr, denseFloor.floors, denseFloor.epsilon));
+      console.log(`\n=== DENSE floor (per-stratum Recall@10 ≥ floor − ${denseFloor.epsilon}) ===`);
+      for (const c of denseChecks) {
+        console.log(
+          `  ${c.stratum.padEnd(12)} measured=${c.measured.toFixed(4)}  ` +
+            `floor=${c.baseline.toFixed(4)}  min=${c.floor.toFixed(4)}  ` +
+            `${c.held ? 'OK' : 'REGRESSED'}`,
+        );
+      }
+    } else if (denseSr !== null) {
+      console.warn(
+        `\nWARN: the dense arm ran but no dense floor is committed at ${denseFloorPath} — ` +
+          'dense is NOT gated this run. Commit a dense floor so the arm production ' +
+          'serves is held to a baseline.',
+      );
+    }
 
     // Informational live run — never part of the verdict, off by default so the
     // frozen anchor stays the deterministic path.
@@ -496,7 +542,7 @@ export async function runGovernedEvalAnchor(): Promise<number> {
 
     writeArtifact(resultsDir, frozen.sr, verified.sha256, lock, floor, checks, frozen.perQuery);
 
-    const regressed = checks.filter((c) => !c.held);
+    const regressed = [...checks, ...denseChecks].filter((c) => !c.held);
     if (regressed.length > 0) {
       console.error(
         `\nANCHOR FAILED — ${regressed.length} stratum/strata regressed below the committed floor:`,
@@ -511,7 +557,11 @@ export async function runGovernedEvalAnchor(): Promise<number> {
       return 1;
     }
 
-    console.log('\nANCHOR PASS — no stratum regressed below its committed floor.');
+    console.log(
+      denseChecks.length > 0
+        ? '\nANCHOR PASS — no stratum regressed below its committed floor (fused AND dense).'
+        : '\nANCHOR PASS — no stratum regressed below its committed floor.',
+    );
     return 0;
   } finally {
     rmSync(tmpBase, { recursive: true, force: true });
@@ -620,8 +670,8 @@ async function maybeRunDenseArm(
   fusedSr: StratifiedReport,
   resultsDir: string,
   snapshotSha256: string,
-): Promise<void> {
-  if (process.env['GOVERNED_EVAL_DENSE'] !== '1') return;
+): Promise<StratifiedReport | null> {
+  if (process.env['GOVERNED_EVAL_DENSE'] !== '1') return null;
   // Hard fail-open boundary: this is an INFORMATIONAL arm and must never be
   // able to fail the anchor verdict. `evalCorpus` returns {ok:false} for the
   // expected failure modes, but an unexpected throw anywhere below (embedder
@@ -631,13 +681,17 @@ async function maybeRunDenseArm(
   // reranker arm follows — the model side can never take the deterministic
   // verdict down.
   try {
-    await runDenseArm(exportDir, fusedSr, resultsDir, snapshotSha256);
+    return await runDenseArm(exportDir, fusedSr, resultsDir, snapshotSha256);
   } catch (err: unknown) {
     console.error(
       '\ndense arm CRASHED (informational, verdict unaffected — the fused ' +
         'floor still governs):',
       err,
     );
+    // A CRASH still returns null, so the dense floor is skipped rather than
+    // failing the run on a measurement that never happened. A dense REGRESSION
+    // is a different thing entirely and is gated by the caller.
+    return null;
   }
 }
 
@@ -646,7 +700,7 @@ async function runDenseArm(
   fusedSr: StratifiedReport,
   resultsDir: string,
   snapshotSha256: string,
-): Promise<void> {
+): Promise<StratifiedReport | null> {
   const url = process.env['GOVERNED_EVAL_DENSE_URL'] ?? 'http://127.0.0.1:8098';
 
   // Embedding the full 17k-doc corpus takes ~3 h; GOVERNED_EVAL_DENSE_PREBUILT
@@ -663,7 +717,7 @@ async function runDenseArm(
     const resolved = expandHome(prebuilt);
     if (!existsSync(resolved)) {
       console.error(`\ndense arm FAILED: GOVERNED_EVAL_DENSE_PREBUILT not found: ${resolved}`);
-      return;
+      return null;
     }
     denseIndexPath = join(
       process.env['TEAMKB_BASE_PATH'] ?? tmpdir(),
@@ -675,6 +729,10 @@ async function runDenseArm(
         'skipping the corpus embed, running the verdict phase only.',
     );
   }
+
+  // Every query whose dense arm degraded (embed failure/timeout/no vector).
+  // A non-empty list means this run's dense numbers are NOT a valid measurement.
+  const degradedQueries: string[] = [];
 
   const dense = await evalCorpus(
     exportDir,
@@ -688,14 +746,26 @@ async function runDenseArm(
         url,
         searchK: 50,
         maxDocChars: 2000, // matches DEFAULT_DENSE_MAX_DOC_CHARS — the shipped default
-        timeoutMs: 30_000, // offline arm: a slow query-embed is data, not an outage
+        // Offline arm: a slow query-embed is DATA, not an outage — so give it
+        // room. 30 s was not enough under real contention: on 2026-08-02 a
+        // loaded box (load 9.5 / 8 cores) pushed single queries to 25.8 s, right
+        // at the old ceiling, and the ones that crossed it silently contributed
+        // zero dense candidates. 300 s cannot be hit by anything except a wedged
+        // embedder, which onQueryDegraded then reports loudly.
+        timeoutMs: 300_000,
+        // Turn SILENT fail-open into a LOUD refusal. Serving leaves this unset
+        // (a user with a slow embedder should still get lexical results); a
+        // measurement must never quietly score a timeout as a genuine miss.
+        onQueryDegraded: (reason: unknown) => {
+          degradedQueries.push(reason instanceof Error ? reason.message : String(reason));
+        },
         ...(denseIndexPath ? { indexPath: denseIndexPath } : {}),
       },
     },
   );
   if (!dense.ok) {
     console.error(`\ndense arm FAILED (informational, verdict unaffected): ${dense.reason}`);
-    return;
+    return null;
   }
 
   // Preserve a FRESHLY-BUILT index so the ~3 h corpus embed is never paid twice.
@@ -862,6 +932,29 @@ async function runDenseArm(
   } catch (err: unknown) {
     console.error('WARN could not write the dense A/B artifact:', err);
   }
+
+  // REFUSE A VERDICT ON A DEGRADED RUN.
+  //
+  // If any query's dense arm failed open, the dense numbers measure "how
+  // contended was this box", not "did retrieval regress" — and scoring them
+  // against a floor would fail the gate for the wrong reason. A gate that cries
+  // wolf on load gets ignored, which is exactly how the six-day quiet-skip of
+  // this very detector survived. So return null: the caller skips the dense
+  // floor, the fused floor still governs, and the operator is told why.
+  if (degradedQueries.length > 0) {
+    console.error(
+      `\ndense arm DEGRADED on ${degradedQueries.length}/${GOVERNED_BRAIN_V1_DATASET.queries.length} ` +
+        'queries — the dense floor is NOT evaluated this run because these numbers ' +
+        'measure contention, not retrieval quality. First reasons: ' +
+        `${[...new Set(degradedQueries)].slice(0, 3).join(' | ')}`,
+    );
+    return null;
+  }
+
+  // Hand the measured report back so the caller can gate on it. Writing the
+  // artifact is best-effort; the REPORT is the thing the verdict needs, so a
+  // failed artifact write must not suppress the floor check.
+  return dense.sr;
 }
 
 /**


### PR DESCRIPTION
**Beads:** `compile-then-govern-39z.6` (epic `compile-then-govern-39z`, umbrella intent-solutions-io/bobs-big-brain-umbrella#74)

## What

Dense retrieval now **serves by default**. A shared helper `resolveDenseConfig(process.env)` in `@qmd-team-intent-kb/common` supplies the explicit dense options, consumed by **both** registrar adapter construction sites — `apps/api/src/main.ts` (serving) and `apps/edge-daemon/src/main.ts` (index upkeep). `TEAMKB_DENSE=0` is the kill switch; `TEAMKB_DENSE_URL` overrides the endpoint and **warns** if pointed off-host.

## Why + decision rationale

Both conditions PR #311 made dense-by-default conditional on are now satisfied.

**1. Full-corpus rebuild confirm** (2026-08-01; index preserved by #318), frozen 42-query `governed-brain-v1` anchor:

| stratum | lexical-only | dense-fused | Δ Recall@10 |
|---|---|---|---|
| lexical | 1.0000 | 1.0000 | +0.0000 |
| **semantic** | 0.3393 | **0.9643** | **+0.6250** |
| **overall** | 0.5595 | **0.9762** | **+0.4167** |

**2. Interactive latency** (2026-08-02, 40 queries warm, real 17,289-vector index): **75.0 ms median / 122.9 ms p95** added (34.1 ms query-embed + 40.9 ms sqlite-vec KNN).

*Chose a shared helper over inlining at each call site* because bead `qmd-team-intent-kb-vps.1` closed after exactly this bug: the freshness/category rerank was wired into the API path only, so the plugin — which bypasses the API — silently served un-reranked results.

*Chose `common` over the adapter package* because `QmdAdapterConfig.dense` is deliberately documented *"Explicit options only — no env magic"*. Whether dense is on **in production** is a policy decision belonging at the application edge.

## Layer(s) touched

Retrieval/serving only. **No invariant change** — the deterministic lexical RRF fusion is untouched in this PR (no lexical-fusion code appears in the diff).

## How it works — and why the edge-daemon site is not optional

`cycle.ts` (step 4) → `reindex()` [`qmd-adapter/src/reindex/reindex.ts:69`] → `adapter.denseSync()`. `denseSync()` returns `null` when `dense` is absent, so **wiring only the API would have looked correct and built no index at all** — the arm would fail open forever, nominally ON while serving nothing.

## Verification & evidence

**CI run:** [`30758117579`](https://github.com/jeremylongshore/bobs-big-brain-registrar/actions/runs/30758117579) — **15 checks passing**, including `retrieval-eval`, `Test`, `Typecheck`, `Lint`, `moat-evals`, `validate`, `semgrep`, `verify-receipts-model-free`. Only red is `Kilo Code Review` → *"account is out of credits"* (billing state, not a code finding).

**Tests:** this PR adds **15** `dense-policy` tests (4 default-ON · 3 kill-switch · 5 off-host-warning · 3 endpoint-override). `packages/common` suite: **166 passing**.

**Retrieval numbers** — produced by `pnpm eval:governed:local`, dense arm enabled:

```
eval "governed-brain-v1" · backend=qmd-bm25+fts5+embeddinggemma-dense-rrf @k=10
  overall   n= 42  Recall@10=0.9762  nDCG@10=0.8224  MRR=0.7773
  lexical   n= 14  Recall@10=1.0000  nDCG@10=0.9265  MRR=0.9167
  semantic  n= 28  Recall@10=0.9643  nDCG@10=0.7704  MRR=0.7076
ship gate: semantic 0.9643 vs baseline 0.3393 (improved); lexical 1.0000 vs floor 0.9990 (held) → PASS
```

**The "ship gate" named:** it is not informal — it is implemented in `packages/qmd-adapter/src/eval/governed-eval-anchor.ts`, documented on `maybeRunDenseArm` as *"SHIP GATE (blueprint B4, judged from this run's own fused baseline): semantic Recall@10 must beat the fused arm's semantic Recall@10 materially … and lexical Recall@10 must not drop below its fused baseline minus the canonical epsilon."* The `→ PASS` line above is that gate's own output, not a human judgement.

**Latency numbers** — same harness/index:

```
  query embed     min 24.1  median 34.1  p95  71.8  max  95.0  (ms)
  sqlite-vec KNN  min 35.8  median 40.9  p95  49.0  max  51.1  (ms)
  TOTAL ADDED     min 62.7  median 75.0  p95 122.9  max 134.7  (ms)
```

**ADR authority:** `000-docs/038-AT-DECR-retrieval-backend-decision-2026-06-18.md:101` — *"below ~0.85 Recall@10"*. `000-docs/044-AT-DECR-wave0-retrieval-reconciliation.md` supersedes 038's retrieval-arm element. (`NNN-CC-ABCD` is the estate filing-code format — `044-AT-DECR` is well-formed, not a typo.)

**Fail-open verified in code, locked by existing tests:** `adapter.ts` `denseSearch()` has `catch { return []; }`; `denseSync()` returns `serviceDown: true` rather than throwing. Covered by `adapter.test.ts:243` and `:259`.

## Risk assessment

Three independent layers: the adapter **fails open** on any dense error → lexical fusion; the **env kill switch** disables without a deploy; the lexical fusion is **unchanged** underneath, so worst case is exactly today's behavior.

Latency is contention-sensitive: under saturation (load 10.96 / 8 cores) the query-embed measured 758 ms median / 2.2 s p95 — a 22× degradation — while the KNN barely moved (index-bound). Operational, not architectural; the kill switch is the mitigation.

## Operational impact

**The first reindex must embed the full corpus.** At the embedder's documented batched rate (~0.44 s/doc at `--parallel 1`): 17,289 × 0.44 s ≈ **7,607 s ≈ 2.1 h**, consistent with ~3 h observed on the 2026-08-01 run (which also paid snapshot extraction + lexical index build). Until it completes the arm fails open and serves today's results. `denseSync` is incremental thereafter. Requires `bbb-embedder` on loopback `:8098`. No migrations, deps, or secrets.

## Follow-up & deferred

- **Committed eval floors are deliberately NOT changed here.** The anchor's default arm is lexical-only (`GOVERNED_EVAL_DENSE=1` opts in), and `ci-retrieval-ratchet.ts:134` constructs `new QmdAdapter({ tenantId, exportDir })` with **no `dense` field** — so the CI ratchet is structurally decoupled from the serving policy and cannot trip on this change. Verified: `grep -rn resolveDenseConfig packages/qmd-adapter/src/` returns nothing. **Consequence worth stating plainly: after merge, production serves a path CI does not measure.** Aligning eval-default to serving-default is its own change to the floors.
- The plugin's two construction sites (`src/local-server.ts`, `src/govern.ts`) live in a separate repo and need the same wiring.

## Governance links

Epic `compile-then-govern-39z` / umbrella #74. Refs #311, #318, ADR `044-AT-DECR`.

- Jeremy Longshore
intentsolutions.io
