### PR TITLE
fix(deploy): make brain releases restart-safe

### DIFF
--- a/000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md
+++ b/000-docs/041-OD-OPSM-brain-api-immutable-release-deploy.md
@@ -42,10 +42,18 @@ serve from an **immutable, tag-pinned release directory** behind an atomic `curr
 └── DEPLOYS.log                         # append-only: <utc> tag= sha= actor= note=
 ```
 
-Each `releases/<tag>` is produced by `git archive <tag>` (no `.git`, immutable) + `pnpm install
---frozen-lockfile` + `pnpm -r build`, built with **`/usr/bin/node`** so `better-sqlite3`'s native
-ABI matches the node the unit runs. Releases are **never rebuilt in place** — a new tag is a new
-directory, and rollback is a symlink flip.
+Each `releases/<ref>-<short-sha>` is produced by `git archive <resolved-commit-sha>` (no `.git`,
+immutable) + a frozen pnpm install + `pnpm -r build`, built with **`/usr/bin/node`** so
+`better-sqlite3`'s native ABI matches the node the unit runs. pnpm uses
+`--package-import-method=copy`: a production release must not share
+writable package-file hardlinks with pnpm's global store or another checkout. Optional local-LLM
+platform binaries are excluded because the tailnet API does not load them. Each build uses a fresh,
+release-local pnpm store and removes that disposable store after the copied dependency graph is
+built, so a corrupted global store cannot contaminate a candidate. Releases are **never
+rebuilt in place** — a new commit is a new directory; a corrupt same-SHA artifact is preserved and
+its replacement gets a unique `-rebuild-<UTC>` suffix. A full commit SHA is a valid deploy input.
+Tag fetches are deliberately not forced: a moved tag aborts instead of silently changing a release's
+source identity.
 
 ## The release floor — the ONE rule
 
@@ -59,22 +67,46 @@ double-hashes `~/.teamkb/tokens.json` and locks out every teammate.
 ## Deploy
 
 ```bash
-cd ~/000-projects/qmd-team-intent-kb
-scripts/deploy-brain-api.sh v0.8.0        # or any later tag that contains a2143be
+cd ~/000-projects/bobs-big-brain-registrar
+scripts/deploy-brain-api.sh v0.8.0        # or a full commit SHA containing a2143be
 ```
 
 What it does, in order (all `set -euo pipefail`, idempotent, safe):
 
-1. `git fetch --tags` in the source repo.
-2. **Floor check** — abort unless the tag contains `a2143be`.
-3. **Build** a fresh `releases/<tag>` (archive → `pnpm install` → `pnpm -r build`). If the dir already
-   exists and passes preflight, it is **reused** (re-running the same tag is a safe no-op re-point).
-4. **Lockout preflight** — `grep parseStoredHash …/dist/auth/token-registry.js`, else abort.
-5. **Smoke** — see below.
-6. **Flip** `current -> releases/<tag>`, then `systemctl --user daemon-reload && restart`.
-7. **Post-restart health gate** — if the new build is unhealthy it **auto-rolls back** the symlink,
+1. `git fetch --tags` without force in the source repo; moved-tag rejection is a hard failure.
+2. Resolve the tag or commit input once and **floor-check that SHA** — abort unless it contains
+   `a2143be`. The build archives that SHA, not the ref name.
+3. **Cold-start the current rollback target.** Every package manifest must parse and a fresh curator
+   process must load. A healthy long-running process does not satisfy this check. Failure aborts
+   without restarting anything.
+4. **Build** a fresh `<ref>-<short-sha>` release (archive → copied, no-optional frozen install →
+   `pnpm -r build`). An
+   existing directory is reused only when its full cold-start preflight passes; otherwise it is
+   preserved and a uniquely named rebuild is created.
+5. **Artifact preflight** — `parseStoredHash` must exist, every `package.json` must be non-empty valid
+   JSON, and a fresh `/usr/bin/node apps/curator/dist/main.js --help` must succeed.
+6. **Smoke** — see below.
+7. **Flip** `current -> releases/<release-name>`, then `systemctl --user daemon-reload && restart`.
+8. **Post-restart health gate** — if the new build is unhealthy it **auto-rolls back** the symlink,
    restarts, and exits non-zero (the service is never left down).
