### PR TITLE
feat(api): publish governance receipt tip

### DIFF
--- a/000-docs/046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md
+++ b/000-docs/046-AT-ARCH-what-each-chain-proves-compile-vs-govern-boundary.md
@@ -27,12 +27,12 @@ The one-line rule:
 
 **Artifacts** (all under the brain root, canonically `~/.teamkb/brain/`):
 
-| Artifact                                      | What it is                                                                                                                                                                                                                 |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `brain/.ico/state.db`                         | The compiler's deterministic kernel state (SQLite): sources, tasks, outputs.                                                                                                                                               |
-| `brain/audit/traces/YYYY-MM-DD.jsonl`         | Daily trace files. Each event carries `event_type`, `event_id`, `timestamp`, `payload`, and a `prev_hash` linking it to the previous event — hash-chained within the day and now cross-day-chained across file boundaries. |
-| `brain/audit/provenance/<sourceId>.jsonl`     | Per-source provenance records: which compile operation (`compile.summarize`, …) emitted which `outputPath` from which source.                                                                                              |
-| `brain/spool/…jsonl` + `<file>.manifest.json` | The emitted spool candidates and the manifest sidecar pinning the file's SHA-256 and listing every emitted `candidateId` (ICO kernel `packages/kernel/src/spool.ts`).                                                      |
+| Artifact                                          | What it is                                                                                                                                                                                                                 |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brain/.ico/state.db`                             | The compiler's deterministic kernel state (SQLite): sources, tasks, outputs.                                                                                                                                               |
+| `brain/audit/traces/YYYY-MM-DD.jsonl`             | Daily trace files. Each event carries `event_type`, `event_id`, `timestamp`, `payload`, and a `prev_hash` linking it to the previous event — hash-chained within the day and now cross-day-chained across file boundaries. |
+| `brain/audit/provenance/<sourceId>.jsonl`         | Per-source provenance records: which compile operation (`compile.summarize`, …) emitted which `outputPath` from which source.                                                                                              |
+| `~/.teamkb/spool/…jsonl` + `<file>.manifest.json` | The emitted spool candidates at the shared compiler/plugin→registrar boundary and the manifest sidecar pinning the file's SHA-256 and listing every emitted `candidateId` (ICO kernel `packages/kernel/src/spool.ts`).     |
 
 **What this chain evidences:** that a compile pass ran over given inputs at a
 recorded time and emitted given artifacts — e.g. "on 2026-07-16 a
@@ -99,6 +99,21 @@ manifest entry → ICO trace event) and reports PASS / FAIL / UNVERIFIABLE per
 link — UNVERIFIABLE, not PASS, when a backing artifact is absent (e.g. no
 brain directory on CI).
 
+### The separate AGP action pointer
+
+The Agent Governance Plane can bind an action to the governance-receipt head it
+observed through authenticated `GET /api/audit/receipt-tip`. The endpoint returns
+the current `audit_events` SHA-256 head and sequence; `?hash=<sha256>` resolves a
+previously observed head after the chain advances. It walks the chain before
+answering, refuses to publish a tip when it finds a tamper signature, and reports
+legacy unverified rows and benign historical ordering forks separately.
+
+This is deliberately a **governance-state pointer**, not a read receipt. It proves
+that a hash occupied a position in the governance chain; it does not record which
+`qmd://` results an agent read or prove that those results caused the action. An
+exact "what did it know?" claim still needs a content-safe per-query read-set
+receipt correlated to the AGP run.
+
 ## 5. The conflation failure mode
 
 The failure mode this document exists to prevent is any sentence shaped like
@@ -133,3 +148,4 @@ flags the wrong forms on brand surfaces.
 | "Did every corpus row come through the promoter?"    | `curator-cli verify-corpus-accounting`                                      | govern                  |
 | "Did a compile pass emit this page?"                 | trace/provenance files under `brain/audit/`                                 | compile                 |
 | "Does this memory's whole lineage hold, end to end?" | `curator-cli provenance-walk --memory-id <id> --db <path> [--brain <path>]` | both, via the bridge    |
