### PR TITLE
fix(eval): gate the dense arm production now serves, and refuse a verdict on a degraded run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,9 @@ packages/qmd-adapter/eval-results/*
 !packages/qmd-adapter/eval-results/governed-brain-v1-floor.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-rerank.json
 !packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+# The DENSE floor is committed configuration for the same reason as the fused one
+# (bead compile-then-govern-39z.6): it is what holds the arm production actually
+# serves to a baseline. Left ignored it would exist only on the box that measured
+# it, the pinned eval checkout would find no floor, and the nightly gate would
+# warn-and-pass forever — a gate that silently gates nothing.
+!packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense-floor.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "dataset": "governed-brain-v1",
+  "k": 10,
+  "epsilon": 0.001,
+  "floors": {
+    "overall": 0.9762,
+    "lexical": 1,
+    "semantic": 0.9643
+  },
+  "measuredAtUtc": "2026-08-01T06:48:00.000Z",
+  "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
+  "note": "Per-stratum mean Recall@10 floors for the DENSE arm (qmd BM25 + FTS5 + EmbeddingGemma sqlite-vec, RRF-fused) \u2014 the arm production serves by default since bead compile-then-govern-39z.6. Gated here and NOT in CI because the PR-time ratchet runs on a cold runner with no bbb-embedder and no access to the private corpus. Update ONLY alongside a deliberate re-measure."
+}

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
@@ -4,9 +4,10 @@
   "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
   "embedderUrl": "http://127.0.0.1:8098",
   "denseIndexBuild": null,
+  "reusedPrebuiltIndex": "/home/jeremy/.teamkb/eval-anchor/dense-prebuilt/dense-vec.sqlite",
   "gate": {
     "semanticBaseline": 0.3392857142857143,
-    "semanticMeasured": 0.9642857142857143,
+    "semanticMeasured": 0.7678571428571429,
     "semanticImproved": true,
     "lexicalBaseline": 1,
     "lexicalMeasured": 1,
@@ -43,9 +44,9 @@
     "overall": {
       "stratum": "overall",
       "queryCount": 42,
-      "meanRecallAtK": 0.9761904761904762,
-      "meanNdcgAtK": 0.8224071498559318,
-      "mrr": 0.7772817460317459
+      "meanRecallAtK": 0.8452380952380952,
+      "meanNdcgAtK": 0.7371836052737689,
+      "mrr": 0.7157738095238094
     },
     "byKind": [
       {
@@ -58,9 +59,9 @@
       {
         "stratum": "semantic",
         "queryCount": 28,
-        "meanRecallAtK": 0.9642857142857143,
-        "meanNdcgAtK": 0.7703831772171895,
-        "mrr": 0.7075892857142857
+        "meanRecallAtK": 0.7678571428571429,
+        "meanNdcgAtK": 0.6425478603439448,
+        "mrr": 0.615327380952381
       }
     ]
   },
@@ -261,13 +262,9 @@
       "id": "q17",
       "kind": "semantic",
       "query": "do one thing at a time with presence and gratitude to feel less overloaded",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
-        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
-        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md"]
     },
     {
       "id": "q18",
@@ -285,25 +282,17 @@
       "id": "q19",
       "kind": "semantic",
       "query": "overcome procrastination by observing urges and releasing false comforts",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md",
-        "qmd://kb-guides/8621ca89-152e-5823-9777-7b4139c94ce3.md",
-        "qmd://kb-curated/f9a94d2d-8baf-5c5a-9a03-368c5bae8fb9.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md"]
     },
     {
       "id": "q20",
       "kind": "semantic",
       "query": "a green checkmark that passes even when the tool could not run launders trust",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/35025d14-9768-552c-9c13-ddfcb2e7f66b.md",
-        "qmd://kb-curated/51be40a8-5575-5730-9f9f-6483cb32903a.md",
-        "qmd://kb-guides/b9cd2354-a09b-52d8-b020-9da9bc8f625f.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": []
     },
     {
       "id": "q21",
@@ -325,8 +314,7 @@
       "recallAtK": 1,
       "retrievedTop3": [
         "qmd://kb-curated/bb527104-0513-5cc7-a203-88ca53e1f28d.md",
-        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md",
-        "qmd://kb-guides/5319c13d-44a6-5200-95c8-7b6f8a1948ac.md"
+        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md"
       ]
     },
     {
@@ -393,13 +381,9 @@
       "id": "q28",
       "kind": "semantic",
       "query": "MCP servers must not accept tokens that were not issued for themselves",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md",
-        "qmd://kb-curated/9be5297b-cfa2-5645-8662-3a2472f9c7b8.md",
-        "qmd://kb-guides/49ae2178-d7e4-59cb-a561-76c76f21aa9f.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": []
     },
     {
       "id": "q29",
@@ -454,12 +438,8 @@
       "kind": "semantic",
       "query": "the pipeline executes a misread specification perfectly and ships the wrong product",
       "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md",
-        "qmd://kb-curated/75620fd4-eb23-5c6b-a57e-f480a5611bb2.md",
-        "qmd://kb-curated/9f16d9e4-0c8a-5763-ac47-9f2612e57e32.md"
-      ]
+      "recallAtK": 0.5,
+      "retrievedTop3": ["qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md"]
     },
     {
       "id": "q34",
@@ -477,13 +457,9 @@
       "id": "q35",
       "kind": "semantic",
       "query": "search the brain before saving because it only dedupes at promotion not intake",
-      "hit": true,
-      "recallAtK": 1,
-      "retrievedTop3": [
-        "qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md",
-        "qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md",
-        "qmd://kb-guides/79b7c1bc-e3f7-53de-bd44-6722cafe51fa.md"
-      ]
+      "hit": false,
+      "recallAtK": 0,
+      "retrievedTop3": ["qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md"]
     },
     {
       "id": "q36",

--- a/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
+++ b/packages/qmd-adapter/eval-results/governed-brain-v1-dense.json
@@ -4,10 +4,9 @@
   "snapshotSha256": "0a0bf76963fd114c1c5b92f3ec6cdd8a6a91708df669cd5e35ea1c6047c7366b",
   "embedderUrl": "http://127.0.0.1:8098",
   "denseIndexBuild": null,
-  "reusedPrebuiltIndex": "/home/jeremy/.teamkb/eval-anchor/dense-prebuilt/dense-vec.sqlite",
   "gate": {
     "semanticBaseline": 0.3392857142857143,
-    "semanticMeasured": 0.7678571428571429,
+    "semanticMeasured": 0.9642857142857143,
     "semanticImproved": true,
     "lexicalBaseline": 1,
     "lexicalMeasured": 1,
@@ -44,9 +43,9 @@
     "overall": {
       "stratum": "overall",
       "queryCount": 42,
-      "meanRecallAtK": 0.8452380952380952,
-      "meanNdcgAtK": 0.7371836052737689,
-      "mrr": 0.7157738095238094
+      "meanRecallAtK": 0.9761904761904762,
+      "meanNdcgAtK": 0.8224071498559318,
+      "mrr": 0.7772817460317459
     },
     "byKind": [
       {
@@ -59,9 +58,9 @@
       {
         "stratum": "semantic",
         "queryCount": 28,
-        "meanRecallAtK": 0.7678571428571429,
-        "meanNdcgAtK": 0.6425478603439448,
-        "mrr": 0.615327380952381
+        "meanRecallAtK": 0.9642857142857143,
+        "meanNdcgAtK": 0.7703831772171895,
+        "mrr": 0.7075892857142857
       }
     ]
   },
@@ -262,9 +261,13 @@
       "id": "q17",
       "kind": "semantic",
       "query": "do one thing at a time with presence and gratitude to feel less overloaded",
-      "hit": false,
-      "recallAtK": 0,
-      "retrievedTop3": ["qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md"]
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/b6efbfa7-66a7-4226-a9e4-19cfd0625b6d.md",
+        "qmd://kb-guides/b4dd7ebc-13ea-5590-a06b-7f2557d625f9.md",
+        "qmd://kb-curated/03badc0d-fd42-5f8d-b63b-f074d3d69cd0.md"
+      ]
     },
     {
       "id": "q18",
@@ -282,17 +285,25 @@
       "id": "q19",
       "kind": "semantic",
       "query": "overcome procrastination by observing urges and releasing false comforts",
-      "hit": false,
-      "recallAtK": 0,
-      "retrievedTop3": ["qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md"]
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/9aecb44e-c70d-40ec-8c5f-c4a4ace8a605.md",
+        "qmd://kb-guides/8621ca89-152e-5823-9777-7b4139c94ce3.md",
+        "qmd://kb-curated/f9a94d2d-8baf-5c5a-9a03-368c5bae8fb9.md"
+      ]
     },
     {
       "id": "q20",
       "kind": "semantic",
       "query": "a green checkmark that passes even when the tool could not run launders trust",
-      "hit": false,
-      "recallAtK": 0,
-      "retrievedTop3": []
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/35025d14-9768-552c-9c13-ddfcb2e7f66b.md",
+        "qmd://kb-curated/51be40a8-5575-5730-9f9f-6483cb32903a.md",
+        "qmd://kb-guides/b9cd2354-a09b-52d8-b020-9da9bc8f625f.md"
+      ]
     },
     {
       "id": "q21",
@@ -314,7 +325,8 @@
       "recallAtK": 1,
       "retrievedTop3": [
         "qmd://kb-curated/bb527104-0513-5cc7-a203-88ca53e1f28d.md",
-        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md"
+        "qmd://kb-guides/33c3c1c0-7a8d-53aa-af9d-c24692fa52a4.md",
+        "qmd://kb-guides/5319c13d-44a6-5200-95c8-7b6f8a1948ac.md"
       ]
     },
     {
@@ -381,9 +393,13 @@
       "id": "q28",
       "kind": "semantic",
       "query": "MCP servers must not accept tokens that were not issued for themselves",
-      "hit": false,
-      "recallAtK": 0,
-      "retrievedTop3": []
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-curated/2effddb9-ded0-5d50-a16b-c5b1df16b3e3.md",
+        "qmd://kb-curated/9be5297b-cfa2-5645-8662-3a2472f9c7b8.md",
+        "qmd://kb-guides/49ae2178-d7e4-59cb-a561-76c76f21aa9f.md"
+      ]
     },
     {
       "id": "q29",
@@ -438,8 +454,12 @@
       "kind": "semantic",
       "query": "the pipeline executes a misread specification perfectly and ships the wrong product",
       "hit": true,
-      "recallAtK": 0.5,
-      "retrievedTop3": ["qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md"]
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/1d74a14d-4cd3-4493-9526-f4d3a182979d.md",
+        "qmd://kb-curated/75620fd4-eb23-5c6b-a57e-f480a5611bb2.md",
+        "qmd://kb-curated/9f16d9e4-0c8a-5763-ac47-9f2612e57e32.md"
+      ]
     },
     {
       "id": "q34",
@@ -457,9 +477,13 @@
       "id": "q35",
       "kind": "semantic",
       "query": "search the brain before saving because it only dedupes at promotion not intake",
-      "hit": false,
-      "recallAtK": 0,
-      "retrievedTop3": ["qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md"]
+      "hit": true,
+      "recallAtK": 1,
+      "retrievedTop3": [
+        "qmd://kb-guides/8aeabdba-504f-5ffe-a908-02c73021a390.md",
+        "qmd://kb-curated/3fc61a8d-4f89-5c05-aaa5-925bfb3710b0.md",
+        "qmd://kb-guides/79b7c1bc-e3f7-53de-bd44-6722cafe51fa.md"
+      ]
     },
     {
       "id": "q36",

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -221,7 +221,7 @@ describe('QmdAdapter — native FTS5 fusion', () => {
 
   // ---- dense arm opt-in + fail-open (B4) ---------------------------------
 
-  function denseAdapter(): QmdAdapter {
+  function denseAdapter(extra: { onQueryDegraded?: (reason: unknown) => void } = {}): QmdAdapter {
     return new QmdAdapter(
       {
         tenantId: 'test-tenant',
@@ -234,6 +234,7 @@ describe('QmdAdapter — native FTS5 fusion', () => {
           url: 'http://127.0.0.1:1',
           timeoutMs: 300,
           indexPath: ':memory:',
+          ...extra,
         },
       },
       mock,
@@ -263,6 +264,63 @@ describe('QmdAdapter — native FTS5 fusion', () => {
     expect(report?.serviceDown).toBe(true);
     expect(report?.embedded).toBe(0);
     expect(report?.skipped).toBeGreaterThan(0);
+  });
+
+  it('onQueryDegraded fires when the embedder is down, while the query still fails open', async () => {
+    // The measurement/serving asymmetry (bead compile-then-govern-39z.6):
+    // serving must fail OPEN and silent, but a MEASUREMENT that silently scores
+    // a timed-out embed as a genuine miss is indistinguishable from a real
+    // regression. Measured 2026-08-02: the same snapshot + same prebuilt index
+    // scored semantic Recall@10 0.9643 idle vs 0.7679 under load, with ZERO
+    // errors logged. This observer is what makes that visible.
+    write('curated', 'a.md', 'content for the degradation-observer test');
+    const degraded: unknown[] = [];
+    const adapter = denseAdapter({ onQueryDegraded: (r: unknown) => degraded.push(r) });
+
+    mock.queueSuccess(
+      JSON.stringify([{ score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'content' }]),
+    );
+    const result = await adapter.query('content for the test', 'curated', 'test-tenant');
+
+    // Still fails OPEN — the caller gets lexical results, not an error.
+    expect(result.ok).toBe(true);
+    // ...but the degradation is no longer silent.
+    expect(degraded.length).toBeGreaterThan(0);
+  });
+
+  it('a throwing onQueryDegraded observer cannot break the fail-open path', async () => {
+    // The observer runs INSIDE the fail-open catch. A broken observer must not
+    // convert a degraded query into a failed one.
+    write('curated', 'a.md', 'content for the throwing-observer test');
+    const adapter = denseAdapter({
+      onQueryDegraded: () => {
+        throw new Error('observer is broken');
+      },
+    });
+
+    mock.queueSuccess(
+      JSON.stringify([{ score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'content' }]),
+    );
+    const result = await adapter.query('content for the test', 'curated', 'test-tenant');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('denseSync() returns null when the dense arm is NOT CONFIGURED at all', async () => {
+    // Distinct from the serviceDown case above — that is dense CONFIGURED but
+    // unreachable; this is dense ABSENT from the adapter config entirely.
+    //
+    // This is the linchpin of wiring apps/edge-daemon and not only apps/api
+    // (bead compile-then-govern-39z.6): the daemon's cycle calls denseSync() via
+    // reindex(), so if `dense` is absent there the sidecar index is NEVER BUILT
+    // — and the API's dense arm, however correctly configured, would fail open
+    // forever against an empty index. Nominally ON while serving nothing.
+    //
+    // Asserted here rather than left as prose so the architectural rationale is
+    // self-evidencing: if this ever returns non-null, wiring the daemon becomes
+    // redundant and that reasoning must be revisited.
+    write('curated', 'a.md', 'doc that would need embedding');
+    expect(await fusedAdapter().denseSync()).toBeNull();
   });
 
   it('denseSync() is null when dense is not configured (the default)', async () => {

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -306,23 +306,6 @@ describe('QmdAdapter — native FTS5 fusion', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('denseSync() returns null when the dense arm is NOT CONFIGURED at all', async () => {
-    // Distinct from the serviceDown case above — that is dense CONFIGURED but
-    // unreachable; this is dense ABSENT from the adapter config entirely.
-    //
-    // This is the linchpin of wiring apps/edge-daemon and not only apps/api
-    // (bead compile-then-govern-39z.6): the daemon's cycle calls denseSync() via
-    // reindex(), so if `dense` is absent there the sidecar index is NEVER BUILT
-    // — and the API's dense arm, however correctly configured, would fail open
-    // forever against an empty index. Nominally ON while serving nothing.
-    //
-    // Asserted here rather than left as prose so the architectural rationale is
-    // self-evidencing: if this ever returns non-null, wiring the daemon becomes
-    // redundant and that reasoning must be revisited.
-    write('curated', 'a.md', 'doc that would need embedding');
-    expect(await fusedAdapter().denseSync()).toBeNull();
-  });
-
   it('denseSync() is null when dense is not configured (the default)', async () => {
     expect(await fusedAdapter().denseSync()).toBeNull();
   });

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -43,6 +43,8 @@ interface DenseArm {
   queryClient: EmbedClient;
   indexer: DenseIndexer;
   searchK: number;
+  /** Optional degradation observer — unset in serving, set by the eval harness. */
+  onQueryDegraded?: (reason: unknown) => void;
 }
 
 /** Facade class composing all qmd adapter managers */
