### PR TITLE
docs(gpg9): record reference import flood decision

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -56,6 +56,7 @@
 - `046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md` — Substrate-boundary doctrine: the ICO trace chain proves COMPILE, the INTKB audit chain proves GOVERN admission; neither proves the other's claims (nor content truth); the spool manifest SHA-256 + UUID-v5 id lineage are the bridge; walked end-to-end by `curator-cli provenance-walk`
 - `047-OD-RNBK-merge-govern-and-anchor-receipts-runbook.md` — merge-govern operator runbook (Wave-2 E3/F3/F4): when/how to run the govern-at-merge CLI, what it does NOT do, signed merge-anchor key custody + rotation (SOPS-encrypted private / committed public), and the opt-in OpenTimestamps receipt for anchor heads with its honest network/trust limits
 - `049-AT-DECR-write-time-provenance-origin-tokens.md` — Write-time provenance (GSB Wave-2 H1–H5): HMAC-SHA256 origin tokens over (id, tenantId, capturedAt) keyed by the 0600 `~/.teamkb/origin-secret`, verified structurally before promotion (`origin_token_invalid` receipted reject), accept-with-`unattested` backward compatibility, team-API channel allowlist (`unrecognized_channel` 422), local-mode channel attestation out of scope v1, honest insider-poisoning residual
+- `052-AT-DECR-reference-import-flood-2026-08-02.md` — Reference-import flood investigation: 2026-07-16 producer replay, bounded/receipted broad-import admission, and reversible legacy-corpus review
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
 - `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)
@@ -126,5 +127,6 @@
 | 049 | AT-DECR | write-time-provenance-origin-tokens                   | Origin-token decision record     |
 | 050 | AT-RNBK | reranker-service-runbook                              | bbb-reranker service runbook     |
 | 051 | AT-RNBK | embedder-service-and-dense-index-runbook              | bbb-embedder + dense index (B4)  |
+| 052 | AT-DECR | reference-import-flood-2026-08-02                     | Reference-import flood decision  |
 
-## Next Available Sequence: 052
+## Next Available Sequence: 053

--- a/000-docs/052-AT-DECR-reference-import-flood-2026-08-02.md
+++ b/000-docs/052-AT-DECR-reference-import-flood-2026-08-02.md
@@ -1,0 +1,78 @@
+# Decision Record — Reference-import flood and bounded admission
+
+**Date:** 2026-08-02
+
+**Status:** Ratified investigation; implementation follows in the linked beads
+
+**Primary bead:** `bd_000-projects-gpg9`
+
+**GitHub:** Registrar #329, #330, #331
+
+**Plane:** LAB-145, LAB-146, LAB-147
+
+## Decision
+
+The 13x growth in the `reference` category was a one-time producer-side
+whole-machine replay on 2026-07-16, not evidence that the normal daily compile
+loop is continuously re-capturing the whole brain. The corrective boundary is
+therefore split:
+
+1. ICO owns incremental spool emission and a per-run ceiling (`intentional-
+cognition-os-l13.3`, compiler PR #190).
+2. Registrar owns the admission contract for broad or bulk imports: explicit
+   batch identity, declared scope and count, trust classification, a durable
+   receipt, and fail-closed promotion when that receipt is absent or invalid
+   (`bd_000-projects-gpg9.1`).
+3. The historical 2026-07-16 corpus gets a reversible inventory and disposition
+   proposal. It is not bulk-deleted or mutated as part of this investigation
+   (`bd_000-projects-gpg9.2`).
+
+## Evidence
+
+The live `~/.teamkb/teamkb.db` was inspected read-only. The candidate table
+shows the 2026-07-16 cohort as:
+
+| Source | Status    | Category  |  Count |
+| ------ | --------- | --------- | -----: |
+| import | promoted  | reference | 14,956 |
+| import | inbox     | reference |    105 |
+| import | duplicate | reference |     44 |
+
+The contemporaneous governance sweep receipt reported `14,958 promoted`, `44
+duplicate`, `0 quarantined`, `0 flagged`, and `106 rejected` from `15,108`
+processed candidates. The small difference between the receipt total and the
+current candidate projection is retained as a reconciliation detail, not
+silently rounded away.
+
+The promoted import rows have 17,010 distinct content hashes across the
+imported corpus, so this was not an exact-row duplication event. However, the
+source paths and timing identify a broad source backfill rather than ordinary
+incremental capture. The compiler commit `589bcc4` (2026-07-17) records the
+producer-side finding: an explicit whole-machine `--bulk` run had emitted about
+17,000 candidates and 51.7 MB.
+
+The registrar spool path does not attach `import_batch_id` values to spool
+intake, while the vault-import path does create batch IDs. That asymmetry is
+why the next control belongs at the broad-import admission boundary instead of
+being inferred later from category counts.
+
+## What this does not claim
+
+- The evidence does not prove that every promoted reference row is low value.
+- It does not justify deleting, demoting, or quarantining the legacy corpus
+  without a reversible inventory and approval.
+- It does not make the qmd dense index a source of truth; retrieval indexes are
+  derived and must be rebuilt only after source and governance state settle.
+- It does not replace the compiler-side watermark. The producer and registrar
+  controls cover different failure boundaries.
+
+## Acceptance boundary
+
+Future broad imports must carry enough durable context for an operator to answer
+"what was emitted, from which scope, under which trust mode, and why was this
+volume allowed?" before promotion. A normal single-source capture must continue
+to work without pretending it is a bulk batch. Any rejected or incomplete batch
+must leave an auditable receipt and a documented recovery path.
+
+The legacy cohort remains an evidence set until `bd_000-projects-gpg9.2`
+produces its reversible inventory and an explicit disposition is approved.


### PR DESCRIPTION
## Summary

- document the verified 2026-07-16 source-import flood and its evidence
- separate compiler-side incremental emission from registrar-side broad-import admission
- add the reversible legacy-corpus review boundary and link both child beads
- index decision record 052

## Tracking

- parent bead: bd_000-projects-gpg9
- admission follow-up: bd_000-projects-gpg9.1 / Registrar #330 / Plane LAB-146
- legacy review follow-up: bd_000-projects-gpg9.2 / Registrar #331 / Plane LAB-147
- root: Registrar #329 / Plane LAB-145

## Verification

- read-only SQLite evidence rechecked against the live teamkb database
- `git diff --check`
- Prettier check on the changed docs
- rebased onto `origin/main` at `bda4588`