### PR TITLE
feat(intake): require receipted broad spool admission

### DIFF
--- a/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md
+++ b/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md
@@ -1,7 +1,7 @@
 # 042-OD-OPSM — Bob's Big Brain + Tobi qmd operator runbook
 
-**Status:** Active  
-**Date:** 2026-07-14  
+**Status:** Active
+**Date:** 2026-08-02
 **Audience:** operators / agents on a box with `~/.teamkb`
 
 ## Product shape
@@ -58,3 +58,35 @@ If search returns empty: run `pnpm search-canary -- --heal`, confirm `bbb-qmd st
 ## Onboarding eval
 
 See `000-docs/043-OD-EVAL-onboarding-qbank-v1.md` for the outsider question bank and baseline.
+
+## Broad and bulk spool admission
+
+Spool files carrying more than 100 candidates, or any candidate stamped
+`source: bulk_import`, are broad-import material. Registrar refuses them before
+insertion unless the manifest has a verified `batchReceipt` with:
+
+- `batchId`, `tenantId`, and discovery `scope` (`wiki`, `outputs`, or `all`)
+- the expected `candidateCount` and a producer-declared `maxCandidates` ceiling
+- the expected `source` and `trustLevel` for every JSONL line
+- a `candidateIds` list matching the JSONL exactly
+
+The accepted batch ID is persisted in `candidates.import_batch_id` and in the
+`import_batches` ledger. The CLI exits non-zero and reports
+`BATCH_ADMISSION_REJECTED`; the edge daemon records the refusal in its cycle
+errors. The rejected spool file is left in place for remediation. Do not delete
+it as a cleanup step.
+
+Recovery:
+
+1. Inspect the sidecar without editing the source file:
+   `jq '.batchReceipt, (.candidateIds | length)' spool-*.jsonl.manifest.json`.
+2. Compare the receipt count, ceiling, tenant, source, and trust stamp to the
+   JSONL producer output. A changed JSONL file also fails the SHA-256 manifest
+   check and is quarantined separately.
+3. Regenerate the spool file from the producer with an explicit batch receipt,
+   or preserve the rejected file for the legacy-corpus review in
+   `bd_000-projects-gpg9.2`. Re-run `curator-cli ingest` only after the receipt
+   and manifest are valid.
+
+The decision record and evidence split are in
+`000-docs/052-AT-DECR-reference-import-flood-2026-08-02.md`.

--- a/apps/curator/src/__tests__/cli.test.ts
+++ b/apps/curator/src/__tests__/cli.test.ts
@@ -267,6 +267,20 @@ describe('dispatch ingest — hand-crafted spool file', () => {
     const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
     expect(parsed['ingested_count']).toBe(1);
   });
+
+  it('returns BATCH_ADMISSION_REJECTED for bulk input without a receipt', async () => {
+    await writeSpoolFile('spool-2026-08-02T170000Z.jsonl', [
+      makeSpoolLine({ source: 'bulk_import', trustLevel: 'untrusted' }),
+    ]);
+
+    const rc = await dispatch(['ingest', spoolDir, '--tenant', 'demo-e2e', '--json'], testDeps);
+    expect(rc).toBe(1);
+    const parsed = JSON.parse(stdoutText().trim()) as Record<string, unknown>;
+    expect(parsed['ok']).toBe(false);
+    expect(parsed['code']).toBe('BATCH_ADMISSION_REJECTED');
+    expect(parsed['admission_rejected_count']).toBe(1);
+    expect(parsed['ingested_count']).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/curator/src/__tests__/spool-admission.test.ts
+++ b/apps/curator/src/__tests__/spool-admission.test.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  CandidateRepository,
+  createTestDatabase,
+  ImportBatchRepository,
+} from '@qmd-team-intent-kb/store';
+
+import { ingestFromSpoolDetailed } from '../intake/spool-intake.js';
+import { makeCandidate } from './fixtures.js';
+
+function jsonl(candidates: ReturnType<typeof makeCandidate>[]): string {
+  return candidates.map((candidate) => JSON.stringify(candidate)).join('\n');
+}
+
+async function writeBulkSpool(
+  spoolDir: string,
+  candidates: ReturnType<typeof makeCandidate>[],
+  receiptOverrides: Record<string, unknown> = {},
+): Promise<void> {
+  const spoolPath = join(spoolDir, 'spool-2026-08-02T170000Z.jsonl');
+  const body = jsonl(candidates);
+  await writeFile(spoolPath, body, 'utf8');
+  await writeFile(
+    `${spoolPath}.manifest.json`,
+    JSON.stringify(
+      {
+        schemaVersion: '1',
+        emittedCount: candidates.length,
+        spoolFile: 'spool-2026-08-02T170000Z.jsonl',
+        spoolFileBytes: Buffer.byteLength(body, 'utf8'),
+        spoolFileSha256: createHash('sha256').update(body, 'utf8').digest('hex'),
+        candidateIds: candidates.map((candidate) => candidate.id),
+        batchReceipt: { ...defaultReceipt(candidates), ...receiptOverrides },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+}
+
+function defaultReceipt(candidates: ReturnType<typeof makeCandidate>[]): Record<string, unknown> {
+  const first = candidates[0]!;
+  return {
+    batchId: 'bulk-batch-2026-08-02',
+    tenantId: first.tenantId,
+    scope: 'all',
+    source: first.source,
+    trustLevel: first.trustLevel,
+    candidateCount: candidates.length,
+    maxCandidates: 5000,
+  };
+}
+
+describe('spool broad/bulk admission', () => {
+  let spoolDir: string;
+  let db: ReturnType<typeof createTestDatabase>;
+  let candidateRepo: CandidateRepository;
+  let batchRepo: ImportBatchRepository;
+
+  beforeEach(async () => {
+    spoolDir = await mkdtemp(join(tmpdir(), 'spool-admission-test-'));
+    db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+    batchRepo = new ImportBatchRepository(db);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await rm(spoolDir, { recursive: true, force: true });
+  });
+
+  it('refuses bulk candidates without a batch receipt before insertion', async () => {
+    const candidate = makeCandidate({
+      source: 'bulk_import',
+      trustLevel: 'untrusted',
+      tenantId: 'tenant-bulk',
+    });
+    const path = join(spoolDir, 'spool-2026-08-02T170000Z.jsonl');
+    const body = jsonl([candidate]);
+    await writeFile(path, body, 'utf8');
+    await writeFile(
+      `${path}.manifest.json`,
+      JSON.stringify({
+        schemaVersion: '1',
+        emittedCount: 1,
+        spoolFileSha256: createHash('sha256').update(body, 'utf8').digest('hex'),
+        candidateIds: [candidate.id],
+      }),
+      'utf8',
+    );
+
+    const result = await ingestFromSpoolDetailed(candidateRepo, spoolDir, {
+      importBatchRepo: batchRepo,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ingested).toHaveLength(0);
+    expect(result.value.admissionRejected).toHaveLength(1);
+    expect(candidateRepo.count()).toBe(0);
+  });
+
+  it('persists a verified batch ID on bulk candidates and completes the batch receipt', async () => {
+    const candidates = [
+      makeCandidate({ source: 'bulk_import', trustLevel: 'untrusted', tenantId: 'tenant-bulk' }),
+      makeCandidate({ source: 'bulk_import', trustLevel: 'untrusted', tenantId: 'tenant-bulk' }),
+    ];
+    await writeBulkSpool(spoolDir, candidates, {});
+
+    const result = await ingestFromSpoolDetailed(candidateRepo, spoolDir, {
+      importBatchRepo: batchRepo,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ingested).toHaveLength(2);
+    expect(result.value.admissionRejected).toHaveLength(0);
+    expect(batchRepo.findById('bulk-batch-2026-08-02')).toMatchObject({
+      status: 'completed',
+      createdCount: 2,
+      rejectedCount: 0,
+      skippedCount: 0,
+    });
+    const rows = db
+      .prepare<[], { import_batch_id: string }>('SELECT import_batch_id FROM candidates')
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.import_batch_id === 'bulk-batch-2026-08-02')).toBe(true);
+  });
+
+  it('refuses a receipt whose declared count exceeds its ceiling', async () => {
+    const candidates = [
+      makeCandidate({ source: 'bulk_import', trustLevel: 'low', tenantId: 'tenant-bulk' }),
+      makeCandidate({ source: 'bulk_import', trustLevel: 'low', tenantId: 'tenant-bulk' }),
+    ];
+    await writeBulkSpool(spoolDir, candidates, { maxCandidates: 1 });
+
+    const result = await ingestFromSpoolDetailed(candidateRepo, spoolDir, {
+      importBatchRepo: batchRepo,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ingested).toHaveLength(0);
+    expect(result.value.admissionRejected[0]?.reason).toContain('exceeds maxCandidates');
+    expect(candidateRepo.count()).toBe(0);
+  });
+
+  it('requires a receipt for a broad import source even when it is not bulk-stamped', async () => {
+    const candidates = Array.from({ length: 101 }, (_, index) =>
+      makeCandidate({
+        source: 'import',
+        tenantId: 'tenant-import',
+        title: `Broad import candidate ${index}`,
+      }),
+    );
+    const path = join(spoolDir, 'spool-2026-08-02T170000Z.jsonl');
+    await writeFile(path, jsonl(candidates), 'utf8');
+
+    const result = await ingestFromSpoolDetailed(candidateRepo, spoolDir, {
+      importBatchRepo: batchRepo,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ingested).toHaveLength(0);
+    expect(result.value.admissionRejected[0]?.reason).toContain('missing batchReceipt');
+    expect(candidateRepo.count()).toBe(0);
+  });
+});

--- a/apps/curator/src/cli.ts
+++ b/apps/curator/src/cli.ts
@@ -48,6 +48,7 @@ import {
   PolicyRepository,
   AuditRepository,
   MemoryLinksRepository,
+  ImportBatchRepository,
   verifyAuditChain,
   computeManifestHash,
   appendSignedMergeAnchor,
@@ -365,11 +366,14 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     const policyRepo = new PolicyRepository(db);
     const auditRepo = new AuditRepository(db);
     const linksRepo = new MemoryLinksRepository(db);
+    const importBatchRepo = new ImportBatchRepository(db);
 
     // Stage A: ingestFromSpoolDetailed — reads JSONL, verifies each file's
     // manifest SHA-256 (tampered files refused + quarantined per dmj.4),
     // validates, writes surviving candidates to the store.
-    const ingestResult = await ingestFromSpoolDetailed(candidateRepo, spoolDir);
+    const ingestResult = await ingestFromSpoolDetailed(candidateRepo, spoolDir, {
+      importBatchRepo,
+    });
     if (!ingestResult.ok) {
       // ingestFromSpoolDetailed returns Result<_, string> — message IS the error.
       const msg = ingestResult.error;
@@ -387,6 +391,8 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     // Candidates refused at the disclosure / secret choke point (Epic 0).
     // Reported, never silently dropped — carries only id + category.
     const disclosureRejected = ingestResult.value.rejected;
+    const admissionRejected = ingestResult.value.admissionRejected;
+    const admissionOk = admissionRejected.length === 0;
 
     // Stage B: Curator.processBatch — dedup + policy + promote.
     // Write-time provenance (H1): resolve the installation origin secret so
@@ -420,12 +426,15 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
     if (json) {
       process.stdout.write(
         JSON.stringify({
-          ok: true,
+          ok: admissionOk,
+          ...(admissionOk ? {} : { code: 'BATCH_ADMISSION_REJECTED' }),
           spool_dir: spoolDir,
           tenant_id: tenantId,
           ingested_count: candidates.length,
           tampered_count: tampered.length,
           tampered,
+          admission_rejected_count: admissionRejected.length,
+          admission_rejected: admissionRejected,
           disclosure_rejected_count: disclosureRejected.length,
           disclosure_rejected: disclosureRejected,
           batch,
@@ -460,8 +469,18 @@ async function cmdIngest(args: string[], deps: CuratorCliDeps): Promise<number> 
           process.stderr.write(`  ${r.candidateId} (${r.category})\n`);
         }
       }
+      if (admissionRejected.length > 0) {
+        process.stderr.write(
+          `\nBATCH_ADMISSION_REJECTED: ${admissionRejected.length} spool file(s) refused before insertion:\n`,
+        );
+        for (const rejection of admissionRejected) {
+          process.stderr.write(
+            `  ${rejection.spoolFile}${rejection.batchId === undefined ? '' : ` (batch ${rejection.batchId})`}: ${rejection.reason}\n`,
+          );
+        }
+      }
     }
-    return 0;
+    return admissionOk ? 0 : 1;
   } finally {
     // better-sqlite3 Databases hold an OS file descriptor — close to avoid
     // leaks when --db points at a real file (in-memory dbs don't care).

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -7,6 +7,7 @@ export type {
   IngestResult,
   SpoolTamperRecord,
   SpoolDisclosureRejection,
+  SpoolAdmissionRejection,
 } from './intake/spool-intake.js';
 export { checkDuplicate } from './dedup/dedup-checker.js';
 export type { DedupResult } from './dedup/dedup-checker.js';

--- a/apps/curator/src/intake/spool-intake.ts
+++ b/apps/curator/src/intake/spool-intake.ts
@@ -5,11 +5,16 @@ import {
   listSpoolFiles,
   readSpoolFile,
   verifySpoolManifest,
+  type SpoolBatchReceipt,
+  type SpoolManifestResult,
 } from '@qmd-team-intent-kb/claude-runtime';
 import { computeContentHash, DisclosureRejectedError } from '@qmd-team-intent-kb/common';
 import type { Result } from '@qmd-team-intent-kb/common';
-import type { CandidateRepository } from '@qmd-team-intent-kb/store';
+import type { CandidateRepository, ImportBatchRepository } from '@qmd-team-intent-kb/store';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/** A file above this size is broad-import material even if it uses `import`. */
+export const DEFAULT_BROAD_IMPORT_CANDIDATE_LIMIT = 100;
 
 /** Options for `ingestFromSpool`. All optional — defaults preserve the
  *  pre-`dmj.4` behavior except that manifest verification is now ON. */
@@ -44,6 +49,12 @@ export interface IngestFromSpoolOptions {
    * `<spool>/ingested`.
    */
   archiveIngestedDir?: string;
+  /**
+   * Durable batch ledger used for broad/bulk spool admission. Production CLI
+   * and daemon wiring supplies this; ordinary single-source spool files remain
+   * backward-compatible without it.
+   */
+  importBatchRepo?: ImportBatchRepository;
 }
 
 /** Record of a spool file refused during ingest because it failed manifest
@@ -62,6 +73,13 @@ export interface SpoolDisclosureRejection {
   category: string;
 }
 
+/** A broad/bulk file refused before any candidate is inserted. */
+export interface SpoolAdmissionRejection {
+  spoolFile: string;
+  reason: string;
+  batchId?: string;
+}
+
 /** Result payload from `ingestFromSpoolDetailed`. */
 export interface IngestResult {
   ingested: MemoryCandidate[];
@@ -73,6 +91,64 @@ export interface IngestResult {
    * fail-closed on the bad candidate, not a denial-of-service on the whole spool.
    */
   rejected: SpoolDisclosureRejection[];
+  /** Broad/bulk files refused before insertion because their receipt was absent or invalid. */
+  admissionRejected: SpoolAdmissionRejection[];
+}
+
+function requiresBatchReceipt(
+  candidates: MemoryCandidate[],
+  broadLimit = DEFAULT_BROAD_IMPORT_CANDIDATE_LIMIT,
+  manifest?: SpoolManifestResult,
+): boolean {
+  return (
+    manifest?.batchReceipt !== undefined ||
+    candidates.some((candidate) => candidate.source === 'bulk_import') ||
+    candidates.length > broadLimit
+  );
+}
+
+function validateBatchReceipt(
+  receipt: SpoolBatchReceipt | undefined,
+  manifest: SpoolManifestResult | undefined,
+  candidates: MemoryCandidate[],
+): string | null {
+  if (receipt === undefined) return 'missing batchReceipt in the spool manifest';
+  if (manifest?.status !== 'verified') {
+    return 'batchReceipt requires a manifest whose spool-file hash verifies';
+  }
+  if (receipt.candidateCount !== candidates.length) {
+    return `batchReceipt candidateCount=${receipt.candidateCount} does not match parsed candidate count=${candidates.length}`;
+  }
+  if (receipt.candidateCount > receipt.maxCandidates) {
+    return `batchReceipt candidateCount=${receipt.candidateCount} exceeds maxCandidates=${receipt.maxCandidates}`;
+  }
+  const candidateIds = manifest.candidateIds;
+  if (candidateIds === undefined || candidateIds.length !== candidates.length) {
+    return 'batchReceipt requires manifest candidateIds for every parsed candidate';
+  }
+  const expectedIds = new Set(candidateIds);
+  if (expectedIds.size !== candidates.length || candidates.some((c) => !expectedIds.has(c.id))) {
+    return 'manifest candidateIds do not match the parsed candidate IDs';
+  }
+  for (const candidate of candidates) {
+    if (candidate.tenantId !== receipt.tenantId) {
+      return `candidate ${candidate.id} tenantId does not match batchReceipt tenantId`;
+    }
+    if (candidate.source !== receipt.source) {
+      return `candidate ${candidate.id} source does not match batchReceipt source`;
+    }
+    if (candidate.trustLevel !== receipt.trustLevel) {
+      return `candidate ${candidate.id} trustLevel does not match batchReceipt trustLevel`;
+    }
+  }
+  if (
+    receipt.source === 'bulk_import' &&
+    receipt.trustLevel !== 'low' &&
+    receipt.trustLevel !== 'untrusted'
+  ) {
+    return "bulk_import batchReceipt must use trustLevel 'low' or 'untrusted'";
+  }
+  return null;
 }
 
 /**
@@ -122,13 +198,20 @@ export async function ingestFromSpoolDetailed(
   const ingested: MemoryCandidate[] = [];
   const tampered: SpoolTamperRecord[] = [];
   const rejected: SpoolDisclosureRejection[] = [];
+  const admissionRejected: SpoolAdmissionRejection[] = [];
+  const importBatchRepo = opts?.importBatchRepo;
 
   for (const filepath of filesResult.value) {
+    let manifest: SpoolManifestResult | undefined;
     if (verifyManifest) {
       const verify = await verifySpoolManifest(filepath);
       // A verification *error* (malformed manifest JSON, unreadable file)
       // is treated like an unreadable spool file: skip, keep processing.
-      if (!verify.ok) continue;
+      if (!verify.ok) {
+        admissionRejected.push({ spoolFile: filepath, reason: verify.error });
+        continue;
+      }
+      manifest = verify.value;
       if (verify.value.status === 'tampered') {
         const quarantinedTo = await quarantineTamperedFile(
           filepath,
@@ -151,9 +234,88 @@ export async function ingestFromSpoolDetailed(
     const readResult = await readSpoolFile(filepath);
     if (!readResult.ok) continue; // skip unreadable files, keep processing others
 
-    for (const candidate of readResult.value) {
+    const candidates = readResult.value;
+    if (requiresBatchReceipt(candidates, DEFAULT_BROAD_IMPORT_CANDIDATE_LIMIT, manifest)) {
+      // A caller may disable ordinary manifest verification for legacy files,
+      // but broad/bulk admission always performs it. This prevents the escape
+      // hatch from becoming a way around the batch receipt contract.
+      if (manifest === undefined) {
+        const verify = await verifySpoolManifest(filepath);
+        if (!verify.ok) {
+          admissionRejected.push({ spoolFile: filepath, reason: verify.error });
+          continue;
+        }
+        manifest = verify.value;
+      }
+      const receiptError = validateBatchReceipt(manifest.batchReceipt, manifest, candidates);
+      if (receiptError !== null) {
+        admissionRejected.push({
+          spoolFile: filepath,
+          reason: receiptError,
+          batchId: manifest.batchReceipt?.batchId,
+        });
+        continue;
+      }
+      if (importBatchRepo === undefined) {
+        admissionRejected.push({
+          spoolFile: filepath,
+          reason: 'durable import batch repository is required for broad/bulk admission',
+          batchId: manifest.batchReceipt?.batchId,
+        });
+        continue;
+      }
+    }
+
+    const receipt = manifest?.batchReceipt;
+    let batchCreated = 0;
+    let batchRejected = 0;
+    let batchSkipped = 0;
+    let batchWasExisting = false;
+
+    if (receipt !== undefined) {
+      if (importBatchRepo === undefined) {
+        // This is unreachable for a validated broad/bulk file, but keeps the
+        // receipt path fail-closed if the admission rules change later.
+        admissionRejected.push({
+          spoolFile: filepath,
+          reason: 'durable import batch repository is required for batch receipts',
+          batchId: receipt.batchId,
+        });
+        continue;
+      }
+      const existingBatch = importBatchRepo.findById(receipt.batchId);
+      batchWasExisting = existingBatch !== null;
+      if (!batchWasExisting) {
+        try {
+          importBatchRepo.insert({
+            id: receipt.batchId,
+            tenantId: receipt.tenantId,
+            sourcePath: filepath,
+            fileCount: 1,
+            createdCount: 0,
+            rejectedCount: 0,
+            skippedCount: 0,
+            status: 'active',
+            createdAt: new Date().toISOString(),
+            rolledBackAt: null,
+          });
+        } catch (e) {
+          admissionRejected.push({
+            spoolFile: filepath,
+            reason: `failed to persist batch receipt: ${e instanceof Error ? e.message : String(e)}`,
+            batchId: receipt.batchId,
+          });
+          continue;
+        }
+      }
+    }
+
+    for (const candidate of candidates) {
       const existing = candidateRepo.findById(candidate.id);
-      if (existing !== null) continue;
+      if (existing !== null) {
+        batchSkipped++;
+        continue;
+      }
 
       const hash = computeContentHash(candidate.content);
       try {
@@ -161,16 +323,28 @@ export async function ingestFromSpoolDetailed(
         // content before it can be written. Refuse this one candidate and keep
         // processing the rest of the batch — a poisoned spool entry must not be
         // able to block every other candidate's ingest.
-        candidateRepo.insert(candidate, hash);
+        candidateRepo.insert(candidate, hash, receipt?.batchId);
         ingested.push(candidate);
+        batchCreated++;
       } catch (e) {
         if (e instanceof DisclosureRejectedError) {
           // Record only the id + category — never the matched value.
           rejected.push({ candidateId: candidate.id, category: e.category });
+          batchRejected++;
           continue;
         }
         throw e;
       }
+    }
+
+    if (receipt !== undefined && !batchWasExisting && importBatchRepo !== undefined) {
+      importBatchRepo.updateCounts(receipt.batchId, {
+        fileCount: 1,
+        createdCount: batchCreated,
+        rejectedCount: batchRejected,
+        skippedCount: batchSkipped,
+      });
+      importBatchRepo.complete(receipt.batchId);
     }
 
     // Idempotency (B1): once a file's candidates are read + ingested, move it out
@@ -182,7 +356,7 @@ export async function ingestFromSpoolDetailed(
     }
   }
 
-  return { ok: true, value: { ingested, tampered, rejected } };
+  return { ok: true, value: { ingested, tampered, rejected, admissionRejected } };
 }
 
 /**

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -1,7 +1,11 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { ingestFromSpool, Curator, loadBrainignoreRuleset } from '@qmd-team-intent-kb/curator';
+import {
+  ingestFromSpoolDetailed,
+  Curator,
+  loadBrainignoreRuleset,
+} from '@qmd-team-intent-kb/curator';
 import {
   loadOrCreateOriginSecret,
   ORIGIN_SECRET_UNAVAILABLE_WARNING,
@@ -111,17 +115,25 @@ async function ingestStep(
   result: CycleResult,
 ): Promise<MemoryCandidate[]> {
   try {
-    const ingestResult = await ingestFromSpool(deps.candidateRepo, config.spoolDir);
+    const ingestResult = await ingestFromSpoolDetailed(deps.candidateRepo, config.spoolDir, {
+      ...(deps.importBatchRepo !== undefined ? { importBatchRepo: deps.importBatchRepo } : {}),
+    });
     if (!ingestResult.ok) {
       result.ingest.errors.push(ingestResult.error);
       logger.error(`Ingest failed: ${ingestResult.error}`);
       return [];
     }
 
+    for (const rejection of ingestResult.value.admissionRejected) {
+      const msg = `Broad/bulk spool admission refused for ${rejection.spoolFile}: ${rejection.reason}`;
+      result.ingest.errors.push(msg);
+      logger.error(msg);
+    }
+
     // Threat #2: Cap candidates per cycle
-    const capped = ingestResult.value.slice(0, config.maxCandidatesPerCycle);
-    if (ingestResult.value.length > config.maxCandidatesPerCycle) {
-      const msg = `Capped ingestion: ${ingestResult.value.length} found, processing ${config.maxCandidatesPerCycle}`;
+    const capped = ingestResult.value.ingested.slice(0, config.maxCandidatesPerCycle);
+    if (ingestResult.value.ingested.length > config.maxCandidatesPerCycle) {
+      const msg = `Capped ingestion: ${ingestResult.value.ingested.length} found, processing ${config.maxCandidatesPerCycle}`;
       result.ingest.errors.push(msg);
       logger.warn(msg);
     }

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -6,6 +6,7 @@ import {
   MemoryRepository,
   PolicyRepository,
   AuditRepository,
+  ImportBatchRepository,
   ExportStateRepository,
   IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
@@ -41,6 +42,7 @@ async function main(): Promise<void> {
 
   const daemonDeps = {
     candidateRepo: new CandidateRepository(db),
+    importBatchRepo: new ImportBatchRepository(db),
     memoryRepo: new MemoryRepository(db),
     policyRepo: new PolicyRepository(db),
     auditRepo: new AuditRepository(db),

--- a/apps/edge-daemon/src/types.ts
+++ b/apps/edge-daemon/src/types.ts
@@ -5,6 +5,7 @@ import type {
   MemoryRepository,
   PolicyRepository,
   AuditRepository,
+  ImportBatchRepository,
   ExportStateRepository,
   IndexStateRepository,
 } from '@qmd-team-intent-kb/store';
@@ -59,6 +60,8 @@ export interface DaemonConfig {
 /** Repository dependencies injected into the daemon */
 export interface DaemonDependencies {
   candidateRepo: CandidateRepository;
+  /** Durable ledger for broad/bulk spool admission receipts. */
+  importBatchRepo?: ImportBatchRepository;
   memoryRepo: MemoryRepository;
   policyRepo: PolicyRepository;
   auditRepo: AuditRepository;

--- a/packages/claude-runtime/src/__tests__/spool-reader.test.ts
+++ b/packages/claude-runtime/src/__tests__/spool-reader.test.ts
@@ -160,6 +160,58 @@ describe('spool-reader', () => {
       }
     });
 
+    it('parses a verified batch receipt and candidate ID pin', async () => {
+      const spool = join(tmpDir, 'spool-bulk.jsonl');
+      const body = '{"id":"candidate-1","content":"hello"}\n';
+      await writeFile(spool, body, 'utf8');
+      await writeFile(
+        `${spool}.manifest.json`,
+        JSON.stringify({
+          spoolFileSha256: sha256(body),
+          candidateIds: ['candidate-1'],
+          batchReceipt: {
+            batchId: 'batch-1',
+            tenantId: 'tenant-1',
+            scope: 'all',
+            source: 'bulk_import',
+            trustLevel: 'untrusted',
+            candidateCount: 1,
+            maxCandidates: 5000,
+          },
+        }),
+        'utf8',
+      );
+
+      const result = await verifySpoolManifest(spool);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.batchReceipt).toMatchObject({
+          batchId: 'batch-1',
+          source: 'bulk_import',
+          candidateCount: 1,
+        });
+        expect(result.value.candidateIds).toEqual(['candidate-1']);
+      }
+    });
+
+    it('rejects a malformed batch receipt before reading candidate content', async () => {
+      const spool = join(tmpDir, 'spool-invalid-receipt.jsonl');
+      const body = '{"id":"candidate-1","content":"hello"}\n';
+      await writeFile(spool, body, 'utf8');
+      await writeFile(
+        `${spool}.manifest.json`,
+        JSON.stringify({
+          spoolFileSha256: sha256(body),
+          batchReceipt: { batchId: 'batch-1', candidateCount: 1 },
+        }),
+        'utf8',
+      );
+
+      const result = await verifySpoolManifest(spool);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('invalid batchReceipt');
+    });
+
     it("returns 'tampered' when the file content no longer matches the manifest", async () => {
       const spool = join(tmpDir, 'spool-3.jsonl');
       await writeFile(spool, 'tampered content\n', 'utf8');

--- a/packages/claude-runtime/src/index.ts
+++ b/packages/claude-runtime/src/index.ts
@@ -38,6 +38,7 @@ export {
   verifySpoolManifest,
   type SpoolManifestStatus,
   type SpoolManifestResult,
+  type SpoolBatchReceipt,
 } from './spool/spool-reader.js';
 export { writeToFailureBucket } from './spool/failure-bucket.js';
 export type { FailureRecord } from './spool/failure-bucket.js';

--- a/packages/claude-runtime/src/spool/spool-reader.ts
+++ b/packages/claude-runtime/src/spool/spool-reader.ts
@@ -20,12 +20,81 @@ import { getSpoolPath } from '../config.js';
  */
 export type SpoolManifestStatus = 'verified' | 'no_manifest' | 'tampered';
 
+/**
+ * Receipt carried by a producer when a spool file represents a broad or bulk
+ * import. The receipt is intentionally small and machine-verifiable: the
+ * candidate count is checked against the JSONL and the ceiling is checked
+ * before any candidate is inserted into the store.
+ */
+export interface SpoolBatchReceipt {
+  /** Stable producer-run identity, persisted as candidates.import_batch_id. */
+  batchId: string;
+  /** Tenant boundary asserted by the producer and checked against every line. */
+  tenantId: string;
+  /** Discovery scope used to produce the file. */
+  scope: 'wiki' | 'outputs' | 'all';
+  /** Source stamp expected on every candidate in the batch. */
+  source: 'import' | 'bulk_import';
+  /** Trust stamp expected on every candidate in the batch. */
+  trustLevel: 'high' | 'medium' | 'low' | 'untrusted';
+  /** Exact number of valid candidates expected in this spool file. */
+  candidateCount: number;
+  /** Producer-declared per-run ceiling; candidateCount must not exceed it. */
+  maxCandidates: number;
+}
+
 export interface SpoolManifestResult {
   status: SpoolManifestStatus;
   /** SHA-256 recorded in the manifest (present when status !== 'no_manifest'). */
   expected?: string;
   /** SHA-256 recomputed from the spool file content (present on verified/tampered). */
   actual?: string;
+  /** Candidate IDs pinned by the producer manifest, when present. */
+  candidateIds?: string[];
+  /** Broad/bulk admission receipt, when present. */
+  batchReceipt?: SpoolBatchReceipt;
+}
+
+function parseBatchReceipt(value: unknown): SpoolBatchReceipt | null {
+  if (value === null || typeof value !== 'object') return null;
+  const r = value as Record<string, unknown>;
+  const batchId = r['batchId'];
+  const tenantId = r['tenantId'];
+  const scope = r['scope'];
+  const source = r['source'];
+  const trustLevel = r['trustLevel'];
+  const candidateCount = r['candidateCount'];
+  const maxCandidates = r['maxCandidates'];
+  const scopes = new Set(['wiki', 'outputs', 'all']);
+  const sources = new Set(['import', 'bulk_import']);
+  const trustLevels = new Set(['high', 'medium', 'low', 'untrusted']);
+  if (
+    typeof batchId !== 'string' ||
+    batchId.length < 1 ||
+    batchId.length > 128 ||
+    typeof tenantId !== 'string' ||
+    tenantId.length < 1 ||
+    !scopes.has(String(scope)) ||
+    !sources.has(String(source)) ||
+    !trustLevels.has(String(trustLevel)) ||
+    typeof candidateCount !== 'number' ||
+    !Number.isSafeInteger(candidateCount) ||
+    candidateCount < 0 ||
+    typeof maxCandidates !== 'number' ||
+    !Number.isSafeInteger(maxCandidates) ||
+    maxCandidates < 1
+  ) {
+    return null;
+  }
+  return {
+    batchId,
+    tenantId,
+    scope: scope as SpoolBatchReceipt['scope'],
+    source: source as SpoolBatchReceipt['source'],
+    trustLevel: trustLevel as SpoolBatchReceipt['trustLevel'],
+    candidateCount,
+    maxCandidates,
+  };
 }
 
 /**
@@ -57,7 +126,11 @@ export async function verifySpoolManifest(
 
   let expected: string;
   try {
-    const manifest = JSON.parse(manifestRaw) as { spoolFileSha256?: unknown };
+    const manifest = JSON.parse(manifestRaw) as {
+      spoolFileSha256?: unknown;
+      candidateIds?: unknown;
+      batchReceipt?: unknown;
+    };
     if (typeof manifest.spoolFileSha256 !== 'string' || manifest.spoolFileSha256.length === 0) {
       return {
         ok: false,
@@ -65,24 +138,47 @@ export async function verifySpoolManifest(
       };
     }
     expected = manifest.spoolFileSha256;
+    const candidateIds = Array.isArray(manifest.candidateIds)
+      ? manifest.candidateIds.filter((id): id is string => typeof id === 'string')
+      : undefined;
+    let batchReceipt: SpoolBatchReceipt | undefined;
+    if (manifest.batchReceipt !== undefined) {
+      const parsedReceipt = parseBatchReceipt(manifest.batchReceipt);
+      if (parsedReceipt === null) {
+        return {
+          ok: false,
+          error: `Manifest ${manifestPath} contains an invalid batchReceipt`,
+        };
+      }
+      batchReceipt = parsedReceipt;
+    }
+
+    // The receipt metadata is useful even when the caller has opted out of
+    // hash verification; return it only after the manifest itself parsed.
+    const metadata = { candidateIds, batchReceipt };
+
+    let content: string;
+    try {
+      content = await readFile(spoolFilePath, 'utf8');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, error: `Failed to read spool file for verification: ${msg}` };
+    }
+
+    const actual = createHash('sha256').update(content, 'utf8').digest('hex');
+    return {
+      ok: true,
+      value: {
+        ...metadata,
+        status: actual === expected ? 'verified' : 'tampered',
+        expected,
+        actual,
+      },
+    };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return { ok: false, error: `Manifest ${manifestPath} is not valid JSON: ${msg}` };
   }
-
-  let content: string;
-  try {
-    content = await readFile(spoolFilePath, 'utf8');
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { ok: false, error: `Failed to read spool file for verification: ${msg}` };
-  }
-
-  const actual = createHash('sha256').update(content, 'utf8').digest('hex');
-  return {
-    ok: true,
-    value: { status: actual === expected ? 'verified' : 'tampered', expected, actual },
-  };
 }
 
 /** Read and parse all candidates from a single spool file */


### PR DESCRIPTION
## Summary

- require a verified `batchReceipt` for `bulk_import` and files over 100 candidates
- validate tenant, source, trust, candidate count, ceiling, and manifest candidate IDs before insertion
- persist accepted batch IDs through the existing `import_batches` ledger and `candidates.import_batch_id`
- surface `BATCH_ADMISSION_REJECTED` in the curator CLI and edge-daemon cycle errors
- document operator recovery for rejected broad/bulk spool files

## Tracking

- Bead: `bd_000-projects-gpg9.1`
- GitHub issue: #330
- Plane: LAB-146
- Commit: `0cc4c81`

## Verification

- `pnpm test` — 204 files / 2,449 tests passed
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

The producer-side manifest receipt is intentionally a follow-up contract in the compiler repo; this PR fails closed until that producer work lands.