### PR TITLE
feat(qmd): enable dense retrieval in production adapters

### DIFF
--- a/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
+++ b/000-docs/051-AT-RNBK-embedder-service-and-dense-index-runbook.md
@@ -6,7 +6,7 @@
 
 ## 1. What this is
 
-An OPT-IN dense retrieval arm. The deterministic RRF fusion in
+A production-default dense retrieval arm. The deterministic RRF fusion in
 `QmdAdapter.query()` gains a THIRD ranked list — top-50 nearest neighbours
 from a sqlite-vec index of EmbeddingGemma-300M document embeddings — joining
 qmd BM25 and native FTS5 by `qmd://` citation. The model runs as a
@@ -39,6 +39,13 @@ dependency-cruiser rule).
   arm exists to buy. `WHERE collection IN (...)` inside the vec0 query returns
   the k nearest _within scope_.
 
+The adapter library remains explicit-by-config so isolated fixtures and
+lexical baselines can opt out. The API, edge daemon, local MCP path, and qmd
+CLI all call `getDefaultDenseConfig()`, which enables this arm by default at
+the serving/reindex boundary. The only emergency override is
+`TEAMKB_DENSE_ENABLED=false`; it is intentionally a kill switch, not the
+normal operating mode.
+
 ## 2. Components
 
 | Piece          | Where                                                                                            | Pinned by                                                                                                                    |
@@ -47,7 +54,7 @@ dependency-cruiser rule).
 | Model weights  | `~/.cache/qmd/models/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf` (333,590,944 bytes)              | SHA-256 `b5ce9d77…490d63` in `weights-manifest.ts` (id `embedding`); re-verified on disk 2026-07-20                          |
 | Service unit   | `~/.config/systemd/user/bbb-embedder.service` (source of truth: `scripts/bbb-embedder.service`)  | ExecStartPre `sha256sum -c ~/.local/lib/bbb/embedder-weights.sha256` — the manifest pin restated where systemd can check it  |
 | Endpoint       | `http://127.0.0.1:8098/v1/embeddings` (+ `/health`)                                              | loopback only; port 8098 chosen free in the 8090–8199 range, ≠ 8097 (bbb-reranker) and avoiding 8090/8091 (forms/scott APIs) |
-| Adapter arm    | `packages/qmd-adapter/src/dense/`                                                                | opt-in via `QmdAdapterConfig.dense`                                                                                          |
+| Adapter arm    | `packages/qmd-adapter/src/dense/`                                                                | default-on through production `getDefaultDenseConfig()`; direct library callers may omit it for lexical-only fixtures        |
 | Sidecar index  | `<qmd-index>/<tenant>/dense-vec.sqlite` (sqlite-vec vec0 + bookkeeping tables)                   | derived data — rebuildable from kb-export + this service; deletable at any time; outside backup scope                        |
 
 Weight-gate design choice: identical to B1 — the unit uses a `sha256sum -c`