+| "Can AGP resolve the governance head it observed?"   | `GET /api/audit/receipt-tip?hash=<sha256>`                                  | govern (`audit_events`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Authenticated `GET /api/audit/receipt-tip` exposes the content-safe global governance-receipt chain head and can resolve a previously observed SHA-256 tip after the chain advances. It verifies the chain before answering, fails closed on tamper signatures, reports legacy unverified rows and benign ordering forks separately, and does not claim to identify the exact search results an agent read. This completes the registrar half of AGP's `gsb_receipt_tip_hash` pointer contract.
+- Authenticated `GET /api/audit/receipt-tip` exposes the content-safe global governance-receipt chain head and can resolve a previously observed SHA-256 tip after the chain advances. It verifies the chain before answering, fails closed on tamper signatures, reports legacy unverified rows and benign ordering forks separately, and does not claim to identify the exact search results an agent read. This completes the registrar half of AGP's `gsb_receipt_tip_hash` pointer contract. The chain-boundary documentation now also names the canonical shared spool at `~/.teamkb/spool` rather than the retired `brain/spool` location.
 
 - **Receipted governance-policy upgrade (`curator-cli upgrade-policy`, epic
   `qmd-team-intent-kb-5bm.2`).** New `curator-cli upgrade-policy --tenant <id> [--db] [--dry-run]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Authenticated `GET /api/audit/receipt-tip` exposes the content-safe global governance-receipt chain head and can resolve a previously observed SHA-256 tip after the chain advances. It verifies the chain before answering, fails closed on tamper signatures, reports legacy unverified rows and benign ordering forks separately, and does not claim to identify the exact search results an agent read. This completes the registrar half of AGP's `gsb_receipt_tip_hash` pointer contract.
+
 - **Receipted governance-policy upgrade (`curator-cli upgrade-policy`, epic
   `qmd-team-intent-kb-5bm.2`).** New `curator-cli upgrade-policy --tenant <id> [--db] [--dry-run]
   [--json]` brings a store's live governance policy up to the recommended anti-dormancy shape

--- a/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
+++ b/apps/api/src/__tests__/__snapshots__/openapi-contract.test.ts.snap
@@ -9,6 +9,11 @@ exports[`OpenAPI contract > publishes a stable apps/api surface (snapshot) 1`] =
         "get",
       ],
     },
+    "/api/audit/receipt-tip": {
+      "methods": [
+        "get",
+      ],
+    },
     "/api/auth/revoke": {
       "methods": [
         "post",

--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -135,4 +135,116 @@ describe('GET /api/audit', () => {
     expect(events.every((e) => e.tenantId === 'team-alpha')).toBe(true);
     expect(events.length).toBe(1);
   });
+
+  describe('GET /api/audit/receipt-tip', () => {
+    it('returns an honest empty-chain response', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/audit/receipt-tip' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        schemaVersion: 1,
+        chain: 'audit_events',
+        scope: 'global-governance-receipt-chain',
+        current: null,
+        requested: null,
+        integrity: {
+          status: 'no_tamper_signatures',
+          checkedRows: 0,
+          unverifiedRows: 0,
+          orderingForks: 0,
+          tamperBreaks: 0,
+        },
+      });
+    });
+
+    it('returns the current tip and resolves it after the chain advances', async () => {
+      auditRepo.insert(makeEvent({ reason: 'first receipt' }));
+      const first = await app.inject({ method: 'GET', url: '/api/audit/receipt-tip' });
+      expect(first.statusCode).toBe(200);
+      const firstBody = first.json<{
+        current: { hash: string; sequence: number; hashVersion: number };
+      }>();
+      expect(firstBody.current.hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(firstBody.current.sequence).toBe(1);
+      expect(firstBody.current.hashVersion).toBe(2);
+
+      auditRepo.insert(makeEvent({ reason: 'second receipt' }));
+      const resolved = await app.inject({
+        method: 'GET',
+        url: `/api/audit/receipt-tip?hash=${firstBody.current.hash}`,
+      });
+      expect(resolved.statusCode).toBe(200);
+      expect(resolved.json()).toMatchObject({
+        current: { sequence: 2 },
+        requested: {
+          hash: firstBody.current.hash,
+          present: true,
+          sequence: 1,
+          isCurrent: false,
+        },
+        integrity: { status: 'no_tamper_signatures', checkedRows: 2 },
+      });
+    });
+
+    it('returns present=false for a well-formed hash that is not in the chain', async () => {
+      const hash = 'a'.repeat(64);
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/audit/receipt-tip?hash=${hash}`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        requested: { hash, present: false, sequence: null, isCurrent: false },
+      });
+    });
+
+    it('rejects a malformed requested hash', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/audit/receipt-tip?hash=not-a-hash',
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'invalid_receipt_hash' });
+    });
+
+    it('is authenticated when the API has a token registry', async () => {
+      const protectedDb = createTestDatabase();
+      const protectedApp = buildApp({
+        db: protectedDb,
+        silent: true,
+        apiKey: 'receipt-reader-token',
+      });
+      try {
+        await protectedApp.ready();
+        const rejected = await protectedApp.inject({
+          method: 'GET',
+          url: '/api/audit/receipt-tip',
+        });
+        expect(rejected.statusCode).toBe(401);
+
+        const accepted = await protectedApp.inject({
+          method: 'GET',
+          url: '/api/audit/receipt-tip',
+          headers: { Authorization: 'Bearer receipt-reader-token' },
+        });
+        expect(accepted.statusCode).toBe(200);
+      } finally {
+        await protectedApp.close();
+        protectedDb.close();
+      }
+    });
+
+    it('fails closed without publishing a tip when the chain has a tamper signature', async () => {
+      auditRepo.insert(makeEvent({ reason: 'original reason' }));
+      db.prepare("UPDATE audit_events SET reason = 'rewritten reason'").run();
+
+      const res = await app.inject({ method: 'GET', url: '/api/audit/receipt-tip' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({
+        current: null,
+        requested: null,
+        error: 'audit_chain_tamper_detected',
+        integrity: { status: 'tamper_signatures_detected', tamperBreaks: 1 },
+      });
+    });
+  });
 });