-8. Append a line to `DEPLOYS.log` and **prune** to the newest 5 release dirs (never the live one).
+9. Append a line to `DEPLOYS.log` and **prune** to the newest 5 release dirs (never the live one).
+
+## Cold-start failure — do not restart
+
+If deploy reports that `current` fails its cold-start preflight, leave the existing process running.
+The process may have loaded its dependencies before the files were damaged; `/api/health` can remain
+green even though the same artifact cannot start again. Do not use `systemctl restart` and do not
+point `current` at another retained release until that release independently passes all three gates:
+
+1. every package manifest parses;
+2. a fresh curator CLI process loads;
+3. an isolated API over a SQLite backup returns health 200, unauthenticated search 401, and an
+   authenticated search with `qmd://` citations.
+
+Build two copied-package artifacts from the recorded tag/SHA, prove both, and use one as the primary
+and one as the rollback. Only then flip `current` and restart. The 2026-08-16 incident proved why:
+510–525 zero-byte hardlinked package manifests affected every retained release simultaneously while
+the week-old API process continued to answer health checks.
 
 ### What the smoke proves (and what it can't)
 
@@ -147,6 +179,6 @@ checkout is never again the live service. To undo the cutover itself, restore th
   code artifact comes from_.
 - **Disk:** each `releases/<tag>` is ~1 GB (full workspace `node_modules`, mostly pnpm-store
   hardlinks); the script keeps the newest 5.
-- **Env overrides** (defaults shown): `TEAMKB_SRC_REPO=$HOME/000-projects/qmd-team-intent-kb`,
+- **Env overrides** (defaults shown): `TEAMKB_SRC_REPO=$HOME/000-projects/bobs-big-brain-registrar`,
   `TEAMKB_API_OPT=$HOME/.local/opt/teamkb-api`, `TEAMKB_API_UNIT=teamkb-brain-api.service`,
   `TEAMKB_API_NODE=/usr/bin/node`, `TEAMKB_KEEP=5`, `TEAMKB_FLOOR_SHA=a2143be`.

--- a/scripts/deploy-brain-api.sh
+++ b/scripts/deploy-brain-api.sh
@@ -30,10 +30,10 @@
 # query is the final human confirmation (see the runbook).
 #
 # Usage:
-#   scripts/deploy-brain-api.sh <tag>          # e.g. scripts/deploy-brain-api.sh v0.8.0
+#   scripts/deploy-brain-api.sh <tag-or-sha>   # e.g. scripts/deploy-brain-api.sh v0.8.0
 #
 # Environment overrides (sane defaults; NO ~/.claude paths):
-#   TEAMKB_SRC_REPO   git repo to fetch/archive from   (default: $HOME/000-projects/qmd-team-intent-kb)
+#   TEAMKB_SRC_REPO   git repo to fetch/archive from   (default: $HOME/000-projects/bobs-big-brain-registrar)
 #   TEAMKB_API_OPT    immutable release root           (default: $HOME/.local/opt/teamkb-api)
 #   TEAMKB_API_UNIT   systemd --user unit name         (default: teamkb-brain-api.service)
 #   TEAMKB_API_NODE   node binary; ABI must match unit (default: /usr/bin/node)
@@ -44,7 +44,7 @@
 set -euo pipefail
 
 # --- config -----------------------------------------------------------------
-SRC="${TEAMKB_SRC_REPO:-$HOME/000-projects/qmd-team-intent-kb}"
+SRC="${TEAMKB_SRC_REPO:-$HOME/000-projects/bobs-big-brain-registrar}"
 OPT="${TEAMKB_API_OPT:-$HOME/.local/opt/teamkb-api}"
 UNIT="${TEAMKB_API_UNIT:-teamkb-brain-api.service}"
 NODE="${TEAMKB_API_NODE:-/usr/bin/node}"