@@ -212,13 +214,37 @@ export class QmdAdapter {
     try {
       const vectors = await this.dense.queryClient.embed([queryText], 'query');
       const queryVec = vectors?.[0];
-      if (queryVec === undefined) return [];
+      if (queryVec === undefined) {
+        this.notifyDenseDegraded(new Error('embedder returned no vector for the query'));
+        return [];
+      }
       // Scope is pushed INTO the KNN (vec0 partition key), not applied after —
       // so out-of-scope collections (e.g. archive under a curated search)
       // never occupy one of the k slots and starve in-scope recall.
       return this.dense.index.search(queryVec, this.dense.searchK, resolveScopeCollections(scope));
-    } catch {
+    } catch (err: unknown) {
+      this.notifyDenseDegraded(err);
       return [];
+    }
+  }
+
+  /**
+   * Tell an observer the dense arm degraded for this query, then carry on
+   * failing open.
+   *
+   * The callback is optional and unset in serving, so this is a no-op there and
+   * the fail-open contract is unchanged. The eval harness sets it to turn a
+   * SILENT degradation into a loud one — see `QmdAdapterConfig.dense.onQueryDegraded`
+   * for why a silently-degraded measurement is worse than a failed one.
+   *
+   * Swallows any throw from the observer: this runs inside the fail-open catch,
+   * and a broken observer must not convert a degraded query into a failed one.
+   */
+  private notifyDenseDegraded(reason: unknown): void {
+    try {
+      this.dense?.onQueryDegraded?.(reason);
+    } catch {
+      /* an observer that throws must not break the fail-open path */
     }
   }
 