@@ -96,29 +103,31 @@ with `title: none | text:` (each prefix ends with a trailing space — see
 un-prefixed text and similarity quality silently degrades. Never bypass the
 client.
 
-## 4. Enabling dense in the adapter
+## 4. Production default and emergency rollback
 
-Dense is OFF unless a caller passes explicit config — no env magic:
+Production entrypoints use the shared default explicitly:
 
 ```ts
+import { getDefaultDenseConfig, QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+
 const adapter = new QmdAdapter({
   tenantId,
   exportDir,
-  dense: {
-    enabled: true,
-    url: 'http://127.0.0.1:8098',
-    // optional: timeoutMs (5000), indexPath, searchK (50),
-    //           maxDocChars (2000), indexTimeoutMs (120000), batchSize (16)
-  },
+  dense: getDefaultDenseConfig(),
 });
 ```
 
-With `dense` absent or `enabled: false` the query path is byte-identical to
-the lexical-only deterministic fusion (unit-tested).
+`getDefaultDenseConfig()` targets the pinned loopback service at
+`http://127.0.0.1:8098` and returns `enabled: true`. Set
+`TEAMKB_DENSE_ENABLED=false` only as a reviewed emergency rollback; the
+fail-open path still serves lexical results if the service or sidecar is
+unavailable. Direct library callers may omit `dense`, or pass
+`{ enabled: false, url: 'http://127.0.0.1:8098' }`, when they intentionally need
+the lexical-only deterministic fusion used by baselines and fixtures.
 
 ## 5. The sidecar index — build, rebuild, staleness
 
-- **What builds it:** `reindex(adapter)` (the CLI / canary / edge-daemon
+- **What builds it:** `reindex(adapter)` (the default-on CLI / canary / edge-daemon
   reindex primitive) now ends with `adapter.denseSync()` when the adapter has
   a dense arm — an incremental sweep of `kb-export` that embeds NEW/CHANGED
   docs only (keyed by content hash of the exact truncated text embedded, not
@@ -252,15 +261,12 @@ phase — this verdict was produced that way against the preserved index at
 emits a per-query progress line (`[verdict] query i/42  N ms  top=…`) so a slow
 or hung query phase is observable, never a silent black box.
 
-### Posture (this PR) + recommendation
+### Historical B4 posture and Track B rollout
 
 Dense EARNED default wiring on the semantic slice — unlike the reranker (a MISS,
-kept opt-in). For THIS PR it nonetheless stays behind the explicit `dense` config
-(fail-open, read-path-only, seam-firewalled: a `DenseScore` cannot become a
-govern `DeterministicScore`), and the plugin does NOT wire it — a conservative
-first landing. **Recommendation (tracked as a B4 follow-up):** the serving/plugin
-path SHOULD enable dense-by-default given the measured **+0.63 semantic Recall@10**,
-pending (a) a full-corpus rebuild that confirms these numbers over 17,295 docs
-and (b) an embedder resource/latency check for the interactive path (a query
-embed is ~0.4 s; the service is `MemoryMax`-bounded and loopback-only). Do not
-flip the default silently — flip it on that evidence.
+kept opt-in). The measured **+0.63 semantic Recall@10** now drives the Track B
+default-on change in the production serving/reindex entrypoints. The rollout
+gate still requires a fresh full-corpus receipt and an interactive latency
+measurement against the live brain; those receipts belong to the Track B bead
+and must be recorded before calling the rollout complete. The plugin remains
+downstream in Track C.

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,6 +18,7 @@
  *   TEAMKB_DB_PATH      — SQLite path (default ~/.teamkb/data/teamkb.db)
  *   TEAMKB_TENANT_ID    — tenant scope for qmd isolation (default intent-solutions)
  *   TEAMKB_EXPORT_DIR   — git-exporter output dir qmd indexes (default ~/.teamkb/kb-export)
+ *   TEAMKB_DENSE_ENABLED — dense retrieval is on by default; set false only for emergency rollback
  *   TEAMKB_REVOKED_FILE — durable revoke-by-actor list (default ~/.teamkb/revoked-actors.json)
  *   TEAMKB_ALLOWED_CHANNELS — comma-separated origin channels captures may claim
  *                         (H3; default: team-mcp,local-mcp)
@@ -31,7 +32,7 @@ import {
   ORIGIN_SECRET_UNAVAILABLE_WARNING,
   resolveTeamKbPath,
 } from '@qmd-team-intent-kb/common';
-import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import { getDefaultDenseConfig, QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { loadBrainignoreRuleset } from '@qmd-team-intent-kb/curator';
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
@@ -55,6 +56,7 @@ async function main(): Promise<void> {
   const adapter = new QmdAdapter({
     tenantId,
     exportDir,
+    dense: getDefaultDenseConfig(),
     stalenessProbe: () => indexStateRepo.stalenessSeconds(tenantId),
   });
 

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -10,7 +10,7 @@ import {
   IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
-import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import { getDefaultDenseConfig, QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { loadDaemonConfig } from './config.js';
 import { PinoDaemonLogger } from './pino-logger.js';
 import { dispatch } from './cli.js';
@@ -55,6 +55,7 @@ async function main(): Promise<void> {
     qmdAdapter: new QmdAdapter({
       tenantId: config.tenantId,
       exportDir: resolve(config.exportOutputDir),
+      dense: getDefaultDenseConfig(),
     }),
   };
 

--- a/apps/mcp-server/src/tools/search.ts
+++ b/apps/mcp-server/src/tools/search.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import type { SearchScope } from '@qmd-team-intent-kb/schema';
-import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
+import { getDefaultDenseConfig, QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import {
   extractMemoryIdFromCitation,
   isSearchVisibleSensitivity,
@@ -123,7 +123,7 @@ export async function searchTool(
 }
 
 function defaultAdapter(tenantId: string, exportDir: string): QmdQueryPort {
-  return new QmdAdapter({ tenantId, exportDir });
+  return new QmdAdapter({ tenantId, exportDir, dense: getDefaultDenseConfig() });
 }
 
 /** Local mode: run qmd in-process and map results to cited hits. */

--- a/packages/qmd-adapter/src/__tests__/config.test.ts
+++ b/packages/qmd-adapter/src/__tests__/config.test.ts
@@ -7,6 +7,8 @@ import {
   getQmdTenantIndexPath,
   getQmdCollectionIndexPath,
   getQmdTenantEnv,
+  DEFAULT_DENSE_URL,
+  getDefaultDenseConfig,
 } from '../config.js';
 
 describe('qmd-adapter config', () => {
@@ -54,5 +56,17 @@ describe('qmd-adapter config', () => {
       XDG_CONFIG_HOME: '/custom/qmd-index/t1/config',
       XDG_CACHE_HOME: '/custom/qmd-index/t1/cache',
     });
+  });
+
+  it('defaults production dense retrieval on at the pinned loopback endpoint', () => {
+    expect(getDefaultDenseConfig({})).toEqual({ enabled: true, url: DEFAULT_DENSE_URL });
+  });
+
+  it('supports the documented emergency dense kill switch', () => {
+    expect(getDefaultDenseConfig({ TEAMKB_DENSE_ENABLED: 'false' })).toEqual({
+      enabled: false,
+      url: DEFAULT_DENSE_URL,
+    });
+    expect(getDefaultDenseConfig({ TEAMKB_DENSE_ENABLED: '  OFF  ' }).enabled).toBe(false);
   });
 });

--- a/packages/qmd-adapter/src/cli.ts
+++ b/packages/qmd-adapter/src/cli.ts
@@ -123,9 +123,13 @@ export async function run(argv: string[], deps: CliDeps = {}): Promise<number> {
       errLog(`reindex FAILED (tenant=${tenantId}): ${result.error.code}: ${result.error.message}`);
       return 1;
     }
-    const { collectionsCreated, indexUpdated } = result.value;
+    const { collectionsCreated, indexUpdated, dense } = result.value;
+    const denseSummary =
+      dense === undefined
+        ? 'dense=disabled'
+        : `dense={embedded:${dense.embedded},removed:${dense.removed},skipped:${dense.skipped},totalDocs:${dense.totalDocs},serviceDown:${dense.serviceDown}}`;
     log(
-      `reindex OK (tenant=${tenantId}): collectionsCreated=[${collectionsCreated.join(', ')}], indexUpdated=${indexUpdated}`,
+      `reindex OK (tenant=${tenantId}): collectionsCreated=[${collectionsCreated.join(', ')}], indexUpdated=${indexUpdated}, ${denseSummary}`,
     );
     return 0;
   }

--- a/packages/qmd-adapter/src/cli.ts
+++ b/packages/qmd-adapter/src/cli.ts
@@ -16,6 +16,7 @@
  *   TEAMKB_TENANT_ID  (default: intent-solutions — the live brain's tenant)
  *   TEAMKB_BASE_PATH  (default: ~/.teamkb)         → exportDir = <base>/kb-export
  *   TEAMKB_EXPORT_DIR (overrides exportDir)
+ *   TEAMKB_DENSE_ENABLED (default: true; set false only for emergency rollback)
  *
  * Why (bead compile-then-govern-e06.13 / risk register R11 / umbrella #27):
  * `brain_search` degrades to an EMPTY result on a missing/misrouted index
@@ -23,7 +24,8 @@
  * exactly the "SEARCH DEGRADED, 0 hits on known-positive controls" incident.
  * `canary` turns that silent failure into a non-zero exit code so CI / the
  * nightly / an operator sees it; `reindex` is the repeatable, idempotent
- * rebuild of the derived index (never touches teamkb.db or brain/raw).
+ * rebuild of the derived lexical + dense indexes (never touches teamkb.db or
+ * brain/raw).
  */
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -33,6 +35,7 @@ import Database from 'better-sqlite3';
 import { getTeamKbBasePath } from '@qmd-team-intent-kb/common';
 import { IndexStateRepository } from '@qmd-team-intent-kb/store';
 import { QmdAdapter } from './adapter.js';
+import { getDefaultDenseConfig } from './config.js';
 import type { StalenessProbe } from './types.js';
 import { reindex } from './reindex/reindex.js';
 import { runSearchCanary, formatCanaryReport } from './canary/search-canary.js';
@@ -107,7 +110,8 @@ export async function run(argv: string[], deps: CliDeps = {}): Promise<number> {
   const errLog = deps.errLog ?? console.error;
   const makeAdapter =
     deps.makeAdapter ??
-    ((tenantId: string, exportDir: string) => new QmdAdapter({ tenantId, exportDir }));
+    ((tenantId: string, exportDir: string) =>
+      new QmdAdapter({ tenantId, exportDir, dense: getDefaultDenseConfig(env) }));
 
   const [command, ...rest] = argv;
   const { tenantId, exportDir } = resolveCliContext(env);

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -37,6 +37,44 @@ export function getQmdTenantEnv(tenantId: string): Record<string, string> {
   };
 }
 
+/** Loopback endpoint served by the pinned EmbeddingGemma user service. */
+export const DEFAULT_DENSE_URL = 'http://127.0.0.1:8098';
+
+/** Configuration for the sqlite-vec + EmbeddingGemma retrieval arm. */
+export interface DenseConfig {
+  enabled: boolean;
+  /** Embedding service base URL (loopback-only in the supported deployment). */
+  url: string;
+  /** Hard timeout for the query-embed call (default 5000 ms). */
+  timeoutMs?: number;
+  /** Override for the derived sqlite-vec sidecar index. */
+  indexPath?: string;
+  /** Dense KNN hits fed to the fusion, pre scope-filter (default 50). */
+  searchK?: number;
+  /** Truncate each doc to this many chars before embedding (default 2000). */
+  maxDocChars?: number;
+  /** Timeout for a document-batch embed call during indexing (default 120000 ms). */
+  indexTimeoutMs?: number;
+  /** Docs per embed request during indexing (default 16). */
+  batchSize?: number;
+}
+
+/**
+ * Resolve the production dense default.
+ *
+ * The library remains explicit-by-config so lexical-only fixtures and callers
+ * can opt out deliberately. Production entrypoints call this helper, which
+ * makes dense retrieval default-on while retaining one documented emergency
+ * kill switch for a broken local embedder.
+ */
+export function getDefaultDenseConfig(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): DenseConfig {
+  const rawEnabled = env['TEAMKB_DENSE_ENABLED']?.trim().toLowerCase();
+  const enabled = rawEnabled === undefined || !['0', 'false', 'off', 'no'].includes(rawEnabled);
+  return { enabled, url: DEFAULT_DENSE_URL };
+}
+
 /** Adapter configuration */
 export interface QmdAdapterConfig {
   tenantId: string;
@@ -95,34 +133,14 @@ export interface QmdAdapterConfig {
     cachePath?: string;
   };
   /**
-   * OPT-IN dense retrieval arm (blueprint bead B4; 038/044-AT-DECR:
-   * sqlite-vec + EmbeddingGemma-300M only). Explicit options only — no env
-   * magic. When omitted or `enabled: false`, the query path is byte-identical
-   * to the lexical-only deterministic fusion. When enabled, the arm FAILS
-   * OPEN: embedder down / index unbuilt / any failure serves the lexical
-   * fusion with no dense list.
+   * Dense retrieval arm (blueprint bead B4; 038/044-AT-DECR: sqlite-vec +
+   * EmbeddingGemma-300M only). The production entrypoints pass
+   * {@link getDefaultDenseConfig}; direct library callers remain lexical-only
+   * when this field is omitted. When enabled, the arm FAILS OPEN: embedder
+   * down / index unbuilt / any failure serves the lexical fusion with no dense
+   * list.
    */
-  dense?: {
-    enabled: boolean;
-    /** Embedding service base URL, e.g. `http://127.0.0.1:8098` (loopback only). */
-    url: string;
-    /** Hard timeout for the query-embed call (default 5000 ms). */
-    timeoutMs?: number;
-    /**
-     * Override for the sqlite-vec sidecar index (tests use `:memory:`).
-     * Defaults to `<qmd-index>/<tenantId>/dense-vec.sqlite` — derived,
-     * rebuildable, deletable data next to the other derived indexes.
-     */
-    indexPath?: string;
-    /** Dense KNN hits fed to the fusion, pre scope-filter (default 50). */
-    searchK?: number;
-    /** Truncate each doc to this many chars before embedding (default 1200). */
-    maxDocChars?: number;
-    /** Timeout for a document-batch embed call during indexing (default 120000 ms). */
-    indexTimeoutMs?: number;
-    /** Docs per embed request during indexing (default 16). */
-    batchSize?: number;
-  };
+  dense?: DenseConfig;
 }
 
 /** Default configuration values */

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -8,13 +8,15 @@ export type {
 } from './types.js';
 
 // Config
-export type { QmdAdapterConfig } from './config.js';
+export type { DenseConfig, QmdAdapterConfig } from './config.js';
 export {
   QMD_INDEX_DIR,
+  DEFAULT_DENSE_URL,
   getQmdIndexBasePath,
   getQmdTenantIndexPath,
   getQmdCollectionIndexPath,
   getQmdTenantEnv,
+  getDefaultDenseConfig,
   DEFAULT_QMD_BINARY,
   DEFAULT_TIMEOUT,
 } from './config.js';
@@ -116,7 +118,8 @@ export type {
   RerankStageOptions,
 } from './rerank/index.js';
 
-// Dense — opt-in sqlite-vec + EmbeddingGemma retrieval arm, fail-open (B4, 038/044-AT-DECR)
+// Dense — production-default sqlite-vec + EmbeddingGemma retrieval arm,
+// fail-open (B4, 038/044-AT-DECR)
 export {
   EmbedClient,
   denseScore,


### PR DESCRIPTION
Canonical bead: `bd_000-projects-gybo.3`  
Closes implementation slice for #326 (full-corpus and live-latency receipts remain rollout acceptance evidence).

## What changed

- Adds a shared `getDefaultDenseConfig()` seam with the pinned loopback EmbeddingGemma endpoint.
- Wires dense retrieval into the production API, edge daemon, local MCP path, and qmd reindex/canary CLI.
- Keeps direct library callers and lexical fixtures explicit-by-config.
- Adds the documented `TEAMKB_DENSE_ENABLED=false` emergency kill switch.
- Updates the B4 runbook to distinguish production default-on from library fixtures and preserves fail-open semantics.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 203 files / 2,444 tests passed

Next rollout evidence is being gathered against the live service: full-corpus dense sidecar receipt, live paraphrase recall, and interactive latency.