--- a/apps/api/src/__tests__/openapi.test.ts
+++ b/apps/api/src/__tests__/openapi.test.ts
@@ -35,6 +35,7 @@ describe('GET /openapi.json', () => {
     expect(spec.paths).toBeDefined();
     expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining(['/api/candidates']));
     expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining(['/api/memories']));
+    expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining(['/api/audit/receipt-tip']));
 
     // Tag metadata should be propagated from route schemas.
     const tagNames = (spec.tags ?? []).map((t) => t.name);

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from 'fastify';
-import type { AuditRepository } from '@qmd-team-intent-kb/store';
+import { type AuditRepository, verifyAuditChain } from '@qmd-team-intent-kb/store';
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
 
 /**
  * Register audit event query routes.
@@ -14,6 +16,88 @@ import type { AuditRepository } from '@qmd-team-intent-kb/store';
  * `memoryId` / `action` query returned rows regardless of ownership.
  */
 export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository): void {
+  app.get(
+    '/api/audit/receipt-tip',
+    {
+      schema: {
+        tags: ['audit'],
+        summary: 'Read or resolve the global governance receipt-chain tip',
+        description:
+          'Authenticated, content-safe receipt pointer for AGP cross-chain correlation. ' +
+          'Optional `hash` resolves a previously observed tip after the chain advances. ' +
+          'This proves chain position, not which search results an agent read.',
+      },
+    },
+    async (request, reply) => {
+      const { hash } = request.query as { hash?: unknown };
+      if (hash !== undefined && (typeof hash !== 'string' || !SHA256_HEX.test(hash))) {
+        return reply.code(400).send({
+          error: 'invalid_receipt_hash',
+          message: 'hash must be a lowercase SHA-256 hex value',
+        });
+      }
+
+      const verification = verifyAuditChain(repo);
+      const tamperBreaks = verification.breaks.filter((finding) => finding.reason !== 'CHAIN_FORK');
+      const orderingForks = verification.breaks.length - tamperBreaks.length;
+      const integrity = {
+        status:
+          tamperBreaks.length === 0
+            ? ('no_tamper_signatures' as const)
+            : ('tamper_signatures_detected' as const),
+        checkedRows: verification.cleanRows,
+        unverifiedRows: verification.unverifiedRows,
+        orderingForks,
+        tamperBreaks: tamperBreaks.length,
+      };
+
+      // Fail closed: never give an agent a tip to sign into a new action when
+      // the current receipt chain has a tamper signature.
+      if (tamperBreaks.length > 0) {
+        return reply.code(503).send({
+          schemaVersion: 1,
+          chain: 'audit_events',
+          scope: 'global-governance-receipt-chain',
+          hashAlgorithm: 'sha256',
+          current: null,
+          requested: null,
+          integrity,
+          error: 'audit_chain_tamper_detected',
+        });
+      }
+
+      const currentPosition = repo.findChainTip();
+      const current =
+        currentPosition === null
+          ? null
+          : {
+              hash: currentPosition.entryHash,
+              sequence: currentPosition.sequence,
+              hashVersion: currentPosition.hashVersion,
+            };
+      const requestedPosition = typeof hash === 'string' ? repo.findChainPosition(hash) : null;
+      const requested =
+        typeof hash !== 'string'
+          ? null
+          : {
+              hash,
+              present: requestedPosition !== null,
+              sequence: requestedPosition?.sequence ?? null,
+              isCurrent: current?.hash === hash,
+            };
+
+      return reply.send({
+        schemaVersion: 1,
+        chain: 'audit_events',
+        scope: 'global-governance-receipt-chain',
+        hashAlgorithm: 'sha256',
+        current,
+        requested,
+        integrity,
+      });
+    },
+  );
+
   app.get(
     '/api/audit',
     {

--- a/packages/store/src/__tests__/audit-repository.test.ts
+++ b/packages/store/src/__tests__/audit-repository.test.ts
@@ -76,6 +76,20 @@ describe('AuditRepository', () => {
     expect(found[0]?.action).toBe('promoted');
     expect(found[1]?.action).toBe('archived');
   });
+
+  it('preserves an explicit future hash version in content-safe chain positions', () => {
+    repo.insert(makeAuditEvent({ memoryId: randomUUID() }));
+    const original = repo.findChainTip();
+    expect(original).not.toBeNull();
+
+    db.prepare('UPDATE audit_events SET hash_version = ? WHERE entry_hash = ?').run(
+      3,
+      original?.entryHash,
+    );
+
+    expect(repo.findChainTip()?.hashVersion).toBe(3);
+    expect(repo.findChainPosition(original?.entryHash ?? '')?.hashVersion).toBe(3);
+  });
 });
 
 describe('AuditRepository — aggregation queries', () => {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -16,7 +16,7 @@ export type {
 } from './repositories/memory-repository.js';
 export { PolicyRepository } from './repositories/policy-repository.js';
 export { AuditRepository } from './repositories/audit-repository.js';
-export type { AuditChainRow } from './repositories/audit-repository.js';
+export type { AuditChainPosition, AuditChainRow } from './repositories/audit-repository.js';
 export { verifyAuditChain, type AuditVerifyResult, type AuditChainBreak } from './audit-verify.js';
 export { computeEntryHash, canonicalRowJson, CURRENT_AUDIT_HASH_VERSION } from './audit-chain.js';
 export type { CanonicalAuditRow, AuditHashVersion } from './audit-chain.js';

--- a/packages/store/src/repositories/audit-repository.ts
+++ b/packages/store/src/repositories/audit-repository.ts
@@ -52,6 +52,27 @@ export interface AuditChainRow {
   hash_version: number | null;
 }
 
+/** Content-safe position of one hash in the global governance receipt chain. */
+export interface AuditChainPosition {
+  entryHash: string;
+  sequence: number;
+  hashVersion: AuditHashVersion;
+}
+
+interface AuditChainPositionRow {
+  entry_hash: string;
+  seq: number;
+  hash_version: number | null;
+}
+
+function rowToChainPosition(row: AuditChainPositionRow): AuditChainPosition {
+  return {
+    entryHash: row.entry_hash,
+    sequence: row.seq,
+    hashVersion: row.hash_version === 2 ? 2 : 1,
+  };
+}
+
 /**
  * Parse a raw SQLite row into a validated AuditEvent domain object.
  * Throws a descriptive error if the row fails validation.
@@ -127,6 +148,8 @@ export class AuditRepository {
   private readonly stmtFindInRange: Database.Statement;
   private readonly stmtCountByTenantAndAction: Database.Statement;
   private readonly stmtLastHash: Database.Statement;
+  private readonly stmtFindChainTip: Database.Statement;
+  private readonly stmtFindChainPosition: Database.Statement;
   private readonly stmtFindAllChronological: Database.Statement;
   /** Atomic (BEGIN IMMEDIATE) prev-read + INSERT — see the constructor. */
   private readonly appendTxn: Database.Transaction<(p: AppendParams) => void>;
@@ -158,6 +181,20 @@ export class AuditRepository {
       SELECT entry_hash FROM audit_events
       WHERE entry_hash IS NOT NULL
       ORDER BY seq DESC
+      LIMIT 1
+    `);
+
+    // Content-safe receipt-pointer reads. These expose only the chain hash and
+    // write-order position — never tenant, actor, reason, or memory content.
+    this.stmtFindChainTip = db.prepare(`
+      SELECT entry_hash, seq, hash_version FROM audit_events
+      WHERE entry_hash IS NOT NULL
+      ORDER BY seq DESC
+      LIMIT 1
+    `);
+    this.stmtFindChainPosition = db.prepare(`
+      SELECT entry_hash, seq, hash_version FROM audit_events
+      WHERE entry_hash = ?
       LIMIT 1
     `);
 
@@ -280,6 +317,18 @@ export class AuditRepository {
    */
   findAllChronological(): AuditChainRow[] {
     return this.stmtFindAllChronological.all() as AuditChainRow[];
+  }
+
+  /** Return the current global governance-receipt chain tip, or null for an empty chain. */
+  findChainTip(): AuditChainPosition | null {
+    const row = this.stmtFindChainTip.get() as AuditChainPositionRow | undefined;
+    return row === undefined ? null : rowToChainPosition(row);
+  }
+
+  /** Resolve a previously observed receipt hash to its stable chain position. */
+  findChainPosition(entryHash: string): AuditChainPosition | null {
+    const row = this.stmtFindChainPosition.get(entryHash) as AuditChainPositionRow | undefined;
+    return row === undefined ? null : rowToChainPosition(row);
   }
 
   /**

--- a/packages/store/src/repositories/audit-repository.ts
+++ b/packages/store/src/repositories/audit-repository.ts
@@ -56,7 +56,7 @@ export interface AuditChainRow {
 export interface AuditChainPosition {
   entryHash: string;
   sequence: number;
-  hashVersion: AuditHashVersion;
+  hashVersion: number;
 }
 
 interface AuditChainPositionRow {
@@ -69,7 +69,10 @@ function rowToChainPosition(row: AuditChainPositionRow): AuditChainPosition {
   return {
     entryHash: row.entry_hash,
     sequence: row.seq,
-    hashVersion: row.hash_version === 2 ? 2 : 1,
+    // NULL predates the version column and therefore means v1. Preserve any
+    // future explicit value so this public pointer surface never launders an
+    // unknown version into a known one.
+    hashVersion: row.hash_version ?? 1,
   };
 }
 


### PR DESCRIPTION
## What

- add authenticated GET /api/audit/receipt-tip for the current global audit_events hash and sequence
- allow a prior lowercase SHA-256 tip to be resolved after the chain advances
- verify the full receipt chain before answering and fail closed without publishing a tip when tamper signatures are present
- preserve unknown future hash-version values rather than silently coercing them
- document that this is a governance-state pointer, not an exact search read-set receipt

## Why

The AGP signed journal-event contract defines gsb_receipt_tip_hash, but the registrar had no stable read surface for minting or resolving that pointer. This adds the registrar half without overstating what the pointer proves.

## Verification

- pnpm validate
- 203 test files passed, 1 skipped
- 2468 tests passed, 2 skipped
- focused audit, repository, and OpenAPI suite after review hardening: 32 tests passed

## Bead

qmd-team-intent-kb-1fx

## Residual boundary

Exact qmd result-set proof is out of scope for this endpoint, which exposes only chain position. The discovered follow-up is qmd-team-intent-kb-sdg.