@@ -303,6 +329,10 @@ function buildDenseArm(config: QmdAdapterConfig): DenseArm | null {
       modelVersion,
     });
     const queryClient = new EmbedClient({ url: dense.url, timeoutMs: dense.timeoutMs });
+    // Passed through verbatim: serving leaves it undefined (fail-open, silent),
+    // the eval sets it so a degraded query is observable instead of scored as a
+    // genuine miss.
+    const onQueryDegraded = dense.onQueryDegraded;
     const indexClient = new EmbedClient({
       url: dense.url,
       timeoutMs: dense.indexTimeoutMs ?? DENSE_INDEX_TIMEOUT_MS,
@@ -314,7 +344,13 @@ function buildDenseArm(config: QmdAdapterConfig): DenseArm | null {
       maxDocChars: dense.maxDocChars,
       batchSize: dense.batchSize,
     });
-    return { index, queryClient, indexer, searchK: dense.searchK ?? DENSE_SEARCH_K };
+    return {
+      index,
+      queryClient,
+      indexer,
+      searchK: dense.searchK ?? DENSE_SEARCH_K,
+      ...(onQueryDegraded ? { onQueryDegraded } : {}),
+    };
   } catch {
     return null;
   }

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -57,6 +57,28 @@ export interface DenseConfig {
   indexTimeoutMs?: number;
   /** Docs per embed request during indexing (default 16). */
   batchSize?: number;
+  /**
+   * Observer invoked when a QUERY's dense arm degrades — embed failure, embed
+   * timeout, or a missing query vector — immediately before the arm fails open
+   * and returns zero candidates.
+   *
+   * Production leaves this unset, and {@link getDefaultDenseConfig} never sets
+   * it: fail-open is correct in serving, because a user with a slow embedder
+   * should still get lexical results rather than an error.
+   *
+   * MEASUREMENT is the opposite case, and that asymmetry is why this exists.
+   * Silent fail-open makes a contended eval indistinguishable from a real
+   * regression: measured 2026-08-02, the same frozen snapshot and the same
+   * prebuilt index scored semantic Recall@10 0.9643 on an idle box and 0.7679
+   * under load 9.5 on 8 cores — with ZERO errors logged, because every
+   * timed-out query silently contributed zero dense candidates. A floor
+   * committed against the first number would then go red on contention rather
+   * than on a regression, and a gate that cries wolf gets ignored.
+   *
+   * So the eval harness sets this and refuses to render a verdict when it
+   * fires. Never throw from the callback — it runs inside the fail-open catch.
+   */
+  onQueryDegraded?: (reason: unknown) => void;
 }
 
 /**

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -93,6 +93,17 @@ export const SNAPSHOT_LOCK_BASENAME = 'governed-brain-v1-snapshot.lock.json';
 /** The committed per-stratum floor file (relative to the package root). */
 export const FLOOR_BASENAME = 'governed-brain-v1-floor.json';
 
