### PR TITLE
docs(skills): harden Registrar runtime contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened the three public skills for skills.sh: `brain`, `brain-save`, and `teamkb` now distinguish
+  the shipped read-only `intent-brain` client from the source-built local operator server, document
+  the real authentication and storage boundaries, use explicit model/effort metadata and runtime
+  references, and report spool writes as proposals rather than promotions. `teamkb` is now a bounded,
+  self-contained workflow that requires explicit approval before importing up to 20 Markdown files.
 - **`bulk_import` candidates are stamped low-trust at the schema boundary (`5bm.8`).** A
   `bulk_import` candidate must now carry `trustLevel` `low` or `untrusted` (the default `medium` is
   refused by `MemoryCandidate`), so a whole-machine digestion can never claim curated-grade trust and

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -32,7 +32,8 @@ export interface McpServerConfig {
   /**
    * Install role. `admin` registers write tools (propose/import/transition/
    * vault) — "Jeremy-only promote". `member` (default) gets read tools only.
-   * Client-side UX gate; the brain API enforces the same boundary server-side.
+   * Client-side capability gate for local writes. The write tools do not call
+   * the brain API; local filesystem permissions are the security boundary.
    */
   role?: 'admin' | 'member';
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -21,9 +21,10 @@ const VERSION = '0.1.0';
  * (propose, import, transition, vault_*) register only for admin installs —
  * "Jeremy-only promote", mirroring the `withSync` conditional-registration
  * pattern. `canWrite` defaults to `config.role === 'admin'`. This is a
- * client-side UX gate (members never see tools they can't use); the brain API
- * enforces the same boundary server-side, so it holds even if a member
- * mis-sets their role.
+ * client-side capability gate (members never see tools they can't use). These
+ * write tools operate directly on the local spool and SQLite database; they do
+ * not call the brain API. Local filesystem permissions are the write security
+ * boundary.
  *
  * Call `isQmdAvailable()` first if you want to conditionally register sync.
  */

--- a/skills/brain-save/SKILL.md
+++ b/skills/brain-save/SKILL.md
@@ -1,125 +1,126 @@
 ---
 name: brain-save
 description: |
-  Saves a single fact, decision, pattern, or convention into the governed knowledge brain so it can be
-  recalled later — and (for admins) retires memories that are outdated. Admin-only and side-effecting:
-  it writes to the governed corpus, so it never auto-fires — invoke it explicitly. Use when an admin
-  wants the brain to remember something specific going forward without a full recompile, or to mark an
-  old memory outdated. Trigger with "/brain-save".
-allowed-tools: 'mcp__teamkb__teamkb_propose, mcp__teamkb__teamkb_transition, mcp__teamkb__teamkb_status'
-version: 1.0.0
+  Create and manage one governed Registrar memory by proposing a durable fact or
+  applying a supported lifecycle transition. This is a local operator write and
+  never auto-fires. Use when an administrator needs to preserve one team fact or
+  retire an outdated memory. Trigger with "/brain-save".
+allowed-tools: 'mcp__teamkb__teamkb_search, mcp__teamkb__teamkb_propose, mcp__teamkb__teamkb_transition, mcp__teamkb__teamkb_status'
+version: 1.1.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 license: Apache-2.0
-compatibility: 'Designed for Claude Code; requires the intent-brain plugin installed with admin role (TEAMKB_ROLE=admin)'
-tags: [brain, governance, save, capture, admin]
-argument-hint: '[save <fact> | retire <memory-id>]'
+compatibility: 'Designed for Claude Code operators running the built Registrar apps/mcp-server with TEAMKB_TENANT_ID, TEAMKB_BASE_PATH, and TEAMKB_ROLE=admin. The shipped intent-brain marketplace plugin is read-only and does not expose these write tools.'
+tags: [brain, governance, save, capture, admin, registrar]
+argument-hint: '[save <fact> | retire <memory-id> | status]'
 disable-model-invocation: true
+model: inherit
+effort: medium
 ---
 
-# Brain Save — write a fact into the brain (admin only)
+# Brain Save — write one local Registrar memory proposal
 
-This is the **write** side of the brain. `/brain` reads; `/brain-save` writes. Use it to tell the brain
-to remember a specific fact going forward — without re-running a full compile — or to retire a memory
-that's no longer true.
+Propose one fact to the local Registrar spool or apply one supported lifecycle transition. Never claim
+that a queued proposal is already governed or searchable.
 
 ## Overview
 
-The brain learns in two ways: the bulk **compile** ingests a whole corpus at once, and `/brain-save`
-adds (or retires) a **single** item on demand. Either way, governance stays in code: this skill
-_proposes_ a memory to the deterministic curator, which decides what actually gets stored after policy
-checks (dedupe, secret-detection). You are saving an item for the brain to keep, not bypassing the
-governance pipeline.
-
-## Why this never auto-fires
-
-`disable-model-invocation: true` means Claude will not trigger this from conversation — it runs only
-when you explicitly type it. Writing to the _shared company brain_ is a deliberate act, not a chat side
-effect. The brain API **also** enforces this server-side: the write tools succeed only for an admin
-token, returning `403` otherwise. This skill is the convenient front door; the server is the real gate.
+This is the full Registrar operator surface, not the read-only `intent-brain` marketplace runtime and
+not the unified `governed-second-brain` plugin. `teamkb_propose`, `teamkb_transition`, and
+`teamkb_status` operate on the local paths configured for `apps/mcp-server`, even when remote search is
+configured. Keep `TEAMKB_API_URL` unset when the search and write sides must address the same brain.
 
 ## Prerequisites
 
-- The `intent-brain` plugin is installed with **admin** role (`TEAMKB_ROLE=admin`), so the write MCP
-  tools are registered. A member install never sees them.
-- Team mode: the admin's per-user `TEAMKB_API_TOKEN` must carry the admin role, or the brain API
-  rejects the write with `403`.
-
-## Authentication
-
-In team mode the write tools reach the brain API over the tailnet with the admin's per-user bearer
-token (`TEAMKB_API_TOKEN`), sent as an `Authorization: Bearer` header. A member token is rejected
-server-side with `403`. Never hardcode the token; supply it via env or a `headersHelper`. In local
-mode no token is needed.
+- Build and configure `apps/mcp-server` from this repository.
+- Set `TEAMKB_TENANT_ID`, `TEAMKB_BASE_PATH`, and `TEAMKB_ROLE=admin`.
+- Protect the local base path with operating-system permissions; `TEAMKB_ROLE=admin` is a tool
+  registration gate, not remote authentication.
+- Read [the runtime contract](references/runtime-contract.md) before operating mixed local/remote mode.
 
 ## Instructions
 
 ### Save a new fact
 
-1. Confirm it's worth keeping — _"Would a new teammate benefit from finding this in 30 days?"_ Skip
-   ephemeral debugging steps, personal preferences, secrets, or anything already in a CLAUDE.md/README.
-2. Pick a category: `decision`, `pattern`, `convention`, `architecture`, `troubleshooting`,
-   `onboarding`, or `reference`.
-3. Call **`teamkb_propose`** with `{ title, content, category, filePaths? }`. It writes to the spool;
-   the curator promotes it after policy checks.
+1. Search first with `teamkb_search({ query: "KEY_TERMS", scope: "all" })`. If existing governed
+   content already covers the fact, stop instead of duplicating it.
+2. Exclude ephemeral debugging, personal preferences, secrets, credentials, and facts already
+   maintained in authoritative project documentation.
+3. Choose `decision`, `pattern`, `convention`, `architecture`, `troubleshooting`, `onboarding`, or
+   `reference`.
+4. Call `teamkb_propose` with `{ title, content, category, filePaths? }`.
+5. Report the returned `candidateId` as queued to the local spool. Promotion happens only when the
+   separate curator processes it; this skill does not run or prove that step.
 
-### Retire an outdated memory
+### Retire or restore a memory
 
-1. Find the memory's UUID (via `/brain` search or `teamkb_status`).
-2. Call **`teamkb_transition`** with `{ memoryId, to, reason, actor }`. Valid moves:
-   `active → {deprecated, superseded, archived}`, `deprecated → {active, archived}`,
-   `superseded → archived`. Every transition writes a hash-chained audit event.
+1. Search for the memory and extract its UUID from a UUID-shaped citation filename such as
+   `qmd://kb-curated/9c2e42f1-7b60-4ed2-a9dd-648d6c786d43.md`.
+2. Call `teamkb_transition` with `{ memoryId, to, reason, actor }`.
+3. Use only transitions the current tool can complete safely: `active` to `deprecated` or `archived`,
+   `deprecated` to `active` or `archived`, and `superseded` to `archived`.
+4. Do not request `active` to `superseded` through this version of the MCP tool; its input surface
+   cannot supply the required replacement-memory link.
 
-### Check brain health
+### Check local status
 
-Call **`teamkb_status`** to see counts by lifecycle state and recent rejection feedback before or after
-a batch of saves.
+Call `teamkb_status` for local database counts and recent governance feedback. Status does not list
+spool proposals and cannot confirm that a newly queued candidate has been promoted.
 
 ## Output
 
-- After a save: report the returned `candidateId` and that it is queued for governance review.
-- After a retire: report the new lifecycle state and confirm an audit event was written.
-- After a status check: summarize counts by lifecycle state and any recent rejections.
+- Save: candidate UUID, local-spool disposition, and an explicit “not yet promoted” statement.
+- Transition: memory UUID, old and new lifecycle states, and audit-event UUID.
+- Status: counts by lifecycle/category/tenant and recent feedback, without printing `dbPath` unless the
+  operator explicitly requests it.
 
 ## Examples
 
-**Save a decision:**
+```text
+teamkb_search({ query: "Apache license", scope: "all" })
+teamkb_propose({
+  title: "License: Apache-2.0 across public engines",
+  content: "The public engines use Apache-2.0.",
+  category: "decision"
+})
 
+Candidate 4f3a2e0e-0ee4-4f63-b63e-22306c45115a was queued locally. It is not governed memory until the
+curator processes it.
 ```
-/brain-save we're going Apache-2.0 on both flagships so the public can self-host.
 
-→ teamkb_propose({ title: "License: Apache-2.0 on both flagships",
-                   content: "...", category: "decision" })
-→ Saved as candidate 4f3a… — queued for governance review.
-```
+```text
+teamkb_transition({
+  memoryId: "9c2e42f1-7b60-4ed2-a9dd-648d6c786d43",
+  to: "deprecated",
+  reason: "Replaced by the current deployment runbook",
+  actor: "registrar-operator"
+})
 
-**Retire a superseded memory:**
-
-```
-/brain-save retire memory 9c2e… — superseded by the new deploy runbook.
-
-→ teamkb_transition({ memoryId: "9c2e…", to: "archived",
-                      reason: "Superseded by the new deploy runbook", actor: "jeremy" })
-→ Memory 9c2e… → archived; audit event written.
+Memory 9c2e42f1-7b60-4ed2-a9dd-648d6c786d43 moved from active to deprecated; audit event
+83e1bc9a-0048-44e7-b70b-52bc7cf6e954 recorded the transition.
 ```
 
 ## Error Handling
 
-| Situation                            | Response                                                                                |
-| ------------------------------------ | --------------------------------------------------------------------------------------- |
-| Write returns `403`                  | The token is not an admin token. The gate working as designed — do not route around it. |
-| Write tools are absent               | The install is `member` role; only an `admin` install registers them.                   |
-| `teamkb_transition` rejects the move | The lifecycle state machine forbids it; pick a valid target state.                      |
-| Content may contain a secret         | Stop and strip it. Do not rely on the pipeline's secret-detection as the only check.    |
+| Situation                        | Response                                                                                            |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Write tools are absent           | The read-only plugin or member role is active; use the built local server with `TEAMKB_ROLE=admin`. |
+| Spool write fails                | Report the error; do not claim the candidate was queued.                                            |
+| Transition ID is not UUID-shaped | Stop and obtain an exact ID from a returned citation.                                               |
+| Transition is rejected           | Report the state-machine reason; do not route around it.                                            |
+| Content may contain a secret     | Strip it before calling `teamkb_propose`; policy scanning is not the only control.                  |
 
 ## Guardrails
 
-- Never save content containing secrets, tokens, or credentials.
-- `reason` on a retire must be a real, human-readable justification — it lands in the permanent audit
-  trail.
-- A `403` is the system working as designed, not a bug to work around.
+- Never persist secrets, tokens, credentials, or private keys.
+- Require a human-readable transition reason and a truthful actor identifier.
+- Local filesystem access is the security boundary for writes; a bearer token does not authorize this
+  tool path.
+- Provenance proves capture origin, not factual truth.
 
 ## Resources
 
-- [Bob's Big Brain](https://github.com/intent-solutions-io/bobs-big-brain-umbrella) — the stack and its governance thesis.
-- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar) — the governance plane (this plugin's home).
-- The read counterpart: the `/brain` skill (cited, member-safe queries).
+- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar) — source,
+  build instructions, and operator documentation.
+- [`apps/mcp-server`](https://github.com/jeremylongshore/bobs-big-brain-registrar/tree/main/apps/mcp-server) —
+  the required full operator runtime.
+- `brain` — read counterpart using the Registrar-native `teamkb_search` tool.

--- a/skills/brain-save/SKILL.md
+++ b/skills/brain-save/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: brain-save
 description: |
-  Create and manage one governed Registrar memory by proposing a durable fact or
-  applying a supported lifecycle transition. This is a local operator write and
-  never auto-fires. Use when an administrator needs to preserve one team fact or
-  retire an outdated memory. Trigger with "/brain-save".
+  Create one Registrar memory proposal or apply a supported lifecycle transition
+  to an existing memory. This is a local operator write and never auto-fires. Use
+  when an administrator needs to preserve one team fact or retire an outdated
+  memory. Trigger with "/brain-save".
 allowed-tools: 'mcp__teamkb__teamkb_search, mcp__teamkb__teamkb_propose, mcp__teamkb__teamkb_transition, mcp__teamkb__teamkb_status'
 version: 1.1.0
 author: Intent Solutions <jeremy@intentsolutions.io>

--- a/skills/brain-save/references/runtime-contract.md
+++ b/skills/brain-save/references/runtime-contract.md
@@ -41,4 +41,5 @@ deduplication, policy, and promotion.
 
 The current `teamkb_transition` surface cannot supply `supersededBy`, although domain validation
 requires that link for an `active` to `superseded` transition. Do not request that transition until the
-tracked runtime defect is fixed. The other state-machine transitions listed in the skill are supported.
+runtime defect tracked as Beads issue `qmd-team-intent-kb-ehi` is fixed. The other state-machine
+transitions listed in the skill are supported.

--- a/skills/brain-save/references/runtime-contract.md
+++ b/skills/brain-save/references/runtime-contract.md
@@ -1,0 +1,44 @@
+# Registrar Brain Save runtime contract
+
+## Contents
+
+- [Required runtime](#required-runtime)
+- [Tool contracts](#tool-contracts)
+- [Mixed-mode boundary](#mixed-mode-boundary)
+- [Security and known limitation](#security-and-known-limitation)
+
+## Required runtime
+
+The repository's shipped `intent-brain` marketplace runtime exposes only `teamkb_search`. Brain Save
+requires the source-built `apps/mcp-server` with `TEAMKB_ROLE=admin`. `TEAMKB_TENANT_ID` is required;
+`TEAMKB_BASE_PATH` selects the local spool, SQLite database, feedback, and export directories.
+
+## Tool contracts
+
+- `teamkb_search`: required `query`; optional `scope` and `limit`.
+- `teamkb_propose`: required `title` and `content`; optional `category` and `filePaths`. Success returns
+  a candidate UUID after a local spool write.
+- `teamkb_status`: no input. Returns local database counts, recent feedback, and `dbPath`.
+- `teamkb_transition`: required UUID `memoryId`, lifecycle `to`, non-empty `reason`, and non-empty
+  `actor`. Success returns old/new states and an audit-event UUID.
+
+`teamkb_status` reads curated database state and feedback. It does not inspect the spool, so it cannot
+confirm a proposal is governed or even visible to the curator yet.
+
+## Mixed-mode boundary
+
+With `TEAMKB_API_URL` set, `teamkb_search` queries the remote API, but propose, status, and transition
+still use local paths. This can create a split-brain operator workflow. Leave the API URL unset unless
+that split is intentional and clearly disclosed.
+
+`TEAMKB_ROLE=admin` controls which local tools register. It is a client-side capability gate, not an
+authentication credential. Protect the local base directory through operating-system permissions.
+
+## Security and known limitation
+
+`teamkb_propose` writes a proposal, not a promoted memory. A separate curator applies secret checks,
+deduplication, policy, and promotion.
+
+The current `teamkb_transition` surface cannot supply `supersededBy`, although domain validation
+requires that link for an `active` to `superseded` transition. Do not request that transition until the
+tracked runtime defect is fixed. The other state-machine transitions listed in the skill are supported.

--- a/skills/brain/SKILL.md
+++ b/skills/brain/SKILL.md
@@ -1,133 +1,117 @@
 ---
 name: brain
 description: |
-  Answers questions about Intent Solutions' own systems, decisions, runbooks, and
-  conventions from the governed knowledge brain, returning a qmd:// citation for
-  every claim — receipts, not recall. Use when a teammate asks what the team knows
-  about its own architecture, infrastructure, decisions, or conventions (e.g.
-  "what does our system map say about the Caddy block", "why did we pick Apache-2.0",
-  "how does the brain auth work", "what is our deploy runbook"). Trigger with "/brain",
-  "ask the brain", "what do we know about", "what does our system map say", or "check
-  the team knowledge base".
+  Search and analyze Intent Solutions' governed team memory through the Registrar,
+  returning qmd:// citations for supported claims. Use when checking recorded
+  architecture, infrastructure, decisions, runbooks, or conventions. Trigger with
+  "/brain", "ask the team brain", or "check the team knowledge base".
 allowed-tools: 'mcp__teamkb__teamkb_search'
-version: 1.0.0
+version: 1.1.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 license: Apache-2.0
-compatibility: 'Designed for Claude Code; requires the intent-brain plugin (auto-wires the teamkb MCP server)'
-tags: [brain, knowledge, search, citations, governance]
+compatibility: 'Designed for Claude Code; requires the Registrar intent-brain remote plugin with TEAMKB_API_URL and a per-user TEAMKB_API_TOKEN, or a locally built Registrar MCP server exposing teamkb_search. The shipped intent-brain marketplace runtime is remote and read-only.'
+tags: [brain, knowledge, search, citations, governance, registrar]
 argument-hint: '[question]'
+model: inherit
+effort: low
 ---
 
-# Brain — cited answers from the governed knowledge base
+# Brain — cite the Registrar's governed team memory
 
-Ask the Intent Solutions knowledge **brain** a question and get an answer grounded
-in the governed corpus, where **every claim carries a qmd:// citation**. The brain
-does not paraphrase from memory — it retrieves governed memories and cites them, so
-any answer is verifiable after the fact.
+Answer questions from the Registrar's governed corpus and attach a returned `qmd://` citation to every
+load-bearing claim. Refuse to present unsupported recall as team knowledge.
 
 ## Overview
 
-This is the read surface of the Compile-Then-Govern stack: ICO **compiles** raw
-material into governed memories, INTKB **governs** them, and qmd **retrieves** them
-with citations. The `teamkb_search` MCP tool fronts that retrieval. The job here is
-to turn a natural-language question into a cited answer — and to refuse to answer
-beyond what the citations support.
+The Registrar is the govern layer of Bob's Big Brain: the Compiler prepares candidate knowledge,
+deterministic policy decides what becomes durable, and qmd retrieves the governed result. This skill
+uses the Registrar-native `teamkb_search` surface. The unified `governed-second-brain` plugin exposes a
+different tool name, `brain_search`; do not mix the two contracts.
 
 ## Prerequisites
 
-- The `intent-brain` plugin is installed, which auto-wires the `teamkb` MCP server.
-- Team mode: `TEAMKB_API_URL` points at the brain on the dev box, and the teammate's
-  per-user `TEAMKB_API_TOKEN` is set. Local mode: neither is set, and search runs
-  against the local `~/.teamkb` index.
+- Install the public `intent-brain` plugin from this repository for remote, read-only search, or build
+  `apps/mcp-server` for the full local operator runtime.
+- For the shipped remote plugin, configure `TEAMKB_API_URL` and a per-user `TEAMKB_API_TOKEN`.
+- Read [the runtime contract](references/runtime-contract.md) for exact inputs, authentication, modes,
+  and failure ambiguity.
 
 ## Authentication
 
-In team mode, `teamkb_search` reaches the brain API over the tailnet with a per-user
-bearer token. The token is supplied as `TEAMKB_API_TOKEN` (set once via env or a
-`headersHelper` script) and is sent as an `Authorization: Bearer` header by the MCP
-server — never hardcode it in committed config. In local mode no token is needed;
-search runs in-process against the local qmd index. This skill never handles the
-token directly; it only calls the MCP tool, which carries the credential.
+The shipped remote client sends `TEAMKB_API_TOKEN` as an `Authorization: Bearer` header to
+`TEAMKB_API_URL`. Supply it through the plugin environment and never print, capture, or commit it. A
+locally built Registrar server can search a local index without API authentication.
 
 ## Instructions
 
-### Step 1: Search the governed corpus
+### Step 1: Search curated memory
 
-Call **`teamkb_search`** with the user's question as `query`. Keep `scope` at its
-default (`curated`) unless the user explicitly asks for inbox/archived material —
-curated is the governed, promoted knowledge.
+Derive 1–4 distinctive keywords from the question, dropping generic question words. Call
+`teamkb_search` with `scope: "curated"` and an optional `limit` from 1 through 50.
 
+```text
+teamkb_search({ query: "Caddy reverse proxy", scope: "curated", limit: 10 })
 ```
-teamkb_search({ query: "the user's question, lightly cleaned up", scope: "curated" })
-```
 
-The tool returns `{ source, results: [{ citation, snippet, score, collection }] }`.
-Each `citation` is a `qmd://COLLECTION/FILENAME` URI — the receipt for that hit.
+If the result is empty, retry the same keywords once with `scope: "all"`. Use `inbox`, `archived`, or
+`bulk` only when the user explicitly requests that uncurated, retired, or bulk-digestion material.
 
-### Step 2: Answer ONLY from the cited results
+### Step 2: Answer only from results
 
-- Synthesize a direct answer from the returned snippets.
-- **Attach the qmd:// citation to every claim**, inline — for example:
-  `The Caddy block reverse-proxies the API (qmd://kb-curated/system-map.md).`
-- If two hits conflict, surface both with their citations rather than silently
-  picking one — the governance layer tracks contradictions; do not paper over them.
-- **Do not add knowledge the citations do not support.** Any reasoning beyond the
-  corpus must be labeled clearly as inference, not the brain's answer.
+- Synthesize a short answer from returned snippets.
+- Attach the exact returned `qmd://` citation to each supported claim.
+- Surface conflicting results with both citations.
+- Label reasoning beyond the cited snippets as inference.
+- Never invent a citation or silently fill a gap with general knowledge.
 
-### Step 3: Handle an empty result honestly
+### Step 3: Handle no evidence
 
-If `results` is empty, say so plainly: the brain has nothing governed on that topic.
-Do **not** fall back to general knowledge and present it as the team's answer.
-Optionally note that the topic may need to be saved (an admin runs `/brain-save`).
+After the curated-to-all retry, state plainly that no governed evidence was found. The legacy remote
+client maps several transport and authorization failures to an empty result, so do not claim that an
+empty response proves the corpus lacks the fact; mention this limitation when the miss is unexpected.
 
 ## Output
 
-1. A short, direct answer.
-2. Each load-bearing claim followed by its qmd:// citation.
-3. A closing **Sources** list of the distinct qmd:// URIs used.
+1. Direct answer or honest no-evidence statement.
+2. Inline `qmd://` citation after every load-bearing claim.
+3. A **Sources** list containing each distinct citation used.
 
 ## Examples
 
-**Cited answer:**
+```text
+/brain what does the system map say about the reverse proxy?
 
-```
-/brain what does our system map say about the Caddy block?
-
-→ Caddy is the single ingress; it reverse-proxies each domain to its container
-  and must be reloaded, not restarted, after edits (qmd://kb-curated/system-map.md).
+The reverse proxy is the single ingress (qmd://kb-curated/9c2e42f1-7b60-4ed2-a9dd-648d6c786d43.md).
 
 Sources:
-- qmd://kb-curated/system-map.md
+- qmd://kb-curated/9c2e42f1-7b60-4ed2-a9dd-648d6c786d43.md
 ```
 
-**Empty result (honest refusal):**
+If both scopes return no results:
 
-```
-/brain what is our refund policy?
-
-→ The brain has nothing governed on a refund policy. I won't guess from general
-  knowledge. If this should be team knowledge, an admin can capture it with
-  /brain-save.
+```text
+No governed evidence was found for that topic. The legacy remote client can also return an empty set
+when the service or credential fails, so an operator should check connectivity if this miss is
+unexpected.
 ```
 
 ## Error Handling
 
-| Situation                                         | Response                                                                              |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `teamkb_search` returns empty `results`           | State the brain has nothing governed; do not fabricate.                               |
-| Tool reports `source: "brain-api"` with 0 results | The remote brain answered but had no match — treat as empty, not as an error.         |
-| MCP tool unavailable                              | The plugin/MCP server is not enabled; tell the user to install/enable `intent-brain`. |
-| User asks to write/capture                        | Out of scope here — direct them to `/brain-save` (admin-only).                        |
+| Situation                  | Response                                                                                                   |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `source` is `unconfigured` | Configure `TEAMKB_API_URL`; do not describe this as an empty corpus.                                       |
+| Empty `brain-api` result   | Complete the scope retry, then state no evidence was returned and note the legacy ambiguity when relevant. |
+| Tool is unavailable        | Enable the Registrar `intent-brain` plugin or locally built `teamkb` MCP server.                           |
+| User asks to write         | This skill is read-only; use the Registrar operator `brain-save` skill only with the full local server.    |
 
 ## Guardrails
 
-- Read-only. This skill never writes to the corpus — capture and promotion are
-  admin-only (`/brain-save`).
-- Never invent a qmd:// URI. Cite only URIs returned by `teamkb_search`.
-- Prefer fewer, well-cited claims over a broad answer that cannot be anchored.
+- Treat inbox, archive, and bulk results as explicitly requested context, not curated truth.
+- Provenance identifies where a capture came from; it does not prove the content is true.
+- Prefer a narrow cited answer over a broad unsupported one.
 
 ## Resources
 
-- [Bob's Big Brain](https://github.com/intent-solutions-io/bobs-big-brain-umbrella) — the stack this brain belongs to.
-- [Bob's Big Brain Compiler](https://github.com/jeremylongshore/bobs-big-brain-compiler) — the compiler (ICO).
-- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar) — the governance + retrieval plane (this plugin's home).
+- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar)
+- [Bob's Big Brain umbrella](https://github.com/intent-solutions-io/bobs-big-brain-umbrella)
+- [tobi/qmd](https://github.com/tobi/qmd), the attributed retrieval engine

--- a/skills/brain/references/runtime-contract.md
+++ b/skills/brain/references/runtime-contract.md
@@ -1,0 +1,42 @@
+# Registrar brain runtime contract
+
+## Contents
+
+- [Search input](#search-input)
+- [Runtime variants](#runtime-variants)
+- [Result interpretation](#result-interpretation)
+- [Authentication and failures](#authentication-and-failures)
+
+## Search input
+
+`teamkb_search` accepts a required non-empty `query`, optional `scope`, and optional integer `limit`
+from 1 through 50. Scope is `curated`, `all`, `inbox`, `archived`, or `bulk`; the default is
+`curated`.
+
+## Runtime variants
+
+The repository's shipped `.mcp.json` starts `plugin-runtime/teamkb-remote.cjs`. That client exposes
+only `teamkb_search` and always calls the configured brain API. It is not the newer unified
+`governed-second-brain` plugin, whose corresponding tool is named `brain_search`.
+
+The source-built `apps/mcp-server` exposes the broader Registrar operator surface. Its search tool
+uses the API when `TEAMKB_API_URL` is configured and otherwise queries the local qmd index.
+
+## Result interpretation
+
+A search result contains `source`, `query`, `scope`, `count`, and `results`. Hits can include
+`citation`, `snippet`, `score`, `title`, and `collection`. Only returned citations may support an
+answer.
+
+The remote client returns `source: unconfigured` when no API URL exists. Successful requests and most
+other failures use `source: brain-api`; authorization failures, non-2xx responses, malformed network
+paths, and transport exceptions currently collapse to an empty result. This legacy ambiguity means an
+empty remote result does not prove the corpus is empty.
+
+## Authentication and failures
+
+The remote client reads `TEAMKB_API_TOKEN` and sends it as a bearer token. The source-built local
+search path needs no API credential. Never expose a token in a query, answer, log excerpt, or capture.
+
+When a remote miss is unexpected, report the ambiguity and ask an operator to validate service health
+and credentials. Do not fabricate a result or claim an outage that the tool response cannot prove.

--- a/skills/teamkb/SKILL.md
+++ b/skills/teamkb/SKILL.md
@@ -1,135 +1,137 @@
 ---
 name: teamkb
 description: |
-  Runs an end-of-session capture sweep for the governed knowledge brain: reviews what
-  happened, classifies insights, checks for conflicts, and proposes governed memories
-  via the teamkb MCP tools. Admin capture workflow that complements the one-shot
-  /brain-save. Use when wrapping up a session with team-relevant discoveries, or
-  when importing existing docs into the brain. Trigger with "/teamkb", "capture this
-  session", or "sweep for team knowledge".
-allowed-tools: 'Read, Glob, Grep, Agent'
-version: 1.0.0
+  Review, classify, and capture a bounded set of team insights or explicitly
+  approved Markdown files through the local Registrar operator tools. This is
+  side-effecting and never auto-fires. Use when closing a session, importing a
+  small document batch, reviewing existing memory, or checking local brain status.
+  Trigger with "/teamkb", "capture this session", or "import these team docs".
+allowed-tools: 'Read, Glob, Grep, AskUserQuestion, mcp__teamkb__teamkb_search, mcp__teamkb__teamkb_propose, mcp__teamkb__teamkb_import, mcp__teamkb__teamkb_status'
+version: 1.1.0
 author: Intent Solutions <jeremy@intentsolutions.io>
 license: Apache-2.0
-compatibility: 'Designed for Claude Code; requires the intent-brain plugin with admin role (TEAMKB_ROLE=admin) for the write tools'
-tags: [brain, capture, governance, knowledge, admin]
-argument-hint: '[capture | import | status | review]'
+compatibility: 'Designed for Claude Code operators running the built Registrar apps/mcp-server with TEAMKB_TENANT_ID, TEAMKB_BASE_PATH, and TEAMKB_ROLE=admin. The shipped intent-brain marketplace plugin is read-only and does not expose capture or import tools.'
+tags: [brain, capture, governance, knowledge, admin, registrar]
+argument-hint: '[capture | import GLOB | review QUERY | status]'
+disable-model-invocation: true
+model: inherit
+effort: medium
 ---
 
-# TeamKB — governed team-knowledge capture sweep
+# TeamKB — bounded local Registrar capture
 
-Capture team memory at the end of a session: review what happened, classify the
-insights worth keeping, check them against existing memories for conflicts, and queue
-them for governance review. This is the multi-step, subagent-driven capture workflow
-that sits alongside the one-shot `/brain-save`.
+Turn a small, explicit set of durable team insights into local spool proposals. Search before capture,
+inspect imports before writing, and report proposals as ungoverned until the curator disposes them.
 
 ## Overview
 
-The brain captures knowledge, validates it through deterministic governance policies,
-and shares it across the team via qmd. This skill drives the **capture** side: it uses
-the `teamkb` MCP tools to propose candidates (never writing governed state directly —
-the curator promotes after policy checks) and delegates the judgment-heavy steps to
-specialized subagents.
+This self-contained operator workflow uses the full locally built Registrar MCP server. It does not
+depend on repository subagents, and it does not work with the read-only `intent-brain` marketplace
+runtime. Capture and import write candidate files to the local spool; deterministic governance and
+promotion happen later in the curator.
 
 ## Prerequisites
 
-- The `intent-brain` plugin is installed with **admin** role (`TEAMKB_ROLE=admin`), so
-  the write MCP tools (`teamkb_propose`, `teamkb_status`) are registered. A member
-  install is read-only and cannot capture.
-- For conflict checking, the brain has an existing corpus to compare against.
+- Build and configure `apps/mcp-server` from the Registrar repository.
+- Set `TEAMKB_TENANT_ID`, `TEAMKB_BASE_PATH`, and `TEAMKB_ROLE=admin`.
+- Keep `TEAMKB_API_URL` unset when search and writes must target the same local brain.
+- Read [the runtime contract](references/runtime-contract.md) for exact bounds and result semantics.
 
-## Authentication
+## Modes
 
-In team mode, the write tools reach the brain API over the tailnet with the admin's
-per-user bearer token (`TEAMKB_API_TOKEN`), sent as an `Authorization: Bearer` header.
-A non-admin token is rejected server-side with `403`. Never hardcode the token; supply
-it via env or a `headersHelper`. In local mode no token is needed.
-
-## Available MCP tools
-
-- **teamkb_propose** — capture a single insight as a candidate `{ title, content, category?, filePaths? }`. Writes to the spool; the governance pipeline decides promotion.
-- **teamkb_import** — bulk-import files as candidates `{ glob, basePath? }`.
-- **teamkb_status** — counts by lifecycle state, category, and recent rejection feedback.
-- **teamkb_transition** — change a memory's lifecycle state `{ memoryId, to, reason, actor }`.
+- `capture`: distill up to five durable insights from the current session and explicitly supplied
+  files, then propose only new content.
+- `import GLOB`: inspect and explicitly approve 1–20 Markdown files before `teamkb_import` queues them.
+- `review QUERY`: search only; make no writes.
+- `status`: call `teamkb_status`; make no writes.
 
 ## Instructions
 
-### Step 1: Review the session
+### Capture a session
 
-Use `Read`, `Glob`, and `Grep` to gather what changed and what was decided — the diff,
-the files touched, and any decisions stated in the conversation. Delegate the sweep to
-the **@teamkb-scout** subagent (via `Agent`) when the session is large.
+1. Review the conversation and use `Read`, `Glob`, or `Grep` only on files the user placed in scope.
+2. Select at most five items that would help a teammate after 30 days. Classify each as `decision`,
+   `pattern`, `convention`, `architecture`, `troubleshooting`, `onboarding`, or `reference`.
+3. Reject ephemeral steps, personal preferences, secrets, and facts already maintained in an
+   authoritative README or project instruction file.
+4. For each candidate, call `teamkb_search` with 1–4 keywords and `scope: "all"`. Skip covered facts;
+   surface contradictions instead of creating a competing memory.
+5. Call `teamkb_propose` once for each surviving item. The returned candidate UUID proves only that
+   the local spool write succeeded.
 
-### Step 2: Classify each candidate insight
+### Import Markdown files
 
-Recognize capturable moments and assign a category:
+1. Require an explicit base directory and glob. Refuse a home directory, repository root, hidden
+   credential directory, or an unresolved environment variable as the base.
+2. Use `Glob` to resolve the exact set. Accept 1–20 `.md` files; require the user to split larger
+   batches.
+3. Use `Grep` for common secret markers and `Read` any suspicious file. Exclude credentials, tokens,
+   private keys, environment dumps, and empty files.
+4. Show the final relative file list and use `AskUserQuestion` for explicit confirmation because
+   `teamkb_import` writes every match to the spool.
+5. Call `teamkb_import({ glob, basePath })` exactly once. Report `queued`, `failed`, and every failed
+   file from `outcomes`; never claim promotion.
 
-1. Decisions made ("Let's use X instead of Y because…") → `decision`
-2. Patterns discovered ("This pattern works well for…") → `pattern`
-3. Conventions agreed ("We should always…") → `convention`
-4. Architecture documented ("The data flows from…") → `architecture`
-5. Bugs solved ("The root cause was…") → `troubleshooting`
-6. Setup documented ("To get this running…") → `onboarding`
+### Review or status
 
-Delegate ambiguous content to **@teamkb-classifier**.
-
-### Step 3: Check for conflicts
-
-Before proposing, delegate to **@teamkb-conflict-checker** to compare each candidate
-against existing memories. Surface conflicts rather than creating duplicates or
-contradictions — the governance layer tracks contradictions explicitly.
-
-### Step 4: Propose
-
-For each surviving candidate, call `teamkb_propose`. Then call `teamkb_status` to
-confirm the candidates landed and review any recent rejection feedback.
-
-## Quality bar
-
-Before proposing, ask: **"Would a new team member benefit from finding this in 30 days?"**
-Do NOT propose:
-
-- Session-specific debugging steps (too ephemeral)
-- Personal preferences (not team knowledge)
-- Content already in CLAUDE.md or README
-- Anything containing secrets, tokens, or credentials
-
-## Subagents
-
-- **@teamkb-scout** — sweeps the session for capturable moments.
-- **@teamkb-curator** — end-of-session capture orchestration.
-- **@teamkb-classifier** — categorizes ambiguous content into a MemoryCategory.
-- **@teamkb-conflict-checker** — compares a proposed memory against existing ones.
+- For `review`, call `teamkb_search` with `curated` first and broaden to `all` only if needed. Cite the
+  exact returned `qmd://` URIs.
+- For `status`, call `teamkb_status` and summarize local counts and recent feedback. Do not print the
+  absolute `dbPath` unless explicitly requested.
 
 ## Output
 
-- A list of proposed candidates with their categories and returned `candidateId`s.
-- Any conflicts surfaced (and how they were resolved).
-- A closing `teamkb_status` summary.
-
-## Error Handling
-
-| Situation                      | Response                                                              |
-| ------------------------------ | --------------------------------------------------------------------- |
-| Write tools absent             | The install is `member` role; capture requires an `admin` install.    |
-| Propose returns `403`          | The token is not an admin token — the gate working as designed.       |
-| Candidate may contain a secret | Strip it; do not rely on pipeline secret-detection as the only check. |
+- Mode and local tenant context, without secrets or absolute storage paths.
+- Proposed or imported candidate UUIDs, categories, and spool disposition.
+- Skipped duplicates, conflicts, rejected files, and reasons.
+- Clear statement that queued candidates are not governed memory until curator processing.
 
 ## Examples
 
-```
+```text
 /teamkb capture
-→ @teamkb-curator reviews the session, proposes 3 candidates (1 decision, 2 patterns).
+Reviewed the session, skipped one README-duplicated fact, and queued two local proposals:
+- decision — 4f3a2e0e-0ee4-4f63-b63e-22306c45115a
+- pattern — 83e1bc9a-0048-44e7-b70b-52bc7cf6e954
+Neither proposal is promoted yet.
+```
 
-/teamkb import docs/**/*.md
-→ Bulk-imports matching files as candidates queued for governance review.
+```text
+/teamkb import docs/runbooks/*.md
+Resolved 6 Markdown files. After explicit approval, teamkb_import queued 5 and failed 1; the failed
+file and error are reported without claiming a partial batch was fully successful.
+```
+
+```text
+/teamkb review deployment rollback
+Searched curated memory first and returned two cited runbook results. No write tools were called.
 
 /teamkb status
-→ Shows counts by lifecycle state and recent rejection feedback.
+Reported local lifecycle/category/tenant counts and recent feedback without exposing the database path.
 ```
+
+## Error Handling
+
+| Situation                               | Response                                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Write tools are absent                  | Use the built local server with `TEAMKB_ROLE=admin`; the shipped marketplace plugin is read-only. |
+| Search is unexpectedly empty            | Check the local qmd index and tenant before concluding no memory exists.                          |
+| Import resolves 0 or more than 20 files | Stop; correct the glob or split the batch.                                                        |
+| Secret-like content is found            | Exclude the file or redact the candidate before any MCP write.                                    |
+| A spool write fails                     | Report exact failed outcomes; do not claim they were queued.                                      |
+
+## Guardrails
+
+- Local operating-system permissions are the write security boundary; `TEAMKB_ROLE=admin` is a
+  registration gate, not authentication.
+- Never broaden an import glob after confirmation.
+- Never save secrets or rely solely on downstream policy detection.
+- Provenance identifies capture origin, not truth.
 
 ## Resources
 
-- The read counterpart: the `/brain` skill (cited, member-safe queries).
-- The one-shot capture: the `/brain-save` skill.
-- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar) — the governance plane.
+- [Bob's Big Brain Registrar](https://github.com/jeremylongshore/bobs-big-brain-registrar) — source,
+  build instructions, and governance architecture.
+- [`apps/mcp-server`](https://github.com/jeremylongshore/bobs-big-brain-registrar/tree/main/apps/mcp-server) —
+  the full local operator runtime required by this skill.
+- `brain-save` — one-item write workflow; `brain` — read-only cited-query workflow.

--- a/skills/teamkb/references/runtime-contract.md
+++ b/skills/teamkb/references/runtime-contract.md
@@ -1,0 +1,46 @@
+# TeamKB operator runtime contract
+
+## Contents
+
+- [Runtime and tools](#runtime-and-tools)
+- [Capture contract](#capture-contract)
+- [Import contract](#import-contract)
+- [Safety bounds](#safety-bounds)
+
+## Runtime and tools
+
+This workflow requires the source-built `apps/mcp-server` with `TEAMKB_ROLE=admin`. The repository's
+shipped `intent-brain` marketplace runtime is read-only and exposes none of the write tools used here.
+
+Search can be local or remote, but `teamkb_propose`, `teamkb_import`, and `teamkb_status` always use
+the local `TEAMKB_BASE_PATH`. Leave `TEAMKB_API_URL` unset to keep the workflow on one local brain.
+
+## Capture contract
+
+`teamkb_propose` accepts required `title` and `content`, plus optional `category` and `filePaths`. It
+writes one candidate to the spool and returns `candidateId` plus a queued message. It does not execute
+the curator or prove promotion.
+
+Search-before-capture uses `teamkb_search` with `scope: all` to reduce duplicates. Search results may
+contain uncurated or retired material in that scope; use them for conflict detection, not as automatic
+truth.
+
+## Import contract
+
+`teamkb_import` accepts a required glob and optional base path. It resolves files with `fast-glob`,
+reads each matched file as UTF-8, rejects unreadable or empty files individually, and writes one spool
+candidate per successful file. Its result contains aggregate `queued` and `failed` counts plus an
+`outcomes` record for every file.
+
+The runtime itself has no batch-size ceiling and no pre-import confirmation. The skill therefore caps
+one invocation at 20 Markdown files, resolves the exact list before calling the tool, scans for likely
+secrets, and requires explicit approval of that unchanged list.
+
+## Safety bounds
+
+- Never use a home directory, repository root, hidden credential directory, unresolved variable, or
+  filesystem root as an import base.
+- Never broaden the approved glob between preview and write.
+- Treat partial import as partial success and report each failed outcome.
+- Do not print absolute local storage paths unless the operator explicitly requests them.
+- Candidate provenance records origin; it does not certify factual accuracy.


### PR DESCRIPTION
## Summary

- bring all three public Registrar skills to marketplace Grade A with Tier-2 production checks
- distinguish the shipped read-only intent-brain runtime from the locally built admin/operator MCP server
- document exact authentication, storage, lifecycle, proposal, and mixed-mode boundaries
- make TeamKB capture/import bounded and require explicit file-list approval
- align stale source comments with the actual local-write security boundary

## Validation

- brain: A 98/100, Tier-2 checks run
- brain-save: A 99/100, Tier-2 checks run
- teamkb: A 100/100, Tier-2 checks run
- claude plugin validate .: pass (one informational root-CLAUDE warning)
- pnpm format:check: pass
- pnpm lint: pass
- pnpm typecheck: pass
- pnpm test: 202 files passed, 2 skipped; 2,467 tests passed, 4 skipped
- focused MCP rerun after comment clarification: 9 files and 71 tests passed; typecheck passed
- gitleaks scan of skills/: clean
- skills@1.5.25 add . --list: exactly brain, brain-save, teamkb

## Runtime truth corrected

The repository-shipped marketplace MCP exposes only remote `teamkb_search`. Write tools belong to the
source-built local operator server. `TEAMKB_ROLE=admin` gates registration in
`apps/mcp-server/src/server.ts`; propose/import write directly to the local spool and transition writes
directly to SQLite, so a bearer token does not authorize those paths. Spool proposals are not promoted
memory. The currently unsafe active-to-superseded transition is explicitly refused and tracked as Beads
issue `qmd-team-intent-kb-ehi`.