@@ -54,10 +54,10 @@ RELEASES="$OPT/releases"
 
 # --- state (used by the EXIT trap) ------------------------------------------
 TAG=""
+RELEASE_NAME=""
 SHA=""
 PREV=""
 STAGING=""
-OLD_ASIDE=""
 FLIPPED=0
 DEPLOY_OK=0
 
@@ -66,8 +66,9 @@ log()  { printf '%s  [deploy] %s\n' "$(date -u +%H:%M:%SZ)" "$*" >&2; }
 die()  { log "ERROR: $*"; exit 1; }
 
 deploylog() {
-  printf '%s  tag=%s  sha=%s  actor=%s  note=%s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${TAG:-?}" "${SHA:-?}" "${USER:-$(id -un)}" "$*" \
+  printf '%s  tag=%s  release=%s  sha=%s  actor=%s  note=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${TAG:-?}" "${RELEASE_NAME:-?}" \
+    "${SHA:-?}" "${USER:-$(id -un)}" "$*" \
     >> "$OPT/DEPLOYS.log"
 }
 
@@ -118,6 +119,34 @@ lockout_preflight() {
     || die "LOCKOUT PREFLIGHT FAILED: parseStoredHash absent in $dir — a pre-E1 build would double-hash ~/.teamkb/tokens.json and lock out ALL users. Refusing to deploy."
 }
 