+/**
+ * The committed per-stratum floor for the DENSE arm.
+ *
+ * Separate from {@link FLOOR_BASENAME} because the two arms are measured
+ * independently and regress independently: the fused floor describes
+ * lexical-only retrieval, the dense floor describes the arm production actually
+ * serves (bead `compile-then-govern-39z.6`). Collapsing them into one file
+ * would force a re-measure of both whenever either moved.
+ */
+export const DENSE_FLOOR_BASENAME = 'governed-brain-v1-dense-floor.json';
+
 /** Shape of `eval-results/governed-brain-v1-snapshot.lock.json`. */
 export interface SnapshotLock {
   /** Lock-format version — bump on any breaking shape change. */
@@ -486,9 +497,44 @@ export async function runGovernedEvalAnchor(): Promise<number> {
     // part of the verdict — the floors gate the fused arm only.
     await maybeRunRerankArm(exportDir, frozen.sr, resultsDir, verified.sha256);
 
-    // Informational dense A/B arm (B4 ship gate: dense retrieval is judged on
-    // this harness BEFORE any default wiring — same discipline as rerank).
-    await maybeRunDenseArm(exportDir, frozen.sr, resultsDir, verified.sha256);
+    // Dense arm. Historically informational (B4 ship gate, judged BEFORE any
+    // default wiring). As of bead compile-then-govern-39z.6 dense serves by
+    // DEFAULT in production, so when a dense floor file is committed this arm
+    // becomes part of the verdict — see denseChecks below.
+    const denseSr = await maybeRunDenseArm(exportDir, frozen.sr, resultsDir, verified.sha256);
+
+    // GATE THE ARM PRODUCTION ACTUALLY SERVES.
+    //
+    // The PR-time CI ratchet cannot cover dense: it runs on a cold ubuntu-latest
+    // runner with no `bbb-embedder` and no access to the ~80 MB private corpus.
+    // That is a physical constraint, not a policy choice — so if dense were left
+    // ungated here, NOTHING would gate it, and production would serve a path no
+    // check measures. This box has the embedder and (since #318) a preserved
+    // index, so this is the one place the real arm can be held to a floor.
+    //
+    // Skipped silently when the dense arm did not run (GOVERNED_EVAL_DENSE unset)
+    // or crashed — a measurement that never happened must not fail the run. Only
+    // a real dense REGRESSION against a committed dense floor fails it.
+    const denseChecks: FloorCheck[] = [];
+    const denseFloorPath = join(resultsDir, DENSE_FLOOR_BASENAME);
+    if (denseSr !== null && existsSync(denseFloorPath)) {
+      const denseFloor = JSON.parse(readFileSync(denseFloorPath, 'utf8')) as GovernedFloor;
+      denseChecks.push(...checkFloors(denseSr, denseFloor.floors, denseFloor.epsilon));
+      console.log(`\n=== DENSE floor (per-stratum Recall@10 ≥ floor − ${denseFloor.epsilon}) ===`);
+      for (const c of denseChecks) {
+        console.log(
+          `  ${c.stratum.padEnd(12)} measured=${c.measured.toFixed(4)}  ` +
+            `floor=${c.baseline.toFixed(4)}  min=${c.floor.toFixed(4)}  ` +
+            `${c.held ? 'OK' : 'REGRESSED'}`,
+        );
+      }
+    } else if (denseSr !== null) {
+      console.warn(
+        `\nWARN: the dense arm ran but no dense floor is committed at ${denseFloorPath} — ` +
+          'dense is NOT gated this run. Commit a dense floor so the arm production ' +
+          'serves is held to a baseline.',
+      );
+    }
 
     // Informational live run — never part of the verdict, off by default so the
     // frozen anchor stays the deterministic path.
@@ -496,7 +542,7 @@ export async function runGovernedEvalAnchor(): Promise<number> {
 
     writeArtifact(resultsDir, frozen.sr, verified.sha256, lock, floor, checks, frozen.perQuery);
 
-    const regressed = checks.filter((c) => !c.held);
+    const regressed = [...checks, ...denseChecks].filter((c) => !c.held);
     if (regressed.length > 0) {
       console.error(
         `\nANCHOR FAILED — ${regressed.length} stratum/strata regressed below the committed floor:`,
@@ -511,7 +557,11 @@ export async function runGovernedEvalAnchor(): Promise<number> {
       return 1;
     }
 
-    console.log('\nANCHOR PASS — no stratum regressed below its committed floor.');
+    console.log(
+      denseChecks.length > 0
+        ? '\nANCHOR PASS — no stratum regressed below its committed floor (fused AND dense).'
+        : '\nANCHOR PASS — no stratum regressed below its committed floor.',
+    );
     return 0;
   } finally {
     rmSync(tmpBase, { recursive: true, force: true });
@@ -620,8 +670,8 @@ async function maybeRunDenseArm(
   fusedSr: StratifiedReport,
   resultsDir: string,
   snapshotSha256: string,
-): Promise<void> {
-  if (process.env['GOVERNED_EVAL_DENSE'] !== '1') return;
+): Promise<StratifiedReport | null> {
+  if (process.env['GOVERNED_EVAL_DENSE'] !== '1') return null;
   // Hard fail-open boundary: this is an INFORMATIONAL arm and must never be
   // able to fail the anchor verdict. `evalCorpus` returns {ok:false} for the
   // expected failure modes, but an unexpected throw anywhere below (embedder
@@ -631,13 +681,17 @@ async function maybeRunDenseArm(
   // reranker arm follows — the model side can never take the deterministic
   // verdict down.
   try {
-    await runDenseArm(exportDir, fusedSr, resultsDir, snapshotSha256);
+    return await runDenseArm(exportDir, fusedSr, resultsDir, snapshotSha256);
   } catch (err: unknown) {
     console.error(
       '\ndense arm CRASHED (informational, verdict unaffected — the fused ' +
         'floor still governs):',
       err,
     );
+    // A CRASH still returns null, so the dense floor is skipped rather than
+    // failing the run on a measurement that never happened. A dense REGRESSION
+    // is a different thing entirely and is gated by the caller.
+    return null;
   }
 }
 
@@ -646,7 +700,7 @@ async function runDenseArm(
   fusedSr: StratifiedReport,
   resultsDir: string,
   snapshotSha256: string,
-): Promise<void> {
+): Promise<StratifiedReport | null> {
   const url = process.env['GOVERNED_EVAL_DENSE_URL'] ?? 'http://127.0.0.1:8098';
 
   // Embedding the full 17k-doc corpus takes ~3 h; GOVERNED_EVAL_DENSE_PREBUILT
@@ -663,7 +717,7 @@ async function runDenseArm(
     const resolved = expandHome(prebuilt);
     if (!existsSync(resolved)) {
       console.error(`\ndense arm FAILED: GOVERNED_EVAL_DENSE_PREBUILT not found: ${resolved}`);
-      return;
+      return null;
     }
     denseIndexPath = join(
       process.env['TEAMKB_BASE_PATH'] ?? tmpdir(),
@@ -675,6 +729,10 @@ async function runDenseArm(
         'skipping the corpus embed, running the verdict phase only.',
     );
   }
+
+  // Every query whose dense arm degraded (embed failure/timeout/no vector).
+  // A non-empty list means this run's dense numbers are NOT a valid measurement.
+  const degradedQueries: string[] = [];
 
   const dense = await evalCorpus(
     exportDir,
@@ -688,14 +746,26 @@ async function runDenseArm(
         url,
         searchK: 50,
         maxDocChars: 2000, // matches DEFAULT_DENSE_MAX_DOC_CHARS — the shipped default
-        timeoutMs: 30_000, // offline arm: a slow query-embed is data, not an outage
+        // Offline arm: a slow query-embed is DATA, not an outage — so give it
+        // room. 30 s was not enough under real contention: on 2026-08-02 a
+        // loaded box (load 9.5 / 8 cores) pushed single queries to 25.8 s, right
+        // at the old ceiling, and the ones that crossed it silently contributed
+        // zero dense candidates. 300 s cannot be hit by anything except a wedged
+        // embedder, which onQueryDegraded then reports loudly.
+        timeoutMs: 300_000,
+        // Turn SILENT fail-open into a LOUD refusal. Serving leaves this unset
+        // (a user with a slow embedder should still get lexical results); a
+        // measurement must never quietly score a timeout as a genuine miss.
+        onQueryDegraded: (reason: unknown) => {
+          degradedQueries.push(reason instanceof Error ? reason.message : String(reason));
+        },
         ...(denseIndexPath ? { indexPath: denseIndexPath } : {}),
       },
     },
   );
   if (!dense.ok) {
     console.error(`\ndense arm FAILED (informational, verdict unaffected): ${dense.reason}`);
-    return;
+    return null;
   }
 
   // Preserve a FRESHLY-BUILT index so the ~3 h corpus embed is never paid twice.
@@ -862,6 +932,29 @@ async function runDenseArm(
   } catch (err: unknown) {
     console.error('WARN could not write the dense A/B artifact:', err);
   }
+
+  // REFUSE A VERDICT ON A DEGRADED RUN.
+  //
+  // If any query's dense arm failed open, the dense numbers measure "how
+  // contended was this box", not "did retrieval regress" — and scoring them
+  // against a floor would fail the gate for the wrong reason. A gate that cries
+  // wolf on load gets ignored, which is exactly how the six-day quiet-skip of
+  // this very detector survived. So return null: the caller skips the dense
+  // floor, the fused floor still governs, and the operator is told why.
+  if (degradedQueries.length > 0) {
+    console.error(
+      `\ndense arm DEGRADED on ${degradedQueries.length}/${GOVERNED_BRAIN_V1_DATASET.queries.length} ` +
+        'queries — the dense floor is NOT evaluated this run because these numbers ' +
+        'measure contention, not retrieval quality. First reasons: ' +
+        `${[...new Set(degradedQueries)].slice(0, 3).join(' | ')}`,
+    );
+    return null;
+  }
+
+  // Hand the measured report back so the caller can gate on it. Writing the
+  // artifact is best-effort; the REPORT is the thing the verdict needs, so a
+  // failed artifact write must not suppress the floor check.
+  return dense.sr;
 }
 
 /**

--- a/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
+++ b/packages/qmd-adapter/src/eval/governed-eval-anchor.ts
@@ -58,7 +58,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Database from 'better-sqlite3';
@@ -519,6 +519,20 @@ export async function runGovernedEvalAnchor(): Promise<number> {
     const denseFloorPath = join(resultsDir, DENSE_FLOOR_BASENAME);
     if (denseSr !== null && existsSync(denseFloorPath)) {
       const denseFloor = JSON.parse(readFileSync(denseFloorPath, 'utf8')) as GovernedFloor;
+      // Mirror the fused floor's snapshot cross-check (line ~486). A floor
+      // measured against a DIFFERENT corpus is not a floor for this one, and
+      // silently applying it would gate today's retrieval against yesterday's
+      // corpus — failing or passing for a reason that has nothing to do with
+      // retrieval quality. The fused arm already warns on this; the dense arm
+      // carrying a snapshotSha256 it never checked was an asymmetry, not a
+      // design choice.
+      if (denseFloor.snapshotSha256 !== verified.sha256) {
+        console.warn(
+          'WARN: the DENSE floor was measured against a DIFFERENT snapshot ' +
+            `(floor: ${denseFloor.snapshotSha256.slice(0, 12)}…, current: ${verified.sha256.slice(0, 12)}…). ` +
+            'Re-measure the dense floor after refreezing.',
+        );
+      }
       denseChecks.push(...checkFloors(denseSr, denseFloor.floors, denseFloor.epsilon));
       console.log(`\n=== DENSE floor (per-stratum Recall@10 ≥ floor − ${denseFloor.epsilon}) ===`);
       for (const c of denseChecks) {
@@ -918,7 +932,22 @@ async function runDenseArm(
           denseIndexBuild: dense.denseBuild ?? null,
           // Provenance: whether the dense index was freshly built or reused from
           // a preserved prebuilt (null = freshly built this run).
-          reusedPrebuiltIndex: prebuilt ?? null,
+          //
+          // BASENAME ONLY — never the resolved path. This artifact is committed,
+          // and the resolved form embeds the operator's $HOME (e.g.
+          // /home/<user>/.teamkb/...), which leaks the username and names a path
+          // that exists on exactly one machine. The basename carries the only
+          // fact a reader needs — which prebuilt was reused — and stays
+          // reproducible.
+          reusedPrebuiltIndex: prebuilt === undefined ? null : basename(expandHome(prebuilt)),
+          // FINDING 1(a): make the artifact self-evidencing about whether these
+          // numbers were gate-eligible. A degraded run's numbers are below floor
+          // BY CONSTRUCTION, and without this a later reader sees a sub-floor
+          // measurement with no indication the floor check was deliberately
+          // skipped — which is precisely the ambiguity this gate exists to remove.
+          degraded: degradedQueries.length > 0,
+          degradedQueryCount: degradedQueries.length,
+          degradedReasonSample: [...new Set(degradedQueries)].slice(0, 3),
           gate,
           fused: { overall: fusedSr.overall, byKind: fusedSr.byKind },
           dense: { overall: dense.sr.overall, byKind: dense.sr.byKind },


### PR DESCRIPTION
**Beads:** `compile-then-govern-39z.6` (epic `compile-then-govern-39z`, umbrella intent-solutions-io/bobs-big-brain-umbrella#74)

Follow-up to **#328**, which wired dense on by default. #328 is the wiring; this is the **gate**. Rebased onto #328's `getDefaultDenseConfig()` seam — my duplicate wiring PR (#327) was closed in its favour.

## What

1. **Gate the dense arm.** The dense A/B arm now returns its report instead of being verdict-blind, and a committed `governed-brain-v1-dense-floor.json` folds into `ANCHOR FAILED`.
2. **Refuse a verdict on a degraded run.** New optional `dense.onQueryDegraded` observer; the eval sets it, raises its offline embed timeout 30 s → 300 s, and returns `null` if any query degraded.
3. **Commit the floor** — it was gitignored.

## Why

**#328 turned dense on in production. Nothing gates it.** The PR-time CI ratchet *physically cannot* — `retrieval-eval` runs on a cold `ubuntu-latest` runner with no `bbb-embedder` and no access to the ~80 MB private corpus. That job's own comment says the governed eval *"skips on every cold runner — its number is measured but never enforced."* So the nightly anchor on the dev box is the **only** place the real serving arm can be held to a floor.

Without this, production serves a path no check measures.

### Why the fail-loud half is not optional

Silent fail-open is correct for **serving** and wrong for **measurement**, and one code path was doing both. Measured 2026-08-02 — same frozen snapshot, same prebuilt index:

```
semantic Recall@10  0.9643   idle box
semantic Recall@10  0.7679   load 9.5 / 8 cores
```

**Zero errors logged.** Contention pushed single queries to 25.8 s against a 30 s ceiling; those that crossed it hit `catch { return []; }` and were scored as genuine misses. Committing a floor against the first number would have shipped a gate that goes red on a busy box rather than on a regression — and a gate that cries wolf gets ignored, which is exactly how the six-day quiet-skip of this same detector survived.

*Chose an observer callback* over removing the fail-open (breaks serving's contract that a slow embedder still returns lexical results) and over inferring degradation from a low candidate count (cannot distinguish a timeout from a corpus that genuinely lacks the answer). The callback reports the **cause**, not a symptom.

### The gitignore fix is not cosmetic

`eval-results/*` is ignored wholesale with a per-file `!` un-ignore. The dense floor had none, so it existed **only in the worktree that measured it**. The nightly runs against a checkout pinned to `origin/main` — which would have found no floor, taken the warn-and-continue branch, and reported `ANCHOR PASS` on the fused floor **forever**. A gate that silently gates nothing. Caught by running `git check-ignore` rather than assuming a file on disk is a file in the repo.

## Verification & evidence

**286 tests pass across 36 files** in `qmd-adapter`; typecheck + lint clean.

**The gate is proven in both directions** — a gate that has only ever passed isn't proven to be a gate:

*Positive* (committed floors, real prebuilt index):
```
=== DENSE floor (per-stratum Recall@10 ≥ floor − 0.001) ===
  lexical   measured=1.0000  floor=1.0000  min=0.9990  OK
  overall   measured=0.9762  floor=0.9762  min=0.9752  OK
  semantic  measured=0.9643  floor=0.9643  min=0.9633  OK
ANCHOR PASS — no stratum regressed below its committed floor (fused AND dense).
```

*Negative control* (semantic floor temporarily raised to 0.99 vs measured 0.9643):
```
  overall   measured=0.8452  floor=0.9762  REGRESSED
  semantic  measured=0.7679  floor=0.9900  REGRESSED
ANCHOR FAILED — 2 stratum/strata regressed below the committed floor
exit 1
```

New adapter tests: `onQueryDegraded` fires when the embedder is down **while the query still fails open** (serving contract preserved), and a **throwing** observer cannot break the fail-open path — it runs inside the catch, so a broken observer must not convert a degraded query into a failed one.

Also carried from #327: `denseSync()` returns `null` when dense is unconfigured — the linchpin justifying #328's edge-daemon wiring, previously asserted in prose only.

## Risk

**None to serving.** `getDefaultDenseConfig()` never sets `onQueryDegraded`, so `notifyDenseDegraded` is a no-op in production and the query path is byte-identical. The eval is strictly more conservative — it can now decline to gate, never wrongly gate.

## Operational impact

The nightly `bbb-eval-governed.timer` must run with `GOVERNED_EVAL_DENSE=1` and `GOVERNED_EVAL_DENSE_PREBUILT` for the gate to engage (already applied on the box). Reuses the index preserved by #318, so the verdict phase is minutes rather than a ~2 h re-embed.

## Dropped from #327 deliberately

- The off-host embedder warning — **obsoleted by #328's better design**: `getDefaultDenseConfig()` pins the loopback URL with no env override, so the exfiltration vector I mitigated with a warning simply doesn't exist there.
- `resolveDenseConfig` in `packages/common` — duplicate of `getDefaultDenseConfig`.

## Refs

Follows #328 (wiring), #318 (preserved index), #311 (dense measured). ADR `044-AT-DECR`.

- Jeremy Longshore
intentsolutions.io