+# A green long-running process does not prove that its on-disk release can
+# start again. Validate package metadata and load the runtime in a fresh Node
+# process before reusing a release or treating it as a rollback target.
+runtime_preflight() {
+  local dir="$1"
+  [ -f "$dir/apps/api/dist/main.js" ] || return 1
+  [ -f "$dir/apps/curator/dist/main.js" ] || return 1
+  grep -q parseStoredHash "$dir/apps/api/dist/auth/token-registry.js" 2>/dev/null || return 1
+
+  # The single-quoted program is JavaScript; its template literal must not be
+  # expanded by the shell.
+  # shellcheck disable=SC2016
+  find "$dir" -type f -name package.json -print0 \
+    | "$NODE" -e '
+        const fs = require("node:fs");
+        const paths = fs.readFileSync(0).toString().split("\0").filter(Boolean);
+        if (paths.length === 0) process.exit(2);
+        for (const path of paths) {
+          const raw = fs.readFileSync(path, "utf8");
+          if (!raw.trim()) throw new Error(`empty package manifest: ${path}`);
+          JSON.parse(raw);
+        }
+      ' >/dev/null 2>&1 \
+    || return 1
+
+  (cd "$dir" && "$NODE" apps/curator/dist/main.js --help >/dev/null 2>&1) || return 1
+}
+
 rollback() {
   log "rolling back the current symlink"
   if [ -n "$PREV" ]; then
@@ -150,32 +179,43 @@ trap cleanup_on_exit EXIT
 
 # Reuse a good release dir, else build a fresh one via `git archive` (self-contained).
 build_release() {
-  local dir="$RELEASES/$TAG"
-  if [ -d "$dir" ] && [ -f "$dir/apps/api/dist/main.js" ] \
-     && grep -q parseStoredHash "$dir/apps/api/dist/auth/token-registry.js" 2>/dev/null; then
-    log "release $TAG already built and passes preflight — reusing (idempotent)"
+  local dir="$RELEASES/$RELEASE_NAME"
+  if [ -d "$dir" ] && runtime_preflight "$dir"; then
+    log "release $RELEASE_NAME already built and passes preflight — reusing (idempotent)"
     return 0
+  fi
+  if [ -d "$dir" ]; then
+    RELEASE_NAME="${RELEASE_NAME}-rebuild-$(date -u +%Y%m%dT%H%M%SZ)"
+    dir="$RELEASES/$RELEASE_NAME"
+    log "release exists but fails cold-start preflight; preserving it and building $RELEASE_NAME"
   fi
   command -v pnpm >/dev/null 2>&1 || die "pnpm not found on PATH"
   [ -x "$NODE" ] || die "node binary not executable: $NODE"
   log "building release $TAG from $SRC @ $SHA (node: $NODE)"
   mkdir -p "$RELEASES"
   STAGING="$(mktemp -d "$RELEASES/.stage-XXXXXX")"
-  git -C "$SRC" archive "$TAG" | tar -x -C "$STAGING"
+  # Archive the resolved commit, never the ref name. Tags can be moved or
+  # deleted; the SHA is the deploy identity recorded in the directory name.
+  git -C "$SRC" archive "$SHA" | tar -x -C "$STAGING"
   (
     cd "$STAGING"
     nodebin_dir="$(dirname "$NODE")"
     export PATH="$nodebin_dir:$PATH"         # pin the node whose ABI the unit uses
     export HUSKY=0                           # no .git in an archive extract
-    pnpm install --frozen-lockfile
+    # A release owns its package files. Shared-store hardlinks can let one
+    # accidental write corrupt production and every rollback simultaneously.
+    # Optional local-LLM platform binaries are not used by the tailnet API.
+    pnpm install --frozen-lockfile --package-import-method=copy --no-optional \
+      --store-dir "$STAGING/.pnpm-store"
     pnpm -r build
+    # The copied node_modules graph is self-contained. Do not ship the
+    # disposable build store or couple future deploys to the global store.
+    rm -rf "$STAGING/.pnpm-store"
   )
   [ -f "$STAGING/apps/api/dist/main.js" ] || die "build produced no apps/api/dist/main.js"
   lockout_preflight "$STAGING"
-  if [ -e "$dir" ]; then
-    OLD_ASIDE="$dir.old.$$"
-    mv "$dir" "$OLD_ASIDE"       # only reached for a broken existing dir (never the live target)
-  fi
+  runtime_preflight "$STAGING" \
+    || die "COLD-START PREFLIGHT FAILED: invalid package metadata or curator startup in $STAGING"
   mv "$STAGING" "$dir"
   STAGING=""
   log "release built: $dir"
@@ -194,37 +234,56 @@ prune_releases() {
     n=$((n + 1))
     [ "$n" -le "$KEEP" ] && continue
     [ "$name" = "$curtarget" ] && continue
-    [ "$name" = "$TAG" ] && continue
+    [ "$name" = "$RELEASE_NAME" ] && continue
     log "pruning old release: $name"
     rm -rf "$d"
   done < <(find "$RELEASES" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | cut -d' ' -f2-)
 }
 
 # --- main -------------------------------------------------------------------
-[ $# -eq 1 ] || die "usage: $(basename "$0") <tag>   (e.g. v0.8.0)"
+[ $# -eq 1 ] || die "usage: $(basename "$0") <tag-or-sha>   (e.g. v0.8.0)"
 TAG="$1"
+case "$TAG" in
+  *[!A-Za-z0-9._-]*|'') die "ref contains characters unsafe for a release directory: $TAG" ;;
+esac
 [ -d "$SRC/.git" ] || die "source repo not found: $SRC (set TEAMKB_SRC_REPO)"
 
-log "fetching tags from origin"
-git -C "$SRC" fetch --tags --force origin >/dev/null 2>&1 || die "git fetch failed in $SRC"
+log "fetching origin without allowing local tag rewrites"
+git -C "$SRC" fetch --tags origin >/dev/null 2>&1 \
+  || die "git fetch failed (including a possible moved-tag rejection) in $SRC"
 
-SHA="$(git -C "$SRC" rev-list -n1 "$TAG" 2>/dev/null || true)"
-[ -n "$SHA" ] || die "tag not found: $TAG"
+SHA="$(git -C "$SRC" rev-parse --verify "${TAG}^{commit}" 2>/dev/null || true)"
+[ -n "$SHA" ] || die "tag or commit not found: $TAG"
+RELEASE_NAME="${TAG}-${SHA:0:12}"
 
 log "verifying release floor ($FLOOR) is an ancestor of $TAG ($SHA)"
-git -C "$SRC" merge-base --is-ancestor "$FLOOR" "$TAG" \
-  || die "REFUSING: $TAG does not contain the release floor $FLOOR (E1 pre-hashed tokens). Deploying it would double-hash tokens.json and lock out all users."
+git -C "$SRC" merge-base --is-ancestor "$FLOOR" "$SHA" \
+  || die "REFUSING: $TAG ($SHA) does not contain the release floor $FLOOR (E1 pre-hashed tokens). Deploying it would double-hash tokens.json and lock out all users."
+
+# Prove the rollback artifact before any restart. If a currently healthy
+# process has corrupt files beneath it, preserve that process and follow the
+# recovery runbook instead of converting latent damage into an outage.
+PREV="$(readlink "$OPT/current" 2>/dev/null || true)"
+if [ -n "$PREV" ]; then
+  case "$PREV" in
+    releases/*) ;;
+    *) die "REFUSING: current points outside releases/: $PREV" ;;
+  esac
+  runtime_preflight "$OPT/$PREV" \
+    || die "REFUSING TO RESTART: current rollback target fails cold-start preflight ($PREV). Keep the healthy process running and follow the recovery runbook."
+fi
 
 build_release
-lockout_preflight "$RELEASES/$TAG"
+lockout_preflight "$RELEASES/$RELEASE_NAME"
+runtime_preflight "$RELEASES/$RELEASE_NAME" \
+  || die "COLD-START PREFLIGHT FAILED after promotion: $RELEASE_NAME"
 
 # Pre-flip smoke against the currently-live service (informational — we still
 # deploy even if the old build is already unhealthy; the hard gate is post-restart).
 if smoke_check; then log "pre-flip: live service healthy"; else log "pre-flip: live service NOT fully healthy (continuing — post-restart smoke is the gate)"; fi
 
-PREV="$(readlink "$OPT/current" 2>/dev/null || true)"
-log "flipping current: ${PREV:-<none>} -> releases/$TAG"
-ln -sfn "releases/$TAG" "$OPT/current"
+log "flipping current: ${PREV:-<none>} -> releases/$RELEASE_NAME"
+ln -sfn "releases/$RELEASE_NAME" "$OPT/current"
 FLIPPED=1
 
 log "daemon-reload + restart $UNIT"
@@ -237,10 +296,9 @@ smoke_check || die "post-restart smoke failed"
 
 # Success — service confirmed healthy on the new build.
 DEPLOY_OK=1
-deploylog "DEPLOYED (current -> releases/$TAG)"
-log "deploy OK: $UNIT now running releases/$TAG (sha $SHA)"
+deploylog "DEPLOYED (current -> releases/$RELEASE_NAME)"
+log "deploy OK: $UNIT now running releases/$RELEASE_NAME (sha $SHA)"
 
 prune_releases
-if [ -n "$OLD_ASIDE" ] && [ -d "$OLD_ASIDE" ]; then rm -rf "$OLD_ASIDE"; fi
 
 log "done."


### PR DESCRIPTION
## What

- identify releases by resolved commit SHA and reject moved tag fetches
- build copied dependency graphs from fresh disposable stores
- cold-start-check the current rollback target and candidate before any restart
- document the zero-byte manifest incident and no-restart recovery path

## Why

A shared pnpm hardlink was zeroed across the checkout and every retained release while the already-running API stayed healthy. Any restart would have converted the latent corruption into an outage.

## Verification

- 67 focused registrar tests pass
- typecheck, shellcheck, bash syntax, harness pin, Prettier, diff check, and gitleaks pass
- independent primary and rollback artifacts cold-started successfully
- live health 200; unauthenticated search 401; tenant-scoped authenticated search returns 3/3 qmd:// citations
- live audit: 24,770 rows; 155 known CHAIN_FORK records; zero tamper breaks

Bead: qmd-team-intent-kb-